### PR TITLE
fix: import kube cluster

### DIFF
--- a/ovh/resource_cloud_project_kube.go
+++ b/ovh/resource_cloud_project_kube.go
@@ -96,7 +96,7 @@ func resourceCloudProjectKube() *schema.Resource {
 func resourceCloudProjectKubeImportState(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
 	givenId := d.Id()
 	splitId := strings.SplitN(givenId, "/", 2)
-	if len(splitId) != 3 {
+	if len(splitId) != 2 {
 		return nil, fmt.Errorf("Import Id is not service_name/kubeid formatted")
 	}
 	serviceName := splitId[0]


### PR DESCRIPTION
Fix #255 

How to test it after fixed:

```
$ terraform import ovh_cloud_project_kube.my_kube_cluster <SERVICE_NAME>/<KUBE_CLUSTER_ID>
```