### PR TITLE
support US subsidiary

### DIFF
--- a/ovh/helpers/helpers.go
+++ b/ovh/helpers/helpers.go
@@ -350,5 +350,6 @@ func ValidateSubsidiary(v string) error {
 		"pt",
 		"sn",
 		"tn",
+		"us",
 	})
 }


### PR DESCRIPTION
Fixes #217

Ideally, it would check the list of valid subsidiary per endpoint. But
that's better than nothing.