### PR TITLE
Fix import of ovh_ip_reverse resources with IPv6

### DIFF
--- a/ovh/resource_ip_reverse.go
+++ b/ovh/resource_ip_reverse.go
@@ -57,9 +57,9 @@ func resourceIpReverse() *schema.Resource {
 
 func resourceIpReverseImportState(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
 	givenId := d.Id()
-	splitId := strings.SplitN(givenId, ":", 2)
+	splitId := strings.SplitN(givenId, "|", 2)
 	if len(splitId) != 2 {
-		return nil, fmt.Errorf("Import Id is not ip:ip_reverse formatted")
+		return nil, fmt.Errorf("Import Id is not ip|ip_reverse formatted")
 	}
 	ip := splitId[0]
 	ipReverse := splitId[1]

--- a/website/docs/r/ip_reverse.html.markdown
+++ b/website/docs/r/ip_reverse.html.markdown
@@ -32,3 +32,11 @@ The following arguments are supported:
 ## Attributes Reference
 
 The id is set to the value of ip_reverse.
+
+## Import
+
+The resource can be imported using the `ip`, `ip_reverse` of the address, separated by "|" E.g.,
+
+```bash
+$ terraform import ovh_ip_reverse.my_reverse '2001:0db8:c0ff:ee::/64|2001:0db8:c0ff:ee::42'
+```


### PR DESCRIPTION
When importing an `ovh_ip_reverse` resources, the user is expected to
provide the IP block and IP address separated with a colon, e.g.
`198.51.100.0/24:198.51.100.42`:

  * `198.51.100.0/24` is extracted as the IP block;
  * `198.51.100.42` is extracted as the address.

Unfortunately, the `:` separator does not work well with IPv6 addresses,
e.g. `2001:0DB8::/32:2001:0DB8::42` is interpreted as:

  * `2001` is extracted as the IP block;
  * `0DB8::/32:2001:0DB8::42` is extracted as the address.

This is obviously wrong and raise an API error:

```
│ Error: calling /ip/%222001/reverse/0DB8::%2F32:2001:0DB8::42:
│ 	 HTTP Error 400: "[ipReverse] Given data (0DB8::/32:2001:0DB8::42) is not valid for type ip"
```

Replace the `:` separator with a `|` separator to avoid this issue.
