### PR TITLE
r/ovh_ip_reverse: new resource

### DIFF
--- a/ovh/helpers.go
+++ b/ovh/helpers.go
@@ -9,6 +9,13 @@ import (
 	"github.com/ovh/go-ovh/ovh"
 )
 
+func validateIpBlock(value string) error {
+	if _, _, err := net.ParseCIDR(value); err != nil {
+		return fmt.Errorf("Value %s is not a valid IP block", value)
+	}
+	return nil
+}
+
 func validateIp(value string) error {
 	if ip := net.ParseIP(value); ip != nil {
 		return nil

--- a/ovh/provider.go
+++ b/ovh/provider.go
@@ -63,6 +63,7 @@ func Provider() terraform.ResourceProvider {
 			"ovh_iploadbalancing_http_route_rule": resourceIPLoadbalancingRouteHTTPRule(),
 			"ovh_domain_zone_record":              resourceOvhDomainZoneRecord(),
 			"ovh_domain_zone_redirection":         resourceOvhDomainZoneRedirection(),
+			"ovh_ip_reverse":                      resourceOvhIpReverse(),
 			// New naming schema (issue #23)
 			"ovh_cloud_network_private":        resourcePublicCloudPrivateNetwork(),
 			"ovh_cloud_network_private_subnet": resourcePublicCloudPrivateNetworkSubnet(),

--- a/ovh/provider_test.go
+++ b/ovh/provider_test.go
@@ -75,6 +75,21 @@ func testAccPreCheck(t *testing.T) {
 		t.Fatal("OVH_IPLB_SERVICE must be set for acceptance tests")
 	}
 
+	v = os.Getenv("OVH_IP_BLOCK")
+	if v == "" {
+		t.Fatal("OVH_IP_BLOCK must be set for acceptance tests")
+	}
+
+	v = os.Getenv("OVH_IP")
+	if v == "" {
+		t.Fatal("OVH_IP must be set for acceptance tests")
+	}
+
+	v = os.Getenv("OVH_IP_REVERSE")
+	if v == "" {
+		t.Fatal("OVH_IP_REVERSE must be set for acceptance tests")
+	}
+
 	if testAccOVHClient == nil {
 		config := Config{
 			Endpoint:          os.Getenv("OVH_ENDPOINT"),

--- a/ovh/resource_ovh_ip_reverse.go
+++ b/ovh/resource_ovh_ip_reverse.go
@@ -1,0 +1,176 @@
+package ovh
+
+import (
+	"fmt"
+	"log"
+	"net"
+	"strings"
+
+	"github.com/hashicorp/terraform/helper/schema"
+
+	"github.com/ovh/go-ovh/ovh"
+)
+
+type OvhIpReverse struct {
+	IpReverse string `json:"ipReverse"`
+	Reverse   string `json:"reverse"`
+}
+
+func resourceOvhIpReverse() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceOvhIpReverseCreate,
+		Read:   resourceOvhIpReverseRead,
+		Update: resourceOvhIpReverseUpdate,
+		Delete: resourceOvhIpReverseDelete,
+
+		Schema: map[string]*schema.Schema{
+			"ip": {
+				Type:     schema.TypeString,
+				Required: true,
+				ValidateFunc: func(v interface{}, k string) (ws []string, errors []error) {
+					err := validateIpBlock(v.(string))
+					if err != nil {
+						errors = append(errors, err)
+					}
+					return
+				},
+			},
+			"ipreverse": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ValidateFunc: func(v interface{}, k string) (ws []string, errors []error) {
+					err := validateIp(v.(string))
+					if err != nil {
+						errors = append(errors, err)
+					}
+					return
+				},
+			},
+			"reverse": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+		},
+	}
+}
+
+func resourceOvhIpReverseCreate(d *schema.ResourceData, meta interface{}) error {
+	provider := meta.(*Config)
+
+	// Create the new reverse
+	newIp := d.Get("ip").(string)
+	newReverse := &OvhIpReverse{
+		Reverse: d.Get("reverse").(string),
+	}
+
+	newIpReverse, ok := d.GetOk("ipreverse")
+	if !ok || newIpReverse == "" {
+		ipAddr, ipNet, _ := net.ParseCIDR(newIp)
+		prefixSize, _ := ipNet.Mask.Size()
+
+		if ipAddr.To4() != nil && prefixSize != 32 {
+			return fmt.Errorf("ipreverse must be set if ip (%s) is not a /32", newIp)
+		} else if ipAddr.To4() == nil && prefixSize != 128 {
+			return fmt.Errorf("ipreverse must be set if ip (%s) is not a /128", newIp)
+		}
+
+		newIpReverse = ipAddr.String()
+		d.Set("ipreverse", newIpReverse)
+	}
+
+	newReverse.IpReverse = newIpReverse.(string)
+
+	log.Printf("[DEBUG] OVH IP Reverse create configuration: %#v", newReverse)
+
+	resultReverse := OvhIpReverse{}
+
+	err := provider.OVHClient.Post(
+		fmt.Sprintf("/ip/%s/reverse", strings.Replace(newIp, "/", "%2F", 1)),
+		newReverse,
+		&resultReverse,
+	)
+	if err != nil {
+		return fmt.Errorf("Failed to create OVH IP Reverse: %s", err)
+	}
+
+	d.SetId(fmt.Sprintf("%s_%s", newIp, resultReverse.IpReverse))
+
+	return resourceOvhIpReverseRead(d, meta)
+}
+
+func resourceOvhIpReverseRead(d *schema.ResourceData, meta interface{}) error {
+	provider := meta.(*Config)
+
+	reverse := OvhIpReverse{}
+	err := provider.OVHClient.Get(
+		fmt.Sprintf("/ip/%s/reverse/%s", strings.Replace(d.Get("ip").(string), "/", "%2F", 1), d.Get("ipreverse").(string)),
+		&reverse,
+	)
+
+	if err != nil {
+		d.SetId("")
+		return nil
+	}
+
+	d.Set("ipreverse", reverse.IpReverse)
+	d.Set("reverse", reverse.Reverse)
+
+	return nil
+}
+
+func resourceOvhIpReverseUpdate(d *schema.ResourceData, meta interface{}) error {
+	provider := meta.(*Config)
+
+	reverse := OvhIpReverse{}
+
+	if attr, ok := d.GetOk("ipreverse"); ok {
+		reverse.IpReverse = attr.(string)
+	}
+	if attr, ok := d.GetOk("reverse"); ok {
+		reverse.Reverse = attr.(string)
+	}
+
+	log.Printf("[DEBUG] OVH IP Reverse update configuration: %#v", reverse)
+
+	err := provider.OVHClient.Post(
+		fmt.Sprintf("/ip/%s/reverse", strings.Replace(d.Get("ip").(string), "/", "%2F", 1)),
+		reverse,
+		nil,
+	)
+	if err != nil {
+		return fmt.Errorf("Failed to update OVH IP Reverse: %s", err)
+	}
+
+	return resourceOvhIpReverseRead(d, meta)
+}
+
+func resourceOvhIpReverseDelete(d *schema.ResourceData, meta interface{}) error {
+	provider := meta.(*Config)
+
+	log.Printf("[INFO] Deleting OVH IP Reverse: %s->%s", d.Get("reverse").(string), d.Get("ipreverse").(string))
+
+	err := provider.OVHClient.Delete(
+		fmt.Sprintf("/ip/%s/reverse/%s", strings.Replace(d.Get("ip").(string), "/", "%2F", 1), d.Get("ipreverse").(string)),
+		nil,
+	)
+
+	if err != nil {
+		return fmt.Errorf("Error deleting OVH IP Reverse: %s", err)
+	}
+
+	return nil
+}
+
+func resourceOvhIpReverseExists(ip, ipreverse string, c *ovh.Client) error {
+	reverse := OvhIpReverse{}
+
+	endpoint := fmt.Sprintf("/ip/%s/reverse/%s", ip, ipreverse)
+
+	err := c.Get(endpoint, &reverse)
+	if err != nil {
+		return fmt.Errorf("calling %s:\n\t %q", endpoint, err)
+	}
+	log.Printf("[DEBUG] Read IP reverse: %s", reverse)
+
+	return nil
+}

--- a/ovh/resource_ovh_ip_reverse_test.go
+++ b/ovh/resource_ovh_ip_reverse_test.go
@@ -1,0 +1,74 @@
+package ovh
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+var testAccIpReverseConfig = fmt.Sprintf(`
+resource "ovh_ip_reverse" "reverse" {
+    ip = "%s"
+    ipreverse = "%s"
+    reverse = "%s"
+}
+`, os.Getenv("OVH_IP_BLOCK"), os.Getenv("OVH_IP"), os.Getenv("OVH_IP_REVERSE"))
+
+func testAccCheckIpReversePreCheck(t *testing.T) {
+	testAccPreCheck(t)
+}
+
+func TestAccIpReverse_basic(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccCheckIpReversePreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckIpReverseDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccIpReverseConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckIpReverseExists("ovh_ip_reverse.reverse", t),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckIpReverseExists(n string, t *testing.T) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		config := testAccProvider.Meta().(*Config)
+
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.Attributes["ip"] == "" {
+			return fmt.Errorf("No IP block is set")
+		}
+
+		if rs.Primary.Attributes["ipreverse"] == "" {
+			return fmt.Errorf("No IP is set")
+		}
+
+		return resourceOvhIpReverseExists(rs.Primary.Attributes["ip"], rs.Primary.Attributes["ipreverse"], config.OVHClient)
+	}
+}
+
+func testAccCheckIpReverseDestroy(s *terraform.State) error {
+	config := testAccProvider.Meta().(*Config)
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "ovh_ip_reverse" {
+			continue
+		}
+
+		err := resourceOvhIpReverseExists(rs.Primary.Attributes["ip"], rs.Primary.Attributes["ipreverse"], config.OVHClient)
+		if err == nil {
+			return fmt.Errorf("IP Reverse still exists")
+		}
+	}
+	return nil
+}

--- a/website/docs/r/ip_reverse.html.markdown
+++ b/website/docs/r/ip_reverse.html.markdown
@@ -1,0 +1,37 @@
+---
+layout: "ovh"
+page_title: "OVH: ovh_ip_reverse"
+sidebar_current: "docs-ovh-resource-ip-reverse"
+description: |-
+    Provides a OVH IP reverse resource.
+---
+
+# ovh_ip_reverse
+
+Provides a OVH IP reverse.
+
+## Example Usage
+
+```hcl
+# Set the reverse of an IP
+resource "ovh_ip_reverse" "test" {
+    ip = "192.0.2.0/24"
+    ipreverse = "192.0.2.1"
+    reverse = "example.com"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `ip` - (Required) The IP block to which the IP belongs
+* `reverse` - (Required) The value of the reverse
+* `ipreverse` - (Optional) The IP to set the reverse of, default to `ip` if `ip` is a /32 (IPv4) or a /128 (IPv6)
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `ipreverse` - The IP to set the reverse of
+* `reverse` - The value of the reverse

--- a/website/ovh.erb
+++ b/website/ovh.erb
@@ -77,6 +77,15 @@
           </ul>
         </li>
 
+        <li<%= sidebar_current("docs-ovh-resource-ip") %>>
+          <a href="#">IP Resources</a>
+          <ul class="nav nav-visible">
+            <li<%= sidebar_current("docs-ovh-resource-ip-reverse") %>>
+              <a href="/docs/providers/ovh/r/ip_reverse.html">ovh_ip_reverse</a>
+            </li>
+          </ul>
+        </li>
+
         <li<%= sidebar_current("docs-ovh-resource-iploadbalancing") %>>
             <a href="#">Iploadbalancing Resources</a>
             <ul class="nav nav-visible">


### PR DESCRIPTION
This PR adds an IP reverse resource allowing to set the reverse DNS of an instance's IP.

Example resource:

```
resource "ovh_ip_reverse" "my_ip_reverse" {
    ipreverse = "192.0.2.42"
    reverse = "example.com"
}
```

To do:
- Add tests
- Add doc
- Add a retry mechanism on resource creation to avoid `Error 400: "example.com. does not resolve to 192.0.2.42" when creating the A record and the IP reverse in the same terraform plan