### PR TITLE
fix: iplb frontend default values

### DIFF
--- a/ovh/helpers/helpers.go
+++ b/ovh/helpers/helpers.go
@@ -209,7 +209,9 @@ func GetNilStringPointerFromData(data interface{}, id string) *string {
 
 func GetNilIntPointerFromData(data interface{}, id string) *int {
 	if resourceData, tok := data.(*schema.ResourceData); tok {
-		return GetNilIntPointer(resourceData.Get(id))
+		if val, ok := resourceData.GetOk(id); ok {
+			return GetNilIntPointer(val)
+		}
 	} else if mapData, tok := data.(map[string]interface{}); tok {
 		if val, ok := mapData[id]; ok {
 			return GetNilIntPointer(val)


### PR DESCRIPTION
The is a fix to the creation of iplb frontend ressources
Since the 0.19.0 version the creation fail as the provider will always set a value for `default_ssl_id` and `default_farm_id` params
The bug was introduce in this commit: [50d254d2ade1](https://github.com/ovh/terraform-provider-ovh/commit/50d254d2ade1022383805293689430e174ed269a#diff-ee495b1dc0a50f4b42ae2b3b09e6f4d2cf9213f3acacba6c5ffc3be37b964cc6
) 
I simply revert the change made to the helper

But I can't test the other implications change or why this change was made in the first place