### PR TITLE
fix: use the right json annotation

### DIFF
--- a/ovh/types_dbaas_logs_input.go
+++ b/ovh/types_dbaas_logs_input.go
@@ -10,20 +10,20 @@ import (
 
 type DbaasLogsInput struct {
 	AllowedNetworks   []string `json:"allowedNetworks"`
-	CreatedAt         string   `json:createdAt`
+	CreatedAt         string   `json:"createdAt"`
 	Description       string   `json:"description"`
 	EngineId          string   `json:"engineId"`
 	ExposedPort       *string  `json:"exposedPort"`
-	Hostname          string   `json:hostname`
-	InputId           string   `json:inputId`
-	IsRestartRequired bool     `json:isRestartRequired`
+	Hostname          string   `json:"hostname"`
+	InputId           string   `json:"inputId"`
+	IsRestartRequired bool     `json:"isRestartRequired"`
 	NbInstance        *int64   `json:"nbInstance"`
-	PublicAddress     string   `json:publicAddress`
-	SslCertificate    string   `json:sslCertificate`
-	Status            string   `json:status`
+	PublicAddress     string   `json:"publicAddress"`
+	SslCertificate    string   `json:"sslCertificate"`
+	Status            string   `json:"status"`
 	StreamId          string   `json:"streamId"`
 	Title             string   `json:"title"`
-	UpdatedAt         string   `json:updatedAt`
+	UpdatedAt         string   `json:"updatedAt"`
 }
 
 func (v DbaasLogsInput) ToMap() map[string]interface{} {

--- a/ovh/types_me.go
+++ b/ovh/types_me.go
@@ -72,7 +72,7 @@ type MePaymentMeanBankAccount struct {
 	Bic                    string             `json:"bic"`
 	CreationDate           string             `json:"creationDate"`
 	DefaultPaymentMean     bool               `json:"defaultPaymentMean"`
-	Description            *string            `json:"description"'`
+	Description            *string            `json:"description"`
 	Iban                   string             `json:"iban"`
 	Icon                   *MePaymentMeanIcon `json:"icon"`
 	Id                     int64              `json:"id"`
@@ -86,7 +86,7 @@ type MePaymentMeanBankAccount struct {
 
 type MePaymentMeanCreditCard struct {
 	DefaultPaymentMean bool               `json:"defaultPaymentMean"`
-	Description        *string            `json:"description"'`
+	Description        *string            `json:"description"`
 	ExpirationDate     string             `json:"expirationDate"`
 	Icon               *MePaymentMeanIcon `json:"icon"`
 	Id                 int64              `json:"id"`
@@ -100,7 +100,7 @@ type MePaymentMeanPaypal struct {
 	AgreementId        string             `json:"agreementId"`
 	CreationDate       string             `json:"creationDate"`
 	DefaultPaymentMean bool               `json:"defaultPaymentMean"`
-	Description        *string            `json:"description"'`
+	Description        *string            `json:"description"`
 	Email              string             `json:"email"`
 	Icon               *MePaymentMeanIcon `json:"icon"`
 	Id                 int64              `json:"id"`

--- a/ovh/types_order_cart_item.go
+++ b/ovh/types_order_cart_item.go
@@ -22,7 +22,7 @@ type OrderCartItemDomainSettings struct {
 }
 
 type OrderCartItemConfiguration struct {
-	Id    int64  `json:id`
+	Id    int64  `json:"id"`
 	Label string `json:"label"`
 	Value string `json:"value"`
 }


### PR DESCRIPTION
Fixes these types of warnings:

    struct field tag `json:createdAt` not compatible with reflect.StructTag.Get: bad syntax for struct tag value