### PR TITLE
Fix typos in allowed logs output format

### DIFF
--- a/ovh/resource_dbaas_logs_output_graylog_stream.go
+++ b/ovh/resource_dbaas_logs_output_graylog_stream.go
@@ -79,7 +79,7 @@ func resourceDbaasLogsOutputGraylogStream() *schema.Resource {
 				ValidateFunc: func(v interface{}, k string) (ws []string, errors []error) {
 					err := helpers.ValidateStringEnum(strings.ToUpper(v.(string)), []string{
 						"ALL",
-						"GLEF",
+						"GELF",
 						"PLAIN",
 					})
 					if err != nil {


### PR DESCRIPTION
This PR fixes a typo in the `cold_storage_content` parameter for the `ovh_dbaas_logs_output_graylog_stream` resources