### PR TITLE
feat(go-ovh): add User-Agent on go-ovh client to identify calls that comes from Terraform

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -14,7 +14,7 @@ builds:
   flags:
     - -trimpath
   ldflags:
-    - '-s -w -X main.version={{.Version}} -X main.commit={{.Commit}}'
+    - '-s -w -X main.version={{.Version}} -X main.commit={{.Commit}} -X github.com/ovh/terraform-provider-ovh/ovh.providerVersion={{.Version}} -X github.com/ovh/terraform-provider-ovh/ovh.providerCommit={{.Commit}}'
   goos:
     - freebsd
     - windows

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/hashicorp/go-version v1.6.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.9.0
 	github.com/mitchellh/go-homedir v1.1.0
-	github.com/ovh/go-ovh v1.1.0
+	github.com/ovh/go-ovh v1.3.0
 	github.com/smartystreets/assertions v0.0.0-20190116191733-b6c0e53d7304 // indirect
 	github.com/ybriffa/rfc3339 v0.0.0-20220203155318-1789e3fd6e70
 	golang.org/x/tools v0.0.0-20201118030313-598b068a9102 // indirect

--- a/go.sum
+++ b/go.sum
@@ -183,7 +183,6 @@ github.com/hashicorp/go-uuid v1.0.0/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/b
 github.com/hashicorp/go-uuid v1.0.1 h1:fv1ep09latC32wFoVwnqcnKJGnMSdBanPczbHAYm1BE=
 github.com/hashicorp/go-uuid v1.0.1/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
 github.com/hashicorp/go-version v1.1.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
-github.com/hashicorp/go-version v1.3.0 h1:McDWVJIU/y+u1BRV06dPaLfLCaT7fUTJLp5r04x7iNw=
 github.com/hashicorp/go-version v1.3.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
 github.com/hashicorp/go-version v1.6.0 h1:feTTfFNnjP967rlCxM/I9g701jU+RN74YKx2mOkIeek=
 github.com/hashicorp/go-version v1.6.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
@@ -272,8 +271,8 @@ github.com/nsf/jsondiff v0.0.0-20200515183724-f29ed568f4ce h1:RPclfga2SEJmgMmz2k
 github.com/nsf/jsondiff v0.0.0-20200515183724-f29ed568f4ce/go.mod h1:uFMI8w+ref4v2r9jz+c9i1IfIttS/OkmLfrk1jne5hs=
 github.com/oklog/run v1.0.0 h1:Ru7dDtJNOyC66gQ5dQmaCa0qIsAUFY3sFpK1Xk8igrw=
 github.com/oklog/run v1.0.0/go.mod h1:dlhp/R75TPv97u0XWUtDeV/lRKWPKSdTuV0TZvrmrQA=
-github.com/ovh/go-ovh v1.1.0 h1:bHXZmw8nTgZin4Nv7JuaLs0KG5x54EQR7migYTd1zrk=
-github.com/ovh/go-ovh v1.1.0/go.mod h1:AxitLZ5HBRPyUd+Zl60Ajaag+rNTdVXWIkzfrVuTXWA=
+github.com/ovh/go-ovh v1.3.0 h1:mvZaddk4E4kLcXhzb+cxBsMPYp2pHqiQpWYkInsuZPQ=
+github.com/ovh/go-ovh v1.3.0/go.mod h1:AxitLZ5HBRPyUd+Zl60Ajaag+rNTdVXWIkzfrVuTXWA=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/ovh/config.go
+++ b/ovh/config.go
@@ -11,6 +11,8 @@ import (
 	"github.com/ovh/go-ovh/ovh"
 )
 
+var providerVersion, providerCommit string
+
 type Config struct {
 	Endpoint          string
 	ApplicationKey    string
@@ -43,6 +45,8 @@ func clientDefault(c *Config) (*ovh.Client, error) {
 	if err != nil {
 		return nil, err
 	}
+
+	client.UserAgent = "Terraform/" + providerVersion + "/" + providerCommit
 	return client, nil
 }
 

--- a/vendor/github.com/ovh/go-ovh/ovh/error.go
+++ b/vendor/github.com/ovh/go-ovh/ovh/error.go
@@ -4,8 +4,12 @@ import "fmt"
 
 // APIError represents an error that can occurred while calling the API.
 type APIError struct {
+	// Error class
+	Class string `json:"class,omitempty"`
 	// Error message.
-	Message string
+	Message string `json:"message"`
+	// Error details
+	Details map[string]string `json:"details,omitempty"`
 	// HTTP code.
 	Code int
 	// ID of the request
@@ -13,5 +17,9 @@ type APIError struct {
 }
 
 func (err *APIError) Error() string {
-	return fmt.Sprintf("Error %d: %q", err.Code, err.Message)
+	if err.Class == "" {
+		return fmt.Sprintf("HTTP Error %d: %q", err.Code, err.Message)
+	}
+
+	return fmt.Sprintf("HTTP Error %d: %s: %q (X-OVH-Query-Id: %s)", err.Code, err.Class, err.Message, err.QueryID)
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -188,7 +188,7 @@ github.com/mitchellh/mapstructure
 github.com/mitchellh/reflectwalk
 # github.com/oklog/run v1.0.0
 github.com/oklog/run
-# github.com/ovh/go-ovh v1.1.0
+# github.com/ovh/go-ovh v1.3.0
 ## explicit
 github.com/ovh/go-ovh/ovh
 # github.com/smartystreets/assertions v0.0.0-20190116191733-b6c0e53d7304


### PR DESCRIPTION
Since most of Terraform providers are customising the User-Agent to detect the calls that comes from Terraform usage, we should do the same on the terraform-provider-ovh.

It will include the Terraform provider version, that will ease the debugging purpose when customers comes to us with problems.
