### PR TITLE
Add FreeBSD support

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -16,6 +16,7 @@ builds:
   ldflags:
     - '-s -w -X main.version={{.Version}} -X main.commit={{.Commit}}'
   goos:
+    - freebsd
     - windows
     - linux
     - darwin


### PR DESCRIPTION
Generate FreeBSD binaries, as in default goreleaser.yml:
https://github.com/hashicorp/terraform-provider-scaffolding/blob/master/.goreleaser.yml