### PR TITLE
Add a Data Source to list all VPS

### DIFF
--- a/ovh/data_vpss.go
+++ b/ovh/data_vpss.go
@@ -1,0 +1,43 @@
+package ovh
+
+import (
+	"fmt"
+	"sort"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/ovh/terraform-provider-ovh/ovh/helpers/hashcode"
+)
+
+func dataSourceVPSs() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceVPSsRead,
+		Schema: map[string]*schema.Schema{
+			// Computed
+			"result": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+			},
+		},
+	}
+}
+
+func dataSourceVPSsRead(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+
+	ids := []string{}
+	err := config.OVHClient.Get("/vps", &ids)
+
+	if err != nil {
+		return fmt.Errorf("Error calling /vps:\n\t %q", err)
+	}
+
+	// sort.Strings sorts in place, returns nothing
+	sort.Strings(ids)
+
+	d.SetId(hashcode.Strings(ids))
+	d.Set("result", ids)
+	return nil
+}

--- a/ovh/data_vpss_test.go
+++ b/ovh/data_vpss_test.go
@@ -1,0 +1,23 @@
+package ovh
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccVPSsDataSource_basic(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheckCredentials(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: "data ovh_vpss servers {}",
+				Check: resource.TestCheckResourceAttrSet(
+					"data.ovh_vpss.servers",
+					"result.#",
+				),
+			},
+		},
+	})
+}

--- a/ovh/provider.go
+++ b/ovh/provider.go
@@ -119,6 +119,7 @@ func Provider() *schema.Provider {
 			"ovh_order_cart_product_options_plan":                     dataSourceOrderCartProductOptionsPlan(),
 			"ovh_order_cart_product_plan":                             dataSourceOrderCartProductPlan(),
 			"ovh_vps":                                                 dataSourceVPS(),
+			"ovh_vpss":                                                dataSourceVPSs(),
 			"ovh_vracks":                                              dataSourceVracks(),
 		},
 

--- a/website/docs/d/vps.html.markdown
+++ b/website/docs/d/vps.html.markdown
@@ -3,7 +3,7 @@ layout: "ovh"
 page_title: "OVH: vps"
 sidebar_current: "docs-ovh-datasource-vps-x"
 description: |-
-  Get information of a vps associatd with your OVJ Account
+  Get information of a vps associatd with your OVH Account
 ---
 
 # ovh\_vps (Data Source)

--- a/website/docs/d/vpss.html.markdown
+++ b/website/docs/d/vpss.html.markdown
@@ -1,0 +1,27 @@
+---
+layout: "ovh"
+page_title: "OVH: vpss"
+sidebar_current: "docs-ovh-datasource-vpss"
+description: |-
+  Get the list of VPS associated with your OVH Account.
+---
+
+# vpss (Data Source)
+
+Use this data source to get the list of VPS associated with your OVH Account.
+
+## Example Usage
+
+```hcl
+data "vpss" "servers" {}
+```
+
+## Argument Reference
+
+This datasource takes no argument.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `result` - The list of VPS IDs associated with your OVH Account.


### PR DESCRIPTION
The `ovh_dedicated_servers` Data Source allows to list all dedicated servers in order to use the `ovh_dedicated_server` data source to collect their details.  The `ovh_vps` data source is similar to `ovh_dedicated_server`, but we are missing a component to list all available VPS.

This PR a new data source that return the list of VPS:

```
data "ovh_vpss" "all_vps" {
}

data "ovh_vps" "vps" {
  for_each = toset(data.ovh_vpss.all_vps.result)
  service_name = each.key
  
}
```

A better name for this data source is still to be found.
