### PR TITLE
Add /me datasource

### DIFF
--- a/ovh/data_me.go
+++ b/ovh/data_me.go
@@ -1,0 +1,195 @@
+package ovh
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func dataSourceMe() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceMeRead,
+		Schema: map[string]*schema.Schema{
+			"address": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Address of nichandle",
+			},
+			"area": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Area of nichandle",
+			},
+			"birth_city": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "City of birth",
+			},
+			"birth_day": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Birth date",
+			},
+			"city": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "City of nichandle",
+			},
+			"company_national_identification_number": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Company National Identification Number",
+			},
+			"corporation_type": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Corporation type",
+			},
+			"country": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Customer country",
+			},
+			"currency": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"code": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "Currency code",
+						},
+						"symbol": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "Currency symbol",
+						},
+					},
+				},
+				Description: "Customer currency",
+			},
+			"customer_code": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Your customer code (a numerical value used for identification when contacting support via phone call)",
+			},
+			"email": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Email address",
+			},
+			"fax": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Fax number",
+			},
+			"firstname": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "First name",
+			},
+			"italian_sdi": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Italian SDI",
+			},
+			"language": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Language",
+			},
+			"legalform": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Customer legal form",
+			},
+			"name": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Customer name",
+			},
+			"national_identification_number": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "National Identification Number",
+			},
+			"nichandle": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Customer identifier",
+			},
+			"organisation": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Name of organisation",
+			},
+			"ovh_company": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "OVH subsidiary",
+			},
+			"ovh_subsidiary": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "OVH subsidiary",
+			},
+			"phone": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Phone number",
+			},
+			"phone_country": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Phone number's country code",
+			},
+			"sex": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Gender",
+			},
+			"spare_email": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Spare email",
+			},
+			"state": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Nichandle state",
+			},
+			"vat": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "VAT number",
+			},
+			"zip": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Zipcode",
+			},
+		},
+	}
+}
+
+func dataSourceMeRead(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+
+	me := &MeResponse{}
+
+	err := config.OVHClient.Get("/me", me)
+	if err != nil {
+		return fmt.Errorf("Unable to retrieve /me information:\n\t %q", err)
+	}
+	log.Printf("[DEBUG] /me information: %+v", me)
+
+	d.SetId(me.Nichandle)
+
+	for k, v := range me.ToMap() {
+		d.Set(k, v)
+	}
+
+	return nil
+}

--- a/ovh/data_me_test.go
+++ b/ovh/data_me_test.go
@@ -1,0 +1,61 @@
+package ovh
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccMeDataSource_basic(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheckCredentials(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMeDatasourceConfig,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(
+						"data.ovh_me.my_account",
+						"country",
+					),
+					resource.TestCheckResourceAttrSet(
+						"data.ovh_me.my_account",
+						"currency.0.code",
+					),
+					resource.TestCheckResourceAttrSet(
+						"data.ovh_me.my_account",
+						"currency.0.symbol",
+					),
+					resource.TestCheckResourceAttrSet(
+						"data.ovh_me.my_account",
+						"email",
+					),
+					resource.TestCheckResourceAttrSet(
+						"data.ovh_me.my_account",
+						"legalform",
+					),
+					resource.TestCheckResourceAttrSet(
+						"data.ovh_me.my_account",
+						"nichandle",
+					),
+					resource.TestCheckResourceAttrSet(
+						"data.ovh_me.my_account",
+						"ovh_company",
+					),
+					resource.TestCheckResourceAttrSet(
+						"data.ovh_me.my_account",
+						"ovh_subsidiary",
+					),
+					resource.TestCheckResourceAttrSet(
+						"data.ovh_me.my_account",
+						"state",
+					),
+				),
+			},
+		},
+	})
+}
+
+const testAccMeDatasourceConfig = `
+data "ovh_me" "my_account" {}
+`

--- a/ovh/provider.go
+++ b/ovh/provider.go
@@ -62,6 +62,7 @@ func Provider() *schema.Provider {
 			"ovh_iploadbalancing":                                     dataSourceIpLoadbalancing(),
 			"ovh_iploadbalancing_vrack_network":                       dataSourceIpLoadbalancingVrackNetwork(),
 			"ovh_iploadbalancing_vrack_networks":                      dataSourceIpLoadbalancingVrackNetworks(),
+			"ovh_me":                                                  dataSourceMe(),
 			"ovh_me_identity_user":                                    dataSourceMeIdentityUser(),
 			"ovh_me_identity_users":                                   dataSourceMeIdentityUsers(),
 			"ovh_me_installation_template":                            dataSourceMeInstallationTemplate(),

--- a/ovh/types_me.go
+++ b/ovh/types_me.go
@@ -4,6 +4,134 @@ import (
 	"fmt"
 )
 
+type MeResponse struct {
+	Address                             *string     `json:"address"`
+	Area                                *string     `json:"area"`
+	BirthCity                           *string     `json:"birthCity"`
+	BirthDay                            *string     `json:"birthDay"`
+	City                                *string     `json:"city"`
+	CompanyNationalIdentificationNumber *string     `json:"companyNationalIdentificationNumber"`
+	CorporationType                     *string     `json:"corporationType"`
+	Country                             string      `json:"country"`
+	Currency                            *MeCurrency `json:"currency"`
+	CustomerCode                        *string     `json:"customerCode"`
+	Email                               string      `json:"email"`
+	Fax                                 *string     `json:"fax"`
+	Firstname                           *string     `json:"firstname"`
+	ItalianSDI                          *string     `json:"italianSDI"`
+	Language                            *string     `json:"language"`
+	Legalform                           string      `json:"legalform"`
+	Name                                *string     `json:"name"`
+	NationalIdentificationNumber        *string     `json:"nationalIdentificationNumber"`
+	Nichandle                           string      `json:"nichandle"`
+	Organisation                        *string     `json:"organisation"`
+	OvhCompany                          string      `json:"ovhCompany"`
+	OvhSubsidiary                       string      `json:"ovhSubsidiary"`
+	Phone                               *string     `json:"phone"`
+	PhoneCountry                        *string     `json:"phoneCountry"`
+	Sex                                 *string     `json:"sex"`
+	SpareEmail                          *string     `json:"spareEmail"`
+	State                               string      `json:"state"`
+	Vat                                 *string     `json:"vat"`
+	Zip                                 *string     `json:"zip"`
+}
+
+func (m MeResponse) ToMap() map[string]interface{} {
+	obj := make(map[string]interface{})
+
+	// Non-nullable values
+	obj["country"] = m.Country
+	obj["email"] = m.Email
+	obj["legalform"] = m.Legalform
+	obj["nichandle"] = m.Nichandle
+	obj["ovh_company"] = m.OvhCompany
+	obj["ovh_subsidiary"] = m.OvhSubsidiary
+	obj["state"] = m.State
+
+	if m.Currency != nil {
+		obj["currency"] = []interface{}{m.Currency.ToMap()}
+	}
+
+	// Nullable values
+	if m.Address != nil {
+		obj["address"] = *m.Address
+	}
+	if m.Area != nil {
+		obj["area"] = *m.Area
+	}
+	if m.BirthCity != nil {
+		obj["birth_city"] = *m.BirthCity
+	}
+	if m.BirthDay != nil {
+		obj["birth_day"] = *m.BirthDay
+	}
+	if m.City != nil {
+		obj["city"] = *m.City
+	}
+	if m.CompanyNationalIdentificationNumber != nil {
+		obj["company_national_identification_number"] = *m.CompanyNationalIdentificationNumber
+	}
+	if m.CorporationType != nil {
+		obj["corporation_type"] = *m.CorporationType
+	}
+	if m.CustomerCode != nil {
+		obj["customer_code"] = *m.CustomerCode
+	}
+	if m.Fax != nil {
+		obj["fax"] = *m.Fax
+	}
+	if m.Firstname != nil {
+		obj["firstname"] = *m.Firstname
+	}
+	if m.ItalianSDI != nil {
+		obj["italian_sdi"] = *m.ItalianSDI
+	}
+	if m.Language != nil {
+		obj["language"] = *m.Language
+	}
+	if m.Name != nil {
+		obj["name"] = *m.Name
+	}
+	if m.NationalIdentificationNumber != nil {
+		obj["national_identification_number"] = *m.NationalIdentificationNumber
+	}
+	if m.Organisation != nil {
+		obj["organisation"] = *m.Organisation
+	}
+	if m.Phone != nil {
+		obj["phone"] = *m.Phone
+	}
+	if m.PhoneCountry != nil {
+		obj["phone_country"] = *m.PhoneCountry
+	}
+	if m.Sex != nil {
+		obj["sex"] = *m.Sex
+	}
+	if m.SpareEmail != nil {
+		obj["spare_email"] = *m.SpareEmail
+	}
+	if m.Vat != nil {
+		obj["vat"] = *m.Vat
+	}
+	if m.Zip != nil {
+		obj["zip"] = *m.Zip
+	}
+
+	return obj
+}
+
+type MeCurrency struct {
+	Code   string `json:"code"`
+	Symbol string `json:"symbol"`
+}
+
+func (c MeCurrency) ToMap() map[string]interface{} {
+	obj := make(map[string]interface{})
+	obj["code"] = c.Code
+	obj["symbol"] = c.Symbol
+	return obj
+}
+
 type MeIdentityUserResponse struct {
 	Creation           string `json:"creation"`
 	Description        string `json:"description"`

--- a/website/docs/d/me.html.markdown
+++ b/website/docs/d/me.html.markdown
@@ -1,0 +1,57 @@
+---
+layout: "ovh"
+page_title: "OVH: me"
+sidebar_current: "docs-ovh-datasource-me"
+description: |-
+  Get information about the current OVH account
+---
+
+# ovh_me (Data Source)
+
+Use this data source to get information about the current OVH account.
+
+## Example Usage
+
+```hcl
+data "ovh_me" "myaccount" {}
+```
+
+## Argument Reference
+
+There are no arguments to this datasource.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `address`: Postal address of the account
+* `area`: Area of the account
+* `birth_city`: City of birth
+* `birth_day`: Birth date
+* `city`: City of the account
+* `company_national_identification_number`: This is the national identification number of the company that possess this account
+* `corporation_type`: Type of corporation
+* `country`: Country of the account
+* `currency`:
+  * `code`: Currency code used by this account (e.g EUR, USD, ...)
+  * `symbol`: Currency symbol used by this account (e.g €, $, ...)
+* `customer_code`: The customer code of this account (a numerical value used for identification when contacting support via phone call)
+* `email`: Email address
+* `fax`: Fax number
+* `firstname`: First name
+* `italian_sdi`: Italian SDI
+* `language`: Preferred language for this account
+* `legalform`: Legal form of the account
+* `name`: Name of the account holder
+* `national_identification_number`: National Identification Number of this account
+* `nichandle`: Nic handle / customer identifier
+* `organisation`: Name of the organisation for this account
+* `ovh_company`: OVH subsidiary
+* `ovh_subsidiary`: OVH subsidiary
+* `phone`: Phone number
+* `phone_country`: Country code of the phone number
+* `sex`: Gender of the account holder
+* `spare_email`: Backup email address
+* `state`: State of the postal address
+* `vat`: VAT number
+* `zip`: Zipcode of the address

--- a/website/ovh.erb
+++ b/website/ovh.erb
@@ -73,6 +73,9 @@
         <li<%= sidebar_current("docs-ovh-datasource-ip-service-x") %>>
           <a href="/docs/providers/ovh/d/ip_service.html">ovh_ip_service</a>
         </li>
+        <li<%= sidebar_current("docs-ovh-datasource-me-x") %>>
+          <a href="/docs/providers/ovh/d/me.html">ovh_me</a>
+        </li>
         <li<%= sidebar_current("docs-ovh-datasource-me-installation-template-x") %>>
           <a href="/docs/providers/ovh/d/me_installation_template.html">ovh_me_installation_template</a>
         </li>
@@ -260,6 +263,9 @@
     <li<%= sidebar_current("docs-ovh-resource-me") %>>
       <a href="#">Me Resources</a>
       <ul class="nav nav-visible">
+        <li<%= sidebar_current("docs-ovh-datasource-me-x") %>>
+          <a href="/docs/providers/ovh/d/me.html">ovh_me</a>
+        </li>
         <li<%= sidebar_current("docs-ovh-resource-me-installation-template-x") %>>
           <a href="/docs/providers/ovh/r/me_installation_template.html">ovh_me_installation_template</a>
         </li>


### PR DESCRIPTION
This PR adds support for the /me API call as a datasource.

This is especially useful (and is the only way) to retrieve information about the current account used by the provider.