### PR TITLE
fix(resource_cloud_project_kube): correct the import method

### DIFF
--- a/ovh/resource_cloud_project_kube.go
+++ b/ovh/resource_cloud_project_kube.go
@@ -20,7 +20,7 @@ func resourceCloudProjectKube() *schema.Resource {
 		Delete: resourceCloudProjectKubeDelete,
 
 		Importer: &schema.ResourceImporter{
-			State: resourceCloudProjectKubeNodePoolImportState,
+			State: resourceCloudProjectKubeImportState,
 		},
 
 		Schema: map[string]*schema.Schema{


### PR DESCRIPTION
the ResourceImporter references the NodePool import method `resourceCloudProjectKubeNodePoolImportState` instead of `resourceCloudProjectKubeImportState`