### PR TITLE
Fix ordering issue with private networks

### DIFF
--- a/ovh/resource_cloud_project_network_private.go
+++ b/ovh/resource_cloud_project_network_private.go
@@ -85,7 +85,7 @@ func resourceCloudProjectNetworkPrivate() *schema.Resource {
 				},
 			},
 			"regions_attributes": {
-				Type:     schema.TypeList,
+				Type:     schema.TypeSet,
 				Computed: true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{


### PR DESCRIPTION
Close https://github.com/ovh/terraform-provider-ovh/issues/253

This fix propose to switch `regions_attributes` to `Set` to follow API behavior. 

Underlying [OVH API](https://api.ovh.com/console/#/cloud/project/{serviceName}/network/private/{networkId}~GET) returns unordered networks and trigger terraform changes during plan/apply :

# First call

```
HTTP/1.1 200 OK
{
  "id": "pn-xxxxxx_43",
  "name": "private-network",
  "vlanId": 43,
  "regions": [
    {
      "region": "GRA7",
      "status": "ACTIVE",
      "openstackId": "********-****-****-****-************"
    },
    {
      "region": "SBG5",
      "status": "ACTIVE",
      "openstackId": "********-****-****-****-************"
    },
    {
      "region": "GRA5",
      "status": "ACTIVE",
      "openstackId": "********-****-****-****-************"
    },
    {
      "region": "GRA9",
      "status": "ACTIVE",
      "openstackId": "********-****-****-****-************"
    }
  ],
  "type": "private",
  "status": "ACTIVE"
}
```

# Second call

```
HTTP/1.1 200 OK
{
  "id": "pn-xxxxxx_43",
  "name": "private-network",
  "vlanId": 43,
  "regions": [
    {
      "region": "GRA5",
      "status": "ACTIVE",
      "openstackId": "********-****-****-****-************"
    },
    {
      "region": "SBG5",
      "status": "ACTIVE",
      "openstackId": "********-****-****-****-************"
    },
    {
      "region": "GRA7",
      "status": "ACTIVE",
      "openstackId": "********-****-****-****-************"
    },
    {
      "region": "GRA9",
      "status": "ACTIVE",
      "openstackId": "********-****-****-****-************"
    }
  ],
  "type": "private",
  "status": "ACTIVE"
}
```