### PR TITLE
deprecate resource_vrack_dedicated_server 

### DIFF
--- a/ovh/resource_vrack_dedicated_server.go
+++ b/ovh/resource_vrack_dedicated_server.go
@@ -32,6 +32,7 @@ func resourceVrackDedicatedServer() *schema.Resource {
 				ForceNew: true,
 			},
 		},
+		DeprecationMessage: "Use ovh_vrack_dedicated_server_interface instead.",
 	}
 }
 

--- a/website/docs/r/dedicated_server_install_task.html.markdown
+++ b/website/docs/r/dedicated_server_install_task.html.markdown
@@ -19,7 +19,7 @@ after a while.
 
 ```hcl
 data ovh_dedicated_server_boots "rescue" {
-  service_name = "ns00000.ip-1-2-3.eu"
+  service_name = "nsxxxxxxx.ip-xx-xx-xx.eu"
   boot_type    = "rescue"
 }
 
@@ -29,21 +29,23 @@ resource "ovh_me_ssh_key" "key" {
 }
 
 resource "ovh_me_installation_template" "debian" {
-  base_template_name = "debian10_64"
-  template_name      = "mydebian10"
+  base_template_name = "debian11_64"
+  template_name      = "mydebian11"
   default_language   = "en"
 
   customization {
-    change_log      = "v1"
-    custom_hostname = "mytest"
     ssh_key_name    = ovh_me_ssh_key.key.key_name
   }
 }
 
-resource ovh_dedicated_server_install_task "server_install" {
-  service_name      = "ns00000.ip-1-2-3.eu"
+resource "ovh_dedicated_server_install_task" "server_install" {
+  service_name      = "nsxxxxxxx.ip-xx-xx-xx.eu"
   template_name     = ovh_me_installation_template.debian.template_name
   bootid_on_destroy = data.ovh_dedicated_server_boots.rescue.result[0]
+
+  details {
+      custom_hostname = "mytest"
+  }
 }
 ```
 

--- a/website/docs/r/dedicated_server_reboot_task.html.markdown
+++ b/website/docs/r/dedicated_server_reboot_task.html.markdown
@@ -18,20 +18,20 @@ after a while.
 ## Example Usage
 
 ```hcl
-data ovh_dedicated_server_boots "rescue" {
-  service_name = "ns00000.ip-1-2-3.eu"
+data "ovh_dedicated_server_boots" "rescue" {
+  service_name = "nsxxxxxxx.ip-xx-xx-xx.eu"
   boot_type    = "rescue"
   kernel       = "rescue64-pro"
 }
 
-resource ovh_dedicated_server_update "server_on_rescue" {
-  service_name = "ns00000.ip-1-2-3.eu"
+resource "ovh_dedicated_server_update" "server_on_rescue" {
+  service_name = "nsxxxxxxx.ip-xx-xx-xx.eu"
   boot_id      = data.ovh_dedicated_server_boots.rescue.result[0]
   monitoring   = true
   state        = "ok"
 }
 
-resource ovh_dedicated_server_reboot_task "server_reboot" {
+resource "ovh_dedicated_server_reboot_task" "server_reboot" {
   service_name = data.ovh_dedicated_server_boots.rescue.service_name
 
   keepers = [
@@ -45,7 +45,7 @@ resource ovh_dedicated_server_reboot_task "server_reboot" {
 The following arguments are supported:
 
 * `service_name` - (Required) The service_name of your dedicated server.
-* `keepers` - List of values traccked to trigger reboot, used also to form implicit dependencies
+* `keepers` - List of values tracked to trigger reboot, used also to form implicit dependencies.
 
 ## Attributes Reference
 

--- a/website/docs/r/dedicated_server_update.html.markdown
+++ b/website/docs/r/dedicated_server_update.html.markdown
@@ -12,20 +12,20 @@ Update various properties of your Dedicated Server.
 
 ~> __WARNING__ `rescue_mail` and `root_device` properties aren't
 updated consistently. This is an issue on the OVHcloud API which 
-has been reported. Meanwhile, these properties aren't not mapped
+has been reported. Meanwhile, these properties are not mapped
 on this terraform resource.
 
 ## Example Usage
 
 ```hcl
-data ovh_dedicated_server_boots "rescue" {
-  service_name = "ns00000.ip-1-2-3.eu"
+data "ovh_dedicated_server_boots" "rescue" {
+  service_name = "nsxxxxxxx.ip-xx-xx-xx.eu"
   boot_type    = "rescue"
   kernel       = "rescue64-pro"
 }
 
-resource ovh_dedicated_server_update "server" {
-  service_name = "ns00000.ip-1-2-3.eu"
+resource "ovh_dedicated_server_update" "server" {
+  service_name = "nsxxxxxxx.ip-xx-xx-xx.eu"
   boot_id      = data.ovh_dedicated_server_boots.rescue.result[0]
   monitoring   = true
   state        = "ok"

--- a/website/docs/r/vrack_dedicated_server.html.markdown
+++ b/website/docs/r/vrack_dedicated_server.html.markdown
@@ -9,7 +9,7 @@ description: |-
 # ovh_vrack_dedicated_server
 
 ~> **NOTE:** The resource `ovh_vrack_dedicated_server` is DEPRECATED and will be removed in a future version.
-Use the resource ['ovh_vrack_dedicated_server_interface'](vrack_dedicated_server_interface.html.markdown) instead.
+Use the resource [`ovh_vrack_dedicated_server_interface`](vrack_dedicated_server_interface.html.markdown) instead.
 
 Attach a dedicated server to a VRack.
 

--- a/website/docs/r/vrack_dedicated_server.html.markdown
+++ b/website/docs/r/vrack_dedicated_server.html.markdown
@@ -8,6 +8,9 @@ description: |-
 
 # ovh_vrack_dedicated_server
 
+~> **NOTE:** The resource `ovh_vrack_dedicated_server` is DEPRECATED and will be removed in a future version.
+Use the resource ['ovh_vrack_dedicated_server_interface'](vrack_dedicated_server_interface.html.markdown) instead.
+
 Attach a dedicated server to a VRack.
 
 ## Example Usage

--- a/website/docs/r/vrack_dedicated_server_interface.html.markdown
+++ b/website/docs/r/vrack_dedicated_server_interface.html.markdown
@@ -13,9 +13,13 @@ Attach a Dedicated Server Network Interface to a VRack.
 ## Example Usage
 
 ```hcl
+data "ovh_dedicated_server" "server" {
+  service_name = "nsxxxxxxx.ip-xx-xx-xx.eu"
+}
+
 resource "ovh_vrack_dedicated_server_interface" "vdsi" {
-  service_name = "12345"
-  interface_id = "67890"
+  service_name = "pn-xxxxxxx" #name of the vrack
+  interface_id = data.ovh_dedicated_server.server.enabled_vrack_vnis[0]
 }
 ```
 


### PR DESCRIPTION
This PR is following this one: #323 that has been reverted.

* Followed https://developer.hashicorp.com/terraform/plugin/sdkv2/best-practices/deprecations#provider-data-source-or-resource-removal and added a `DeprecationMessage` to the resource schema definition.
* Changed the documentation to highlight the deprecation if favor of `ovh_vrack_dedicated_server_interface`.
* And some minor documentation fixes.