### PR TITLE
feat(ovh_cloud_project_region_storage_presign): add resource

### DIFF
--- a/ovh/provider.go
+++ b/ovh/provider.go
@@ -139,6 +139,7 @@ func Provider() *schema.Provider {
 			"ovh_cloud_project_kube_iprestrictions":                       resourceCloudProjectKubeIpRestrictions(),
 			"ovh_cloud_project_network_private":                           resourceCloudProjectNetworkPrivate(),
 			"ovh_cloud_project_network_private_subnet":                    resourceCloudProjectNetworkPrivateSubnet(),
+			"ovh_cloud_project_region_storage_presign":                    resourceCloudProjectRegionStoragePresign(),
 			"ovh_cloud_project_user":                                      resourceCloudProjectUser(),
 			"ovh_cloud_project_user_s3_credential":                        resourceCloudProjectUserS3Credential(),
 			"ovh_cloud_project_user_s3_policy":                            resourceCloudProjectUserS3Policy(),

--- a/ovh/resource_cloud_project_region_storage_presign.go
+++ b/ovh/resource_cloud_project_region_storage_presign.go
@@ -1,0 +1,92 @@
+package ovh
+
+import (
+	"fmt"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/ovh/terraform-provider-ovh/ovh/helpers"
+	"net/url"
+	"strconv"
+	"time"
+)
+
+func resourceCloudProjectRegionStoragePresign() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceCloudProjectRegionStoragePresignCreate,
+		Read:   schema.Noop,
+		Delete: schema.Noop,
+
+		Schema: map[string]*schema.Schema{
+			"service_name": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				DefaultFunc: schema.EnvDefaultFunc("OVH_CLOUD_PROJECT_SERVICE", nil),
+				Description: "Service name of the resource representing the ID of the cloud project.",
+			},
+			"region_name": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: "Region name.",
+			},
+			"name": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: "The S3 storage container's name.",
+			},
+			"expire": {
+				Type:        schema.TypeInt,
+				Required:    true,
+				ForceNew:    true,
+				Description: "How long (in seconds) the URL will be valid.",
+			},
+			"method": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+				ValidateFunc: func(v interface{}, k string) (ws []string, errors []error) {
+					err := helpers.ValidateStringEnum(v.(string), []string{"GET", "PUT"})
+					if err != nil {
+						errors = append(errors, err)
+					}
+					return
+				},
+			},
+			"object": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: "Name of the object to download or upload.",
+			},
+
+			// Computed
+			"url": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Presigned URL.",
+			},
+		},
+	}
+}
+
+func resourceCloudProjectRegionStoragePresignCreate(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+	serviceName := d.Get("service_name").(string)
+	regionName := d.Get("region_name").(string)
+	name := d.Get("name").(string)
+
+	resp := &PresignedURL{}
+	opts := (&PresignedURLInput{}).FromResource(d)
+
+	endpoint := fmt.Sprintf("/cloud/project/%s/region/%s/storage/%s/presign", url.PathEscape(serviceName), url.PathEscape(regionName), url.PathEscape(name))
+	if err := config.OVHClient.Post(endpoint, opts, resp); err != nil {
+		return fmt.Errorf("Error calling post %s:\n\t %q", endpoint, err)
+	}
+	d.SetId(strconv.FormatInt(time.Now().Unix(), 10))
+	err := d.Set("url", resp.URL)
+	if err != nil {
+		return err
+	}
+	return nil
+}

--- a/ovh/resource_cloud_project_region_storage_presign_test.go
+++ b/ovh/resource_cloud_project_region_storage_presign_test.go
@@ -1,0 +1,74 @@
+package ovh
+
+import (
+	"fmt"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"os"
+	"testing"
+)
+
+const testCloudProjectRegionStoragePresign = `
+resource "ovh_cloud_project_region_storage_presign" "presign_url" {
+  service_name = "%s"
+  region_name  = "%s"
+  name         = "%s"
+  expire       = 3600
+  method       = "GET"
+  object       = "%s"
+}
+`
+
+func testAccPreCheckCloudRegionStorage(t *testing.T) {
+	testAccPreCheckCredentials(t)
+	checkEnvOrSkip(t, "OVH_CLOUD_PROJECT_STORAGE_REGION_TEST")
+	checkEnvOrSkip(t, "OVH_CLOUD_PROJECT_STORAGE_BUCKET_NAME_TEST")
+	checkEnvOrSkip(t, "OVH_CLOUD_PROJECT_STORAGE_OBJECT_TEST")
+}
+
+func testAccCheckCloudRegionStorage(t *testing.T) {
+
+	type cloudProjectRegionStorageResponse struct {
+		Name   string `json:"name"`
+		Region string `json:"region"`
+	}
+
+	r := cloudProjectRegionStorageResponse{}
+
+	endpoint := fmt.Sprintf("/cloud/project/%s/region/%s/storage/%s",
+		os.Getenv("OVH_CLOUD_PROJECT_SERVICE_TEST"),
+		os.Getenv("OVH_CLOUD_PROJECT_STORAGE_REGION_TEST"),
+		os.Getenv("OVH_CLOUD_PROJECT_STORAGE_BUCKET_NAME_TEST"))
+
+	err := testAccOVHClient.Get(endpoint, &r)
+	if err != nil {
+		t.Fatalf("Error: %q\n", err)
+	}
+	t.Logf("Read Storage Container %s -> name: '%s', region: '%s'", endpoint, r.Name, r.Region)
+}
+
+func TestCloudProjectRegionStoragePresign(t *testing.T) {
+	serviceName := os.Getenv("OVH_CLOUD_PROJECT_SERVICE_TEST")
+	regionName := os.Getenv("OVH_CLOUD_PROJECT_STORAGE_REGION_TEST")
+	name := os.Getenv("OVH_CLOUD_PROJECT_STORAGE_BUCKET_NAME_TEST")
+	object := os.Getenv("OVH_CLOUD_PROJECT_STORAGE_OBJECT_TEST")
+
+	config := fmt.Sprintf(testCloudProjectRegionStoragePresign, serviceName, regionName, name, object)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheckCloudRegionStorage(t)
+			testAccPreCheckCloud(t)
+			testAccCheckCloudProjectExists(t)
+			testAccCheckCloudRegionStorage(t)
+		},
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("ovh_cloud_project_region_storage_presign.presign_url", "url"),
+				),
+			},
+		},
+	})
+}

--- a/ovh/types_presigned_url.go
+++ b/ovh/types_presigned_url.go
@@ -1,0 +1,23 @@
+package ovh
+
+import (
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+type PresignedURL struct {
+	Method string `json:"method"`
+	URL    string `json:"url"`
+}
+
+type PresignedURLInput struct {
+	Expire int    `json:"expire"`
+	Method string `json:"method"`
+	Object string `json:"object"`
+}
+
+func (opts *PresignedURLInput) FromResource(d *schema.ResourceData) *PresignedURLInput {
+	opts.Expire = d.Get("expire").(int)
+	opts.Method = d.Get("method").(string)
+	opts.Object = d.Get("object").(string)
+	return opts
+}

--- a/website/docs/r/cloud_project_region_storage_presign.html.markdown
+++ b/website/docs/r/cloud_project_region_storage_presign.html.markdown
@@ -1,0 +1,56 @@
+---
+layout: "ovh"
+page_title: "OVH: cloud_project_region_storage_presign"
+sidebar_current: "docs-ovh-resource-cloud-project-region-storage-presign"
+description: |-
+  Generates a temporary presigned S3 URLs to download or upload an object.
+---
+
+# ovh_cloud_project_region_storage_presign
+
+Generates a temporary presigned S3 URLs to download or upload an object.
+
+-> __NOTE__ This resource is only compatible with the `High Performance - S3` solution for object storage.
+
+## Example Usage
+
+```hcl
+resource "ovh_cloud_project_region_storage_presign" "presigned_url" {
+  service_name = "xxxxxxxxxxxxxxxxx"
+  region_name  = "GRA"
+  name         = "s3-bucket-name"
+  expire       = 3600
+  method       = "GET"
+  object       = "an-object-in-the-bucket"
+}
+
+output "presigned_url" {
+  value = ovh_cloud_project_region_storage_presign.presigned_url.url
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `service_name` - (Required) The id of the public cloud project. If omitted,
+  the `OVH_CLOUD_PROJECT_SERVICE` environment variable is used.
+* `region_name` - (Required) The region in which your storage is located.
+  Ex.: "GRA".
+* `name` - (Required) The name of your S3 storage container/bucket.
+* `expire` - (Required) Define, in seconds, for how long your URL will be valid.
+* `method` - (Required) The method you want to use to interact with your object. Can be either 'GET' or 'PUT'.
+* `object` - (Required) The name of the object in your S3 bucket.
+
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `service_name` - See Argument Reference above.
+* `region_name` - See Argument Reference above.
+* `name` - See Argument Reference above.
+* `expire` - See Argument Reference above.
+* `method` - See Argument Reference above.
+* `object` - See Argument Reference above.
+* `url` - Computed URL result.

--- a/website/ovh.erb
+++ b/website/ovh.erb
@@ -160,6 +160,9 @@
         <li<%= sidebar_current("docs-ovh-resource-cloud-project-network-private-subnet") %>>
           <a href="/docs/providers/ovh/r/cloud_project_network_private_subnet.html">ovh_cloud_project_network_private_subnet</a>
         </li>
+         <li<%= sidebar_current("docs-ovh-resource-cloud-project-region-storage-presign") %>>
+           <a href="/docs/providers/ovh/r/cloud_project_region_storage_presign.html">ovh_cloud_project_region_storage_presign</a>
+         </li>
         <li<%= sidebar_current("docs-ovh-resource-cloud-project-user") %>>
           <a href="/docs/providers/ovh/r/cloud_project_user.html">ovh_cloud_project_user</a>
         </li>


### PR DESCRIPTION
Use this resource to presign url to interact with s3 fast storage.

This can be used for multiple uses-cases like uploading a post-install script to s3 then passing the URL to a dedicated_server install task. The URL is signed for a fixed period, hence the `expire` parameter.

Signed-off-by: Arnaud SINAYS <sinaysarnaud@gmail.com>