### PR TITLE
Extend order termination timeout to 30minutes

### DIFF
--- a/ovh/order.go
+++ b/ovh/order.go
@@ -422,7 +422,7 @@ func orderDelete(d *schema.ResourceData, meta interface{}, terminate TerminateFu
 
 	var email *NotificationEmail
 	// wait for email
-	err = resource.Retry(5*time.Minute, func() *resource.RetryError {
+	err = resource.Retry(30*time.Minute, func() *resource.RetryError {
 		email, err = getNewNotificationEmail(matches, oldEmailsIds, meta)
 		if err != nil {
 			log.Printf("[DEBUG] error while getting email notification. retry: %v", err)


### PR DESCRIPTION
Sometimes the order API takes too long to send the confirmation email after calling `.../terminate` on a product.

This email contains the token needed to call `.../confirmTermination`.

The PR increases the timeout of waiting for that email to show up in `/me/notifications/email/history`