### PR TITLE
Add missing `id` attribute

### DIFF
--- a/website/docs/r/cloud_project_kube.html.markdown
+++ b/website/docs/r/cloud_project_kube.html.markdown
@@ -43,6 +43,7 @@ The following arguments are supported:
 
 The following attributes are exported:
 
+* `id` - Managed Kubernetes Service ID
 * `service_name` - See Argument Reference above.
 * `name` - See Argument Reference above.
 * `region` - See Argument Reference above.


### PR DESCRIPTION
Hey there :vulcan_salute:

this PR adds the missing `id` attribute. I stumbled on this while creating a node pool, that needs the `kube_id` as an argument.

Kind regards
Florian