### PR TITLE
Add S3 Credential datasource and resource

### DIFF
--- a/ovh/data_cloud_project_user_s3_credential.go
+++ b/ovh/data_cloud_project_user_s3_credential.go
@@ -18,7 +18,7 @@ func dataCloudProjectUserS3Credential() *schema.Resource {
 				Required:    true,
 				ForceNew:    true,
 				DefaultFunc: schema.EnvDefaultFunc("OVH_CLOUD_PROJECT_SERVICE", nil),
-				Description: "Service name of the resource representing the id of the cloud project.",
+				Description: "Service name of the resource representing the ID of the cloud project.",
 			},
 			"user_id": {
 				Type:        schema.TypeString,

--- a/ovh/data_cloud_project_user_s3_credential.go
+++ b/ovh/data_cloud_project_user_s3_credential.go
@@ -1,0 +1,70 @@
+package ovh
+
+import (
+	"fmt"
+	"log"
+	"net/url"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/ovh/terraform-provider-ovh/ovh/helpers"
+)
+
+func dataCloudProjectUserS3Credential() *schema.Resource {
+	return &schema.Resource{
+		Read: dataCloudProjectUserS3CredentialRead,
+		Schema: map[string]*schema.Schema{
+			"service_name": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				DefaultFunc: schema.EnvDefaultFunc("OVH_CLOUD_PROJECT_SERVICE", nil),
+				Description: "Service name of the resource representing the id of the cloud project.",
+			},
+			"user_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: "The user ID",
+			},
+			"access_key_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: "The access key",
+			},
+
+			//Computed
+			"secret_access_key": {
+				Type:      schema.TypeString,
+				Computed:  true,
+				Sensitive: true,
+			},
+		},
+	}
+}
+
+func dataCloudProjectUserS3CredentialRead(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+	serviceName := d.Get("service_name").(string)
+	userID := d.Get("user_id").(string)
+	accessKey := d.Get("access_key_id").(string)
+
+	log.Printf("[DEBUG] Will read public cloud secret access key for access key %s user %s on project: %s", accessKey, userID, serviceName)
+
+	endpoint := fmt.Sprintf(
+		"/cloud/project/%s/user/%s/s3Credentials/%s",
+		url.PathEscape(serviceName),
+		url.PathEscape(userID),
+		url.PathEscape(accessKey),
+	)
+
+	s3Credential := &CloudProjectUserS3Credential{}
+	if err := config.OVHClient.Get(endpoint, &s3Credential); err != nil {
+		return helpers.CheckDeleted(d, err, endpoint)
+	}
+
+	d.SetId(serviceName)
+	d.Set("secret_access_key", s3Credential.Secret)
+
+	return nil
+}

--- a/ovh/data_cloud_project_user_s3_credential_test.go
+++ b/ovh/data_cloud_project_user_s3_credential_test.go
@@ -1,0 +1,74 @@
+package ovh
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+var testAccDataCloudProjectUserS3CredentialConfig = fmt.Sprintf(`
+resource "ovh_cloud_project_user" "user" {
+ service_name = "%s"
+ description  = "my user for acceptance tests"
+}
+
+resource "ovh_cloud_project_user_s3_credential" "s3_cred_1" {
+ service_name = ovh_cloud_project_user.user.service_name
+ user_id      = ovh_cloud_project_user.user.id
+}
+
+resource "ovh_cloud_project_user_s3_credential" "s3_cred_2" {
+ service_name = ovh_cloud_project_user.user.service_name
+ user_id      = ovh_cloud_project_user.user.id
+}
+
+data "ovh_cloud_project_user_s3_credentials" "keys" {
+ service_name = ovh_cloud_project_user.user.service_name
+ user_id      = ovh_cloud_project_user.user.id
+ depends_on   = [ovh_cloud_project_user_s3_credential.s3_cred_1, ovh_cloud_project_user_s3_credential.s3_cred_2]
+}
+
+data "ovh_cloud_project_user_s3_credential" "s3_cred_key_2" {
+ service_name  = ovh_cloud_project_user.user.service_name
+ user_id       = ovh_cloud_project_user.user.id
+ access_key_id = data.ovh_cloud_project_user_s3_credentials.keys.access_key_ids[1]
+ depends_on    = [ovh_cloud_project_user_s3_credential.s3_cred_1, ovh_cloud_project_user_s3_credential.s3_cred_2]
+}
+
+data "ovh_cloud_project_user_s3_credential" "s3_cred_key_1" {
+ service_name  = ovh_cloud_project_user.user.service_name
+ user_id       = ovh_cloud_project_user.user.id
+ access_key_id = ovh_cloud_project_user_s3_credential.s3_cred_1.access_key_id
+ depends_on    = [ovh_cloud_project_user_s3_credential.s3_cred_1, ovh_cloud_project_user_s3_credential.s3_cred_2]
+}
+
+output "same_secret_key_cred_1" {
+    value = data.ovh_cloud_project_user_s3_credential.s3_cred_key_1.secret_access_key == ovh_cloud_project_user_s3_credential.s3_cred_1.secret_access_key
+    sensitive=true
+}
+
+output "same_secret_key_cred_2" {
+    value = data.ovh_cloud_project_user_s3_credential.s3_cred_key_2.secret_access_key == ovh_cloud_project_user_s3_credential.s3_cred_2.secret_access_key
+    sensitive=true
+}
+`, os.Getenv("OVH_CLOUD_PROJECT_SERVICE_TEST"))
+
+func TestAccDataCloudProjectUserS3Credential_basic(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheckCredentials(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataCloudProjectUserS3CredentialConfig,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckOutput(
+						"same_secret_key_cred_1", "true"),
+					resource.TestCheckOutput(
+						"same_secret_key_cred_2", "true"),
+				),
+			},
+		},
+	})
+}

--- a/ovh/data_cloud_project_user_s3_credential_test.go
+++ b/ovh/data_cloud_project_user_s3_credential_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
 
-var testAccDataCloudProjectUserS3CredentialConfig = fmt.Sprintf(`
+const testAccDataCloudProjectUserS3CredentialConfig_basic = `
 resource "ovh_cloud_project_user" "user" {
  service_name = "%s"
  description  = "my user for acceptance tests"
@@ -47,15 +47,19 @@ output "same_secret_key_cred_2" {
     value = data.ovh_cloud_project_user_s3_credential.s3_cred_key_2.secret_access_key == ovh_cloud_project_user_s3_credential.s3_cred_2.secret_access_key
     sensitive=true
 }
-`, os.Getenv("OVH_CLOUD_PROJECT_SERVICE_TEST"))
+`
 
 func TestAccDataCloudProjectUserS3Credential_basic(t *testing.T) {
+	serviceName := os.Getenv("OVH_CLOUD_PROJECT_SERVICE_TEST")
+
+	config := fmt.Sprintf(testAccDataCloudProjectUserS3CredentialConfig_basic, serviceName)
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheckCredentials(t) },
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDataCloudProjectUserS3CredentialConfig,
+				Config: config,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet(
 						"data.ovh_cloud_project_user_s3_credential.s3_cred_key_1",

--- a/ovh/data_cloud_project_user_s3_credential_test.go
+++ b/ovh/data_cloud_project_user_s3_credential_test.go
@@ -24,16 +24,10 @@ resource "ovh_cloud_project_user_s3_credential" "s3_cred_2" {
  user_id      = ovh_cloud_project_user.user.id
 }
 
-data "ovh_cloud_project_user_s3_credentials" "keys" {
- service_name = ovh_cloud_project_user.user.service_name
- user_id      = ovh_cloud_project_user.user.id
- depends_on   = [ovh_cloud_project_user_s3_credential.s3_cred_1, ovh_cloud_project_user_s3_credential.s3_cred_2]
-}
-
 data "ovh_cloud_project_user_s3_credential" "s3_cred_key_2" {
  service_name  = ovh_cloud_project_user.user.service_name
  user_id       = ovh_cloud_project_user.user.id
- access_key_id = data.ovh_cloud_project_user_s3_credentials.keys.access_key_ids[1]
+ access_key_id = ovh_cloud_project_user_s3_credential.s3_cred_2.access_key_id
  depends_on    = [ovh_cloud_project_user_s3_credential.s3_cred_1, ovh_cloud_project_user_s3_credential.s3_cred_2]
 }
 
@@ -63,6 +57,14 @@ func TestAccDataCloudProjectUserS3Credential_basic(t *testing.T) {
 			{
 				Config: testAccDataCloudProjectUserS3CredentialConfig,
 				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(
+						"data.ovh_cloud_project_user_s3_credential.s3_cred_key_1",
+						"secret_access_key",
+					),
+					resource.TestCheckResourceAttrSet(
+						"data.ovh_cloud_project_user_s3_credential.s3_cred_key_2",
+						"secret_access_key",
+					),
 					resource.TestCheckOutput(
 						"same_secret_key_cred_1", "true"),
 					resource.TestCheckOutput(

--- a/ovh/data_cloud_project_user_s3_credentials.go
+++ b/ovh/data_cloud_project_user_s3_credentials.go
@@ -1,0 +1,67 @@
+package ovh
+
+import (
+	"fmt"
+	"log"
+	"net/url"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func dataCloudProjectUserS3Credentials() *schema.Resource {
+	return &schema.Resource{
+		Read: dataCloudProjectUserS3CredentialsRead,
+		Schema: map[string]*schema.Schema{
+			"service_name": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				DefaultFunc: schema.EnvDefaultFunc("OVH_CLOUD_PROJECT_SERVICE", nil),
+				Description: "Service name of the resource representing the id of the cloud project.",
+			},
+			"user_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: "The user ID",
+			},
+			"access_key_ids": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+			},
+		},
+	}
+}
+
+func dataCloudProjectUserS3CredentialsRead(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+	serviceName := d.Get("service_name").(string)
+	userID := d.Get("user_id").(string)
+
+	log.Printf("[DEBUG] Will read public cloud access key ids for user %s on project: %s", userID, serviceName)
+
+	endpoint := fmt.Sprintf(
+		"/cloud/project/%s/user/%s/s3Credentials",
+		url.PathEscape(serviceName),
+		url.PathEscape(userID),
+	)
+
+	credentials := make([]CloudProjectUserS3Credential, 0)
+	if err := config.OVHClient.Get(endpoint, &credentials); err != nil {
+		return fmt.Errorf("Error calling %s:\n\t %q", endpoint, err)
+	}
+
+	accessKeys := make([]string, 0, len(credentials))
+
+	for _, key := range credentials {
+		accessKeys = append(accessKeys, key.Access)
+	}
+
+	d.SetId(fmt.Sprintf("%s/%s", serviceName, userID))
+	d.Set("access_key_ids", accessKeys)
+
+	return nil
+}

--- a/ovh/data_cloud_project_user_s3_credentials.go
+++ b/ovh/data_cloud_project_user_s3_credentials.go
@@ -17,7 +17,7 @@ func dataCloudProjectUserS3Credentials() *schema.Resource {
 				Required:    true,
 				ForceNew:    true,
 				DefaultFunc: schema.EnvDefaultFunc("OVH_CLOUD_PROJECT_SERVICE", nil),
-				Description: "Service name of the resource representing the id of the cloud project.",
+				Description: "Service name of the resource representing the ID of the cloud project.",
 			},
 			"user_id": {
 				Type:        schema.TypeString,

--- a/ovh/data_cloud_project_user_s3_credentials_test.go
+++ b/ovh/data_cloud_project_user_s3_credentials_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
 
-var testAccDataCloudProjectUserS3CredentialsConfig = fmt.Sprintf(`
+const testAccDataCloudProjectUserS3CredentialsConfig_basic = `
 resource "ovh_cloud_project_user" "user" {
  service_name = "%s"
  description  = "my user for acceptance tests"
@@ -28,15 +28,19 @@ data "ovh_cloud_project_user_s3_credentials" "keys" {
 output "access_key_ids_count" {
     value = length(data.ovh_cloud_project_user_s3_credentials.keys.access_key_ids)
 }
-`, os.Getenv("OVH_CLOUD_PROJECT_SERVICE_TEST"))
+`
 
 func TestAccDataCloudProjectUserS3Credentials_basic(t *testing.T) {
+	serviceName := os.Getenv("OVH_CLOUD_PROJECT_SERVICE_TEST")
+
+	config := fmt.Sprintf(testAccDataCloudProjectUserS3CredentialsConfig_basic, serviceName)
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheckCredentials(t) },
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDataCloudProjectUserS3CredentialsConfig,
+				Config: config,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet(
 						"data.ovh_cloud_project_user_s3_credentials.keys",

--- a/ovh/data_cloud_project_user_s3_credentials_test.go
+++ b/ovh/data_cloud_project_user_s3_credentials_test.go
@@ -38,6 +38,10 @@ func TestAccDataCloudProjectUserS3Credentials_basic(t *testing.T) {
 			{
 				Config: testAccDataCloudProjectUserS3CredentialsConfig,
 				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(
+						"data.ovh_cloud_project_user_s3_credentials.keys",
+						"access_key_ids.#",
+					),
 					resource.TestCheckOutput(
 						"access_key_ids_count", "1"),
 				),

--- a/ovh/data_cloud_project_user_s3_credentials_test.go
+++ b/ovh/data_cloud_project_user_s3_credentials_test.go
@@ -1,0 +1,47 @@
+package ovh
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+var testAccDataCloudProjectUserS3CredentialsConfig = fmt.Sprintf(`
+resource "ovh_cloud_project_user" "user" {
+ service_name = "%s"
+ description  = "my user for acceptance tests"
+}
+
+resource "ovh_cloud_project_user_s3_credential" "s3_cred" {
+ service_name = ovh_cloud_project_user.user.service_name
+ user_id      = ovh_cloud_project_user.user.id
+}
+
+data "ovh_cloud_project_user_s3_credentials" "keys" {
+ service_name = ovh_cloud_project_user.user.service_name
+ user_id      = ovh_cloud_project_user.user.id
+ depends_on   = [ovh_cloud_project_user_s3_credential.s3_cred]
+}
+
+output "access_key_ids_count" {
+    value = length(data.ovh_cloud_project_user_s3_credentials.keys.access_key_ids)
+}
+`, os.Getenv("OVH_CLOUD_PROJECT_SERVICE_TEST"))
+
+func TestAccDataCloudProjectUserS3Credentials_basic(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheckCredentials(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataCloudProjectUserS3CredentialsConfig,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckOutput(
+						"access_key_ids_count", "1"),
+				),
+			},
+		},
+	})
+}

--- a/ovh/provider.go
+++ b/ovh/provider.go
@@ -58,6 +58,7 @@ func Provider() *schema.Provider {
 			"ovh_cloud_project_kube_nodepool":                         dataSourceCloudProjectKubeNodepool(),
 			"ovh_cloud_project_region":                                dataSourceCloudProjectRegion(),
 			"ovh_cloud_project_regions":                               dataSourceCloudProjectRegions(),
+			"ovh_cloud_project_user_s3_credentials":                   dataCloudProjectUserS3Credentials(),
 			"ovh_dbaas_logs_input_engine":                             dataSourceDbaasLogsInputEngine(),
 			"ovh_dbaas_logs_output_graylog_stream":                    dataSourceDbaasLogsOutputGraylogStream(),
 			"ovh_dedicated_ceph":                                      dataSourceDedicatedCeph(),

--- a/ovh/provider.go
+++ b/ovh/provider.go
@@ -106,6 +106,7 @@ func Provider() *schema.Provider {
 			"ovh_cloud_project_network_private":                           resourceCloudProjectNetworkPrivate(),
 			"ovh_cloud_project_network_private_subnet":                    resourceCloudProjectNetworkPrivateSubnet(),
 			"ovh_cloud_project_user":                                      resourceCloudProjectUser(),
+			"ovh_cloud_project_user_s3_credential":                        resourceCloudProjectUserS3Credential(),
 			"ovh_dbaas_logs_input":                                        resourceDbaasLogsInput(),
 			"ovh_dbaas_logs_output_graylog_stream":                        resourceDbaasLogsOutputGraylogStream(),
 			"ovh_dedicated_ceph_acl":                                      resourceDedicatedCephACL(),

--- a/ovh/provider.go
+++ b/ovh/provider.go
@@ -58,6 +58,7 @@ func Provider() *schema.Provider {
 			"ovh_cloud_project_kube_nodepool":                         dataSourceCloudProjectKubeNodepool(),
 			"ovh_cloud_project_region":                                dataSourceCloudProjectRegion(),
 			"ovh_cloud_project_regions":                               dataSourceCloudProjectRegions(),
+			"ovh_cloud_project_user_s3_credential":                    dataCloudProjectUserS3Credential(),
 			"ovh_cloud_project_user_s3_credentials":                   dataCloudProjectUserS3Credentials(),
 			"ovh_dbaas_logs_input_engine":                             dataSourceDbaasLogsInputEngine(),
 			"ovh_dbaas_logs_output_graylog_stream":                    dataSourceDbaasLogsOutputGraylogStream(),

--- a/ovh/resource_cloud_project_user_s3_credential.go
+++ b/ovh/resource_cloud_project_user_s3_credential.go
@@ -27,7 +27,7 @@ func resourceCloudProjectUserS3Credential() *schema.Resource {
 				Required:    true,
 				ForceNew:    true,
 				DefaultFunc: schema.EnvDefaultFunc("OVH_CLOUD_PROJECT_SERVICE", nil),
-				Description: "Service name of the resource representing the id of the cloud project.",
+				Description: "Service name of the resource representing the ID of the cloud project.",
 			},
 			"user_id": {
 				Type:        schema.TypeString,

--- a/ovh/resource_cloud_project_user_s3_credential.go
+++ b/ovh/resource_cloud_project_user_s3_credential.go
@@ -1,0 +1,162 @@
+package ovh
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"net/url"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/ovh/terraform-provider-ovh/ovh/helpers"
+)
+
+func resourceCloudProjectUserS3Credential() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceCloudProjectUserS3CredentialCreate,
+		Read:   resourceCloudProjectUserS3CredentialRead,
+		Delete: resourceCloudProjectUserS3CredentialDelete,
+
+		Importer: &schema.ResourceImporter{
+			StateContext: resourceCloudProjectUserS3CredentialImportState,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"service_name": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				DefaultFunc: schema.EnvDefaultFunc("OVH_CLOUD_PROJECT_SERVICE", nil),
+				Description: "Service name of the resource representing the id of the cloud project.",
+			},
+			"user_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: "The user ID",
+			},
+			"internal_user_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"access_key_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"secret_access_key": {
+				Type:      schema.TypeString,
+				Computed:  true,
+				Sensitive: true,
+			},
+		},
+	}
+}
+
+func resourceCloudProjectUserS3CredentialImportState(ctx context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+	access := d.Id()
+	serviceName := ""
+	userId := ""
+
+	splitId := strings.SplitN(access, "/", 3)
+	if len(splitId) == 3 {
+		serviceName = splitId[0]
+		userId = splitId[1]
+		access = splitId[2]
+	}
+
+	if serviceName == "" || userId == "" || access == "" {
+		return nil, fmt.Errorf("Import Id is not service_name/user_id/access_key formatted")
+	}
+
+	d.SetId(access)
+	d.Set("service_name", serviceName)
+	d.Set("user_id", userId)
+
+	return []*schema.ResourceData{d}, nil
+}
+
+func resourceCloudProjectUserS3CredentialCreate(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+	serviceName := d.Get("service_name").(string)
+	userID := d.Get("user_id").(string)
+
+	s3Credential := &CloudProjectUserS3Credential{}
+
+	log.Printf("[DEBUG] Will create Public Cloud S3 AccessKey for user: %s from project: %s", userID, serviceName)
+	endpoint := fmt.Sprintf(
+		"/cloud/project/%s/user/%s/s3Credentials",
+		url.PathEscape(serviceName),
+		url.PathEscape(userID),
+	)
+
+	if err := config.OVHClient.Post(endpoint, nil, s3Credential); err != nil {
+		return fmt.Errorf("calling Post %s :\n\t %q", endpoint, err)
+	}
+
+	d.SetId(s3Credential.Access)
+	d.Set("secret_access_key", s3Credential.Secret)
+	for k, v := range s3Credential.ToMap() {
+		d.Set(k, v)
+	}
+
+	log.Printf("[DEBUG] Created the Public Cloud S3 AccessKey %s", s3Credential)
+
+	return resourceCloudProjectUserS3CredentialRead(d, meta)
+}
+
+func resourceCloudProjectUserS3CredentialRead(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+	serviceName := d.Get("service_name").(string)
+	userID := d.Get("user_id").(string)
+
+	s3Credential := &CloudProjectUserS3Credential{}
+
+	log.Printf("[DEBUG] Will read the Public Cloud S3 AccessKey %s for user %s from project: %s", d.Id(), userID, serviceName)
+
+	endpoint := fmt.Sprintf(
+		"/cloud/project/%s/user/%s/s3Credentials/%s",
+		url.PathEscape(serviceName),
+		userID,
+		d.Id(),
+	)
+
+	if err := config.OVHClient.Get(endpoint, s3Credential); err != nil {
+		return helpers.CheckDeleted(d, err, endpoint)
+	}
+
+	d.SetId(s3Credential.Access)
+	// set resource attributes
+	for k, v := range s3Credential.ToMap() {
+		d.Set(k, v)
+	}
+
+	log.Printf("[DEBUG] Read the Public Cloud S3 AccessKey %s", s3Credential)
+	return nil
+}
+
+func resourceCloudProjectUserS3CredentialDelete(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+	serviceName := d.Get("service_name").(string)
+	userID := d.Get("user_id").(string)
+
+	id := d.Id()
+
+	log.Printf("[DEBUG] Will delete the Public Cloud S3 AccessKey %s for user %s from project: %s", id, userID, serviceName)
+
+	endpoint := fmt.Sprintf(
+		"/cloud/project/%s/user/%s/s3Credentials/%s",
+		url.PathEscape(serviceName),
+		userID,
+		id,
+	)
+
+	if err := config.OVHClient.Delete(endpoint, nil); err != nil {
+		return fmt.Errorf("calling Delete %s:\n\t %q", endpoint, err)
+	}
+
+	log.Printf("[DEBUG] Deleted the Public Cloud S3 AccessKey %s for user %s from project %s", id, userID, serviceName)
+
+	d.SetId("")
+
+	return nil
+}

--- a/ovh/resource_cloud_project_user_s3_credential_test.go
+++ b/ovh/resource_cloud_project_user_s3_credential_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
 
-var testAccCloudProjectUserS3CredentialConfig = fmt.Sprintf(`
+const testAccCloudProjectUserS3CredentialConfig_basic = `
 resource "ovh_cloud_project_user" "user" {
  service_name = "%s"
  description  = "my user for acceptance tests"
@@ -18,15 +18,19 @@ resource "ovh_cloud_project_user_s3_credential" "s3_cred" {
  service_name  = ovh_cloud_project_user.user.service_name
  user_id       = ovh_cloud_project_user.user.id
 }
-`, os.Getenv("OVH_CLOUD_PROJECT_SERVICE_TEST"))
+`
 
 func TestAccCloudProjectUserS3Credential_basic(t *testing.T) {
+	serviceName := os.Getenv("OVH_CLOUD_PROJECT_SERVICE_TEST")
+
+	config := fmt.Sprintf(testAccCloudProjectUserS3CredentialConfig_basic, serviceName)
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheckCloud(t); testAccCheckCloudProjectExists(t) },
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCloudProjectUserS3CredentialConfig,
+				Config: config,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet(
 						"ovh_cloud_project_user_s3_credential.s3_cred", "access_key_id"),

--- a/ovh/resource_cloud_project_user_s3_credential_test.go
+++ b/ovh/resource_cloud_project_user_s3_credential_test.go
@@ -1,0 +1,39 @@
+package ovh
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+var testAccCloudProjectUserS3CredentialConfig = fmt.Sprintf(`
+resource "ovh_cloud_project_user" "user" {
+ service_name = "%s"
+ description  = "my user for acceptance tests"
+}
+
+resource "ovh_cloud_project_user_s3_credential" "s3_cred" {
+ service_name  = ovh_cloud_project_user.user.service_name
+ user_id       = ovh_cloud_project_user.user.id
+}
+`, os.Getenv("OVH_CLOUD_PROJECT_SERVICE_TEST"))
+
+func TestAccCloudProjectUserS3Credential_basic(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheckCloud(t); testAccCheckCloudProjectExists(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCloudProjectUserS3CredentialConfig,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(
+						"ovh_cloud_project_user_s3_credential.s3_cred", "access_key_id"),
+					resource.TestCheckResourceAttrSet(
+						"ovh_cloud_project_user_s3_credential.s3_cred", "secret_access_key"),
+				),
+			},
+		},
+	})
+}

--- a/ovh/types_cloud.go
+++ b/ovh/types_cloud.go
@@ -149,6 +149,26 @@ type CloudProjectUserOpenstackRC struct {
 	Content string `json:"content"`
 }
 
+type CloudProjectUserS3Credential struct {
+	Access      string `json:"access"`
+	Secret      string `json:"secret"`
+	ServiceName string `json:"tenantId"`
+	UserId      string `json:"userId"`
+}
+
+func (u *CloudProjectUserS3Credential) String() string {
+	return fmt.Sprintf("CloudProjectUserS3Credential[ServiceName:%s, UserId: %s, Access: %s]", u.ServiceName, u.UserId, u.Access)
+}
+
+func (u CloudProjectUserS3Credential) ToMap() map[string]interface{} {
+	obj := make(map[string]interface{})
+	obj["access_key_id"] = u.Access
+	obj["secret_access_key"] = u.Secret
+	obj["service_name"] = u.ServiceName
+	obj["internal_user_id"] = u.UserId
+	return obj
+}
+
 type CloudProjectRegionResponse struct {
 	ContinentCode      string                       `json:"continentCode"`
 	DatacenterLocation string                       `json:"datacenterLocation"`

--- a/website/docs/d/cloud_project_user_s3_credential.html.markdown
+++ b/website/docs/d/cloud_project_user_s3_credential.html.markdown
@@ -13,24 +13,33 @@ Use this data source to retrieve the Secret Access Key of an Access Key ID assoc
 ## Example Usage
 
 ```hcl
-data "ovh_cloud_project_user_s3_credentials" "s3_credentials" {
+data "ovh_cloud_project_user_s3_credentials" "my_s3_credentials" {
    service_name = "XXXXXX"
    user_id      = "1234"
 }
 
-data "ovh_cloud_project_user_s3_credential" "s3_cred_1" {
-   service_name  = "XXXXXX"
-   user_id       = "1234"
-   access_key_id = data.ovh_cloud_project_user_s3_credentials.s3_credentials.access_key_ids[0]
+data "ovh_cloud_project_user_s3_credential" "my_s3_credential" {
+   service_name  = data.ovh_cloud_project_user_s3_credentials.my_s3_credentials.service_name
+   user_id       = data.ovh_cloud_project_user_s3_credentials.my_s3_credentials.user_id
+   access_key_id = data.ovh_cloud_project_user_s3_credentials.my_s3_credentials.access_key_ids[0]
+}
+
+output "my_access_key_id" {
+   value = ovh_cloud_project_user_s3_credential.my_s3_credential.access_key_id
+}
+
+output "my_secret_access_key" {
+   value     = ovh_cloud_project_user_s3_credential.my_s3_credential.secret_access_key
+   sensitive = true
 }
 ```
 
 ## Argument Reference
 
-- `service_name` - (Required) The id of the public cloud project. If omitted,
+- `service_name` - (Required) The ID of the public cloud project. If omitted,
   the `OVH_CLOUD_PROJECT_SERVICE` environment variable is used.
 
-- `user_id` - (Required) The id of a public cloud project's user.
+- `user_id` - (Required) The ID of a public cloud project's user.
 
 - `access_key_id` - the Access Key ID
 

--- a/website/docs/d/cloud_project_user_s3_credential.html.markdown
+++ b/website/docs/d/cloud_project_user_s3_credential.html.markdown
@@ -1,0 +1,39 @@
+---
+layout: "ovh"
+page_title: "OVH: cloud_project_user_s3_credential"
+sidebar_current: "docs-ovh-datasource-cloud-project-user-s3-credential"
+description: |-
+  Get the Secret Access Key of an Access Key ID of a public cloud project's user.
+---
+
+# ovh_cloud_project_user_s3_credential (Data Source)
+
+Use this data source to retrieve the Secret Access Key of an Access Key ID associated with a public cloud project's user.
+
+## Example Usage
+
+```hcl
+data "ovh_cloud_project_user_s3_credentials" "s3_credentials" {
+   service_name = "XXXXXX"
+   user_id      = "1234"
+}
+
+data "ovh_cloud_project_user_s3_credential" "s3_cred_1" {
+   service_name  = "XXXXXX"
+   user_id       = "1234"
+   access_key_id = data.ovh_cloud_project_user_s3_credentials.s3_credentials.access_key_ids[0]
+}
+```
+
+## Argument Reference
+
+- `service_name` - (Required) The id of the public cloud project. If omitted,
+  the `OVH_CLOUD_PROJECT_SERVICE` environment variable is used.
+
+- `user_id` - (Required) The id of a public cloud project's user.
+
+- `access_key_id` - the Access Key ID
+
+## Attributes Reference
+
+- `secret_access_key` - (Sensitive) the Secret Access Key

--- a/website/docs/d/cloud_project_user_s3_credentials.html.markdown
+++ b/website/docs/d/cloud_project_user_s3_credentials.html.markdown
@@ -1,0 +1,31 @@
+---
+layout: "ovh"
+page_title: "OVH: cloud_project_user_s3_credentials"
+sidebar_current: "docs-ovh-datasource-cloud-project-user-s3-credentials"
+description: |-
+  Get the list of Access Key ID of a public cloud project's user.
+---
+
+# ovh_cloud_project_user_s3_credentials (Data Source)
+
+Use this data source to retrieve the list of all the S3 access_key_id associated with a public cloud project's user.
+
+## Example Usage
+
+```hcl
+data "ovh_cloud_project_user_s3_credentials" "user_1234_s3_credentials" {
+   service_name = "XXXXXX"
+   user_id      = "1234"
+}
+```
+
+## Argument Reference
+
+- `service_name` - (Required) The id of the public cloud project. If omitted,
+  the `OVH_CLOUD_PROJECT_SERVICE` environment variable is used.
+
+- `user_id` - (Required) The id of a public cloud project's user.
+
+## Attributes Reference
+
+- `access_key_ids` - The list of the Access Key ID associated with this user.

--- a/website/docs/d/cloud_project_user_s3_credentials.html.markdown
+++ b/website/docs/d/cloud_project_user_s3_credentials.html.markdown
@@ -13,18 +13,22 @@ Use this data source to retrieve the list of all the S3 access_key_id associated
 ## Example Usage
 
 ```hcl
-data "ovh_cloud_project_user_s3_credentials" "user_1234_s3_credentials" {
+data "ovh_cloud_project_user_s3_credentials" "my_s3_credentials" {
    service_name = "XXXXXX"
    user_id      = "1234"
+}
+
+output "access_key_ids" {
+   value = data.ovh_cloud_project_user_s3_credentials.my_s3_credentials.access_key_ids
 }
 ```
 
 ## Argument Reference
 
-- `service_name` - (Required) The id of the public cloud project. If omitted,
+- `service_name` - (Required) The ID of the public cloud project. If omitted,
   the `OVH_CLOUD_PROJECT_SERVICE` environment variable is used.
 
-- `user_id` - (Required) The id of a public cloud project's user.
+- `user_id` - (Required) The ID of a public cloud project's user.
 
 ## Attributes Reference
 

--- a/website/docs/r/cloud_project_user_s3_credential.html.markdown
+++ b/website/docs/r/cloud_project_user_s3_credential.html.markdown
@@ -16,9 +16,12 @@ Creates an S3 Credential for a user in a public cloud project.
 resource "ovh_cloud_project_user" "user" {
  service_name = "XXX
  description  = "my user for acceptance tests"
+ role_names   = [
+  "objectstore_operator"
+ ]
 }
 
-resource "ovh_cloud_project_user_s3_credential" "s3_credential" {
+resource "ovh_cloud_project_user_s3_credential" "my_s3_credentials" {
  service_name = ovh_cloud_project_user.user.service_name
  user_id      = ovh_cloud_project_user.user.id
 }
@@ -28,10 +31,10 @@ resource "ovh_cloud_project_user_s3_credential" "s3_credential" {
 
 The following arguments are supported:
 
-- `service_name` - (Required) The id of the public cloud project. If omitted,
+- `service_name` - (Required) The ID of the public cloud project. If omitted,
   the `OVH_CLOUD_PROJECT_SERVICE` environment variable is used.
 
-- `user_id` - (Required) The id of a public cloud project's user.
+- `user_id` - (Required) The ID of a public cloud project's user.
 
 ## Attributes Reference
 

--- a/website/docs/r/cloud_project_user_s3_credential.html.markdown
+++ b/website/docs/r/cloud_project_user_s3_credential.html.markdown
@@ -1,0 +1,51 @@
+---
+layout: "ovh"
+page_title: "OVH: ovh_cloud_project_user_s3_credential"
+sidebar_current: "docs-ovh-resource-cloud-project-user-s3-credential"
+description: |-
+  Creates an S3 Credential for a user in a public cloud project.
+---
+
+# ovh_cloud_project_user_s3_credential
+
+Creates an S3 Credential for a user in a public cloud project.
+
+## Example Usage
+
+```hcl
+resource "ovh_cloud_project_user" "user" {
+ service_name = "XXX
+ description  = "my user for acceptance tests"
+}
+
+resource "ovh_cloud_project_user_s3_credential" "s3_credential" {
+ service_name = ovh_cloud_project_user.user.service_name
+ user_id      = ovh_cloud_project_user.user.id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+- `service_name` - (Required) The id of the public cloud project. If omitted,
+  the `OVH_CLOUD_PROJECT_SERVICE` environment variable is used.
+
+- `user_id` - (Required) The id of a public cloud project's user.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+- `service_name` - See Argument Reference above.
+- `user_id` - See Argument Reference above.
+- `access_key_id` - the Access Key ID
+- `secret_access_key` - (Sensitive) the Secret Access Key
+
+## Import
+
+OVHcloud User S3 Credentials can be imported using the `service_name`, `user_id` and `access_key_id` of the credential, separated by "/" E.g.,
+
+```
+$ terraform import ovh_cloud_project_user_s3_credential.s3_credential <service_name>/<user_id>/<access_key_id>
+```

--- a/website/ovh.erb
+++ b/website/ovh.erb
@@ -37,6 +37,12 @@
         <li<%= sidebar_current("docs-ovh-datasource-cloud-project-regions") %>>
           <a href="/docs/providers/ovh/d/cloud_project_regions.html">ovh_cloud_project_regions</a>
         </li>
+        <li<%= sidebar_current("docs-ovh-datasource-cloud-project-user-s3-credential") %>>
+          <a href="/docs/providers/ovh/d/cloud_project_user_s3_credential.html">ovh_cloud_project_user_s3_credential</a>
+        </li>
+        <li<%= sidebar_current("docs-ovh-datasource-cloud-project-user-s3-credentials") %>>
+          <a href="/docs/providers/ovh/d/cloud_project_user_s3_credentials.html">ovh_cloud_project_user_s3_credentials</a>
+        </li>
         <li<%= sidebar_current("docs-ovh-datasource-dbaas-logs-input-engine-x") %>>
           <a href="/docs/providers/ovh/d/dbaas_logs_input_engine.html">ovh_dbaas_logs_input_engine</a>
         </li>
@@ -147,6 +153,9 @@
         </li>
         <li<%= sidebar_current("docs-ovh-resource-cloud-project-user") %>>
           <a href="/docs/providers/ovh/r/cloud_project_user.html">ovh_cloud_project_user</a>
+        </li>
+        <li<%= sidebar_current("docs-ovh-resource-cloud-project-user-s3-credential") %>>
+          <a href="/docs/providers/ovh/r/cloud_project_user_s3_credential.html">ovh_cloud_project_user_s3_credential</a>
         </li>
         <li<%= sidebar_current("docs-ovh-resource-cloud-project-failover-ip-attach") %>>
           <a href="/docs/providers/ovh/d/cloud_project_failover_ip_attach.html">ovh_cloud_project_failover_ip_attach</a>


### PR DESCRIPTION
Add the datasources and resource to create and retrieve S3 Credentials (AccessKeyId and SecretAccessKey) required to access S3 buckets. Fixes #285 