### PR TITLE
Improve readme (generation of keys)

### DIFF
--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -8,32 +8,21 @@ description: |-
 
 # OVH Provider
 
-The OVH provider is used to interact with the
-many resources supported by OVH. The provider needs to be configured
-with the proper credentials before it can be used.
+The OVH provider is used to interact with the many resources supported by OVH. 
+The provider needs to be configured with the proper credentials before it can be used.
 
 Use the navigation to the left to read about the available resources.
 
 ## Configuration of the provider
 
-Requests to OVH APIs need to configure secrets keys in the provider, either fetching them from `~/.ovh.conf` file, in configuration of OVH provider or from your environment.
+Requests to OVH APIs require a set of secrets keys and the definition of the API end point. 
+See [First Steps with the API](https://docs.ovh.com/gb/en/customer/first-steps-with-ovh-api/) (or the French version, [Premiers pas avec les API OVHcloud](https://docs.ovh.com/fr/api/api-premiers-pas/)) for a detailed explanation.
 
-It is recommend to install [ovh-cli](https://github.com/ovh/ovh-cli) to handle and manage all your secret keys.
+Besides the API end-point, the required keys are the `application_key`, the `application_secret`, and the `consumer_key`.
+These keys can be generated via the [OVH token generation page](https://api.ovh.com/createToken/?GET=/*&POST=/*&PUT=/*&DELETE=/*). 
 
-Follow [installation](https://github.com/ovh/ovh-cli#installation) then [setup](https://github.com/ovh/ovh-cli#getting-started) steps of ovh-cli to initialize your environment (secret keys and `~/.ovh.conf` file).
+These parameters can be configured directly in the provider block as shown hereafter.
 
-Then, you can just declare a minimal configuration of the OVH provider:
-
-```hcl
-# Configure the OVH Provider
-provider "ovh" {
-  endpoint = "ovh-eu"
-}
-```
-Secret keys `endpoint`, `application_key`, `application_secret` or
-`consumer_key` will be fetched from the `~/.ovh.conf` file.
-
-Or you can declare them in provider configuration:
 
 ```hcl
 # Configure the OVH Provider
@@ -45,7 +34,13 @@ provider "ovh" {
 }
 ```
 
-Or let the provider fetching them from your environment (see "[Configuration reference](#configuration-reference)").
+Alternatively the secret keys can be retrieved from your environment.
+
+ * `OVH_APPLICATION_KEY`
+ * `OVH_APPLICATION_SECRET`
+ * `OVH_CONSUMER_KEY` 
+
+This later method (or a similar alternative) is recommended to avoid storing secret data in a source repository.
 
 
 ## Example Usage


### PR DESCRIPTION
Based on my difficulties to use the OVH provider I proposed some improvements to the readme on Terraform registry. It solves issue #161 and #9.

I describe how to retrieve the API keys and re-ordered the description about its use in the configuration.

Note that the english speaking documentation (the only one I found via Google) do barely help. The French speaking one is much better.

I wonder if there shouldn't be a hint to use the `Use Provider` button to generate the `required providers` block. Newcomers might not be familiar with the use non-official providers.