### PR TITLE
Kube: optional update_policy parameter at cluster creation

### DIFF
--- a/ovh/resource_cloud_project_kube.go
+++ b/ovh/resource_cloud_project_kube.go
@@ -146,10 +146,6 @@ func resourceCloudProjectKubeCreate(d *schema.ResourceData, meta interface{}) er
 	params := (&CloudProjectKubeCreateOpts{}).FromResource(d)
 	res := &CloudProjectKubeResponse{}
 
-	if params.UpdatePolicy != nil {
-		return fmt.Errorf("the attribute update_policy cannot be set at cluster creation time. Once the cluster is created this attribute can be set and/or updated. This is a temporary bug on our OVH APIV6 side")
-	}
-
 	log.Printf("[DEBUG] Will create kube: %+v", params)
 	err := config.OVHClient.Post(endpoint, params, res)
 	if err != nil {

--- a/ovh/resource_cloud_project_kube_test.go
+++ b/ovh/resource_cloud_project_kube_test.go
@@ -90,6 +90,7 @@ resource "ovh_cloud_project_kube" "cluster" {
 	service_name  = "%s"
 	name          = "%s"
 	region        = "%s"
+	update_policy = "ALWAYS_UPDATE"
 }
 `
 

--- a/website/docs/r/cloud_project_kube.html.markdown
+++ b/website/docs/r/cloud_project_kube.html.markdown
@@ -58,7 +58,7 @@ The following arguments are supported:
   * default_vrack_gateway - If defined, all egress traffic will be routed towards this IP address, which should belong to the private network. Empty string means disabled.
   * private_network_routing_as_default - Defines whether routing should default to using the nodes' private interface, instead of their public interface. Default is false.
 
-* `update_policy` - Cluster update policy. Choose between [ALWAYS_UPDATE, MINIMAL_DOWNTIME, NEVER_UPDATE]'.
+* `update_policy` - Cluster update policy. Choose between [ALWAYS_UPDATE, MINIMAL_DOWNTIME, NEVER_UPDATE].
 
 ## Attributes Reference
 


### PR DESCRIPTION
optional update_policy parameter at cluster creation, APIV6 was updated 

no exception thrown at cluster creation when specifying the update_policy parameter