### PR TITLE
Add resource dedicated_server_networking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,9 @@ website/node_modules
 
 website/vendor
 
+# exclude localbuild
+terraform-provider-ovh
+
 # Test exclusions
 !command/test-fixtures/**/*.tfstate
 !command/test-fixtures/**/.terraform/

--- a/ovh/provider.go
+++ b/ovh/provider.go
@@ -163,6 +163,7 @@ func Provider() *schema.Provider {
 			"ovh_dedicated_server_install_task":                           resourceDedicatedServerInstallTask(),
 			"ovh_dedicated_server_reboot_task":                            resourceDedicatedServerRebootTask(),
 			"ovh_dedicated_server_update":                                 resourceDedicatedServerUpdate(),
+			"ovh_dedicated_server_networking":                             resourceDedicatedServerNetworking(),
 			"ovh_domain_zone":                                             resourceDomainZone(),
 			"ovh_domain_zone_record":                                      resourceOvhDomainZoneRecord(),
 			"ovh_domain_zone_redirection":                                 resourceOvhDomainZoneRedirection(),

--- a/ovh/resource_dedicated_server_networking.go
+++ b/ovh/resource_dedicated_server_networking.go
@@ -1,0 +1,251 @@
+package ovh
+
+import (
+	"fmt"
+	"log"
+	"net/url"
+	"sort"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/ovh/go-ovh/ovh"
+)
+
+func resourceDedicatedServerNetworking() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceDedicatedServerNetworkingCreate,
+		Read:   resourceDedicatedServerNetworkingRead,
+		Delete: resourceDedicatedServerNetworkingDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(45 * time.Minute),
+			Delete: schema.DefaultTimeout(45 * time.Minute),
+		},
+
+		Schema: map[string]*schema.Schema{
+			"service_name": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: "The internal name of your dedicated server.",
+			},
+			"interfaces": {
+				// we want to have the interfaces in a determinist order
+				Type: schema.TypeSet,
+				// we can bond all 4 interfaces
+				// we can bond 2x2 interfaces
+				// we cannot bond 3 interfaces and leave one alone
+				// we cannot separate all 4 interfaces
+				MinItems:    1,
+				MaxItems:    2,
+				Required:    true,
+				ForceNew:    true,
+				Description: "Interface or interfaces aggregation.",
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"macs": {
+							// we want to have the MACs in a determinist order
+							Type:        schema.TypeSet,
+							Required:    true,
+							ForceNew:    true,
+							Description: "Interface Mac address",
+							Elem:        &schema.Schema{Type: schema.TypeString},
+						},
+						"type": {
+							Type:        schema.TypeString,
+							Required:    true,
+							ForceNew:    true,
+							Description: "Interface type",
+							// The ValidateFunc expect a signature func(val any, key string) (warns []string, errs []error)
+							// we are not yet using go 1.18+ as such we cannot use any
+							// Once in 1.18 we can add a validation to enforce type is either public or vrack
+						},
+					},
+				},
+			},
+
+			//Computed
+			"description": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Operation description",
+			},
+			"status": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Operation status",
+			},
+		},
+	}
+}
+
+func resourceDedicatedServerNetworkingCreate(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+	serviceName := d.Get("service_name").(string)
+
+	opts := (&DedicatedServerNetworkingCreateOpts{}).FromResource(d)
+	log.Printf("%v\n", opts)
+
+	// Before trying to manipulate networking details on the given server, let's make sure no operations are in progress
+	if err := waitForDedicatedServerNetworking(serviceName, config.OVHClient); err != nil {
+		return err
+	}
+
+	endpoint := fmt.Sprintf(
+		"/dedicated/server/%s/networking",
+		url.PathEscape(serviceName),
+	)
+
+	dedicatedServerNetworking := DedicatedServerNetworking{}
+	if err := config.OVHClient.Post(endpoint, opts, dedicatedServerNetworking); err != nil {
+		return fmt.Errorf("Error calling POST %s:\n\t %q", endpoint, err)
+	}
+
+	// Once new networking details have been sent let's wait until the changes are active
+	if err := waitForDedicatedServerNetworking(serviceName, config.OVHClient); err != nil {
+		return err
+	}
+
+	d.SetId(serviceName)
+	return resourceDedicatedServerNetworkingRead(d, meta)
+}
+
+func resourceDedicatedServerNetworkingRead(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+	// To make it possible to use terraform import let's use d.Id() instead of d.Get("service_name").(string)
+	serviceName := d.Id()
+
+	serverNetworkingDetails, err := getDedicatedServerNetworkingDetails(serviceName, config.OVHClient)
+	if err != nil {
+		return fmt.Errorf("Error retrieving networking details for %s:\n\t %q", serviceName, err)
+	}
+
+	d.Set("service_name", serviceName)
+	d.Set("description", serverNetworkingDetails.Status)
+	d.Set("status", serverNetworkingDetails.Status)
+
+	networkInterfaces := make([]map[string]interface{}, len(serverNetworkingDetails.Interfaces))
+	for i, networkInterfaceDetails := range serverNetworkingDetails.Interfaces {
+
+		networkInterface := make(map[string]interface{})
+		networkInterface["type"] = networkInterfaceDetails.Type
+		macs := networkInterfaceDetails.Macs
+
+		// we want the MACs associated to an interface to be in a determist order to avoid false positive diff
+		sort.Strings(macs)
+		networkInterface["macs"] = macs
+
+		networkInterfaces[i] = networkInterface
+	}
+
+	// we want interfaces to be in a determist order to avoid false positive diff
+	sort.SliceStable(networkInterfaces, func(i, j int) bool {
+		return networkInterfaces[i]["type"].(string) < networkInterfaces[j]["type"].(string)
+	})
+
+	err = d.Set("interfaces", networkInterfaces)
+	if err != nil {
+		return fmt.Errorf("Error persisting interfaces in state for %s:\n\t %q", serviceName, err)
+	}
+	return nil
+}
+
+func resourceDedicatedServerNetworkingDelete(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+	serviceName := d.Get("service_name").(string)
+
+	// Before trying to manipulate networking details on the given server, let's make sure no operations are in progress
+	if err := waitForDedicatedServerNetworking(serviceName, config.OVHClient); err != nil {
+		return err
+	}
+
+	endpoint := fmt.Sprintf(
+		"/dedicated/server/%s/networking",
+		url.PathEscape(serviceName),
+	)
+
+	dedicatedServerNetworking := DedicatedServerNetworking{}
+	if err := config.OVHClient.Delete(endpoint, dedicatedServerNetworking); err != nil {
+		return fmt.Errorf("Error calling DELETE %s:\n\t %q", endpoint, err)
+	}
+
+	// Once new networking details have been sent let's wait until the changes are active
+	if err := waitForDedicatedServerNetworking(serviceName, config.OVHClient); err != nil {
+		return err
+	}
+
+	// we cant delete the task through the API, just forget about its Id
+	d.SetId("")
+	return nil
+}
+
+func waitForDedicatedServerNetworking(serviceName string, c *ovh.Client) error {
+
+	refreshFunc := func() (interface{}, string, error) {
+		var taskErr error
+		var serverNetworkingDetails *DedicatedServerNetworking
+
+		// The Dedicated Server API often returns 500/404 errors
+		// in such case we retry to retrieve task status
+		// 404 may happen because of some inconsistency between the
+		// api endpoint call and the target region executing the task
+		retryErr := resource.Retry(5*time.Minute, func() *resource.RetryError {
+			var err error
+			serverNetworkingDetails, err = getDedicatedServerNetworkingDetails(serviceName, c)
+			if err != nil {
+				if errOvh, ok := err.(*ovh.APIError); ok && (errOvh.Code == 404 || errOvh.Code == 500) {
+					return resource.RetryableError(err)
+				}
+				// other error dont retry and fail
+				taskErr = err
+			}
+			return nil
+		})
+
+		if retryErr != nil {
+			return serverNetworkingDetails, "", retryErr
+		}
+
+		if taskErr != nil {
+			return serverNetworkingDetails, "", taskErr
+		}
+
+		log.Printf("[INFO] Networking parameter for %s: %s", serviceName, serverNetworkingDetails.Status)
+		return serverNetworkingDetails, serverNetworkingDetails.Status, nil
+	}
+
+	log.Printf("[INFO] Waiting for networking details to be applied for %s", serviceName)
+
+	stateConf := &resource.StateChangeConf{
+		Pending:    []string{"deploying"},
+		Target:     []string{"active"},
+		Refresh:    refreshFunc,
+		Timeout:    45 * time.Minute,
+		Delay:      10 * time.Second,
+		MinTimeout: 3 * time.Second,
+	}
+
+	if _, err := stateConf.WaitForState(); err != nil {
+		return fmt.Errorf("Error waiting for Dedicated Server networking task for %s to complete: %s", serviceName, err)
+	}
+
+	return nil
+}
+
+func getDedicatedServerNetworkingDetails(serviceName string, c *ovh.Client) (*DedicatedServerNetworking, error) {
+	serverNetworkingDetails := &DedicatedServerNetworking{}
+	endpoint := fmt.Sprintf(
+		"/dedicated/server/%s/networking",
+		url.PathEscape(serviceName),
+	)
+
+	if err := c.Get(endpoint, serverNetworkingDetails); err != nil {
+		return nil, err
+	}
+
+	return serverNetworkingDetails, nil
+}

--- a/ovh/resource_dedicated_server_networking_test.go
+++ b/ovh/resource_dedicated_server_networking_test.go
@@ -1,0 +1,94 @@
+package ovh
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccresourceDedicatedServerNetworking(t *testing.T) {
+	confTemplates := []string{
+		testAccDedicatedServerNetworkingPublicVrack,
+		testAccDedicatedServerNetworkingSingleVrack,
+		testAccDedicatedServerNetworkingDualVrack,
+	}
+
+	for _, confTemplate := range confTemplates {
+		resource.Test(t, resource.TestCase{
+			PreCheck: func() {
+				testAccPreCheckCredentials(t)
+				testAccPreCheckDedicatedServer(t)
+			},
+			Providers: testAccProviders,
+			Steps: []resource.TestStep{
+				{
+					Config: testAccDedicatedServerNetworkingConfig(confTemplate),
+					Check: resource.ComposeTestCheckFunc(
+						resource.TestCheckResourceAttr(
+							"ovh_dedicated_server_networking.server", "status", "active"),
+					),
+				},
+			},
+		})
+	}
+}
+
+func testAccDedicatedServerNetworkingConfig(confTemplate string) string {
+	dedicated_server := os.Getenv("OVH_DEDICATED_SERVER")
+	renderedConfig := fmt.Sprintf(
+		confTemplate,
+		dedicated_server,
+	)
+	return renderedConfig
+}
+
+const testAccDedicatedServerNetworkingPublicVrack = `
+data "ovh_dedicated_server" "server" {
+  service_name = "%s"
+}
+
+resource "ovh_dedicated_server_networking" "server" {
+  service_name = data.ovh_dedicated_server.server.service_name
+  interfaces {
+    macs = slice(sort(flatten(data.ovh_dedicated_server.server.vnis.*.nics)), 0, 2)
+    type = "public"
+  }
+  interfaces {
+    macs = slice(sort(flatten(data.ovh_dedicated_server.server.vnis.*.nics)), 2, 4)
+    type = "vrack"
+  }
+}
+`
+
+const testAccDedicatedServerNetworkingSingleVrack = `
+data "ovh_dedicated_server" "server" {
+  service_name = "%s"
+}
+
+resource "ovh_dedicated_server_networking" "server" {
+  service_name = data.ovh_dedicated_server.server.service_name
+  interfaces {
+    macs = flatten(data.ovh_dedicated_server.server.vnis.*.nics)
+    type = "vrack"
+  }
+}
+`
+
+const testAccDedicatedServerNetworkingDualVrack = `
+data "ovh_dedicated_server" "server" {
+  service_name = "%s"
+}
+resource "ovh_dedicated_server_networking" "server" {
+  service_name = data.ovh_dedicated_server.server.service_name
+  interfaces {
+    macs = slice(sort(flatten(data.ovh_dedicated_server.server.vnis.*.nics)), 0, 2)
+    type = "vrack"
+  }
+  interfaces {
+    macs = slice(sort(flatten(data.ovh_dedicated_server.server.vnis.*.nics)), 2, 4)
+    type = "vrack"
+  }
+}
+`

--- a/ovh/types_dedicated_server_networking.go
+++ b/ovh/types_dedicated_server_networking.go
@@ -1,0 +1,62 @@
+package ovh
+
+import (
+	"fmt"
+	"sort"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+type DedicatedServerNetworking struct {
+	Status      string                               `json:"status"`
+	Description string                               `json:"description"`
+	Interfaces  []DedicatedServerNetworkingInterface `json:"interfaces"`
+}
+
+type DedicatedServerNetworkingInterface struct {
+	Macs []string `json:"macs"`
+	Type string   `json:"type"`
+}
+
+type DedicatedServerNetworkingCreateOpts struct {
+	Interfaces []DedicatedServerNetworkingInterface `json:"interfaces"`
+}
+
+type DedicatedServerNetworkingResponse struct {
+	Status string
+}
+
+func (opts *DedicatedServerNetworkingCreateOpts) FromResource(d *schema.ResourceData) *DedicatedServerNetworkingCreateOpts {
+	rawNetworkInterfaces := d.Get("interfaces").(*schema.Set).List()
+
+	opts.Interfaces = make([]DedicatedServerNetworkingInterface, len(rawNetworkInterfaces))
+
+	for i, rawNetworkInterface := range rawNetworkInterfaces {
+		var networkingInterface DedicatedServerNetworkingInterface
+		data := rawNetworkInterface.(map[string]interface{})
+
+		if raw, ok := data["macs"]; ok {
+			rawMacs := raw.(*schema.Set).List()
+			networkingInterface.Macs = make([]string, len(rawMacs))
+			for i, mac := range rawMacs {
+				networkingInterface.Macs[i] = fmt.Sprint(mac)
+			}
+
+			// we want the MACs associated to an interface to be in a determist order to avoid false positive diff
+			sort.Strings(networkingInterface.Macs)
+		}
+
+		if raw, ok := data["type"]; ok {
+			networkingInterface.Type = raw.(string)
+		}
+
+		opts.Interfaces[i] = networkingInterface
+	}
+
+	// we want interfaces to be in a determist order to avoid false positive diff
+	sort.SliceStable(opts.Interfaces, func(i, j int) bool {
+		return opts.Interfaces[i].Type < opts.Interfaces[j].Type
+	})
+
+	return opts
+}

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -153,6 +153,8 @@ variables must also be set:
 
 * `OVH_CLOUD_PROJECT_KUBE_VERSION_TEST` - The version of your public cloud kubernetes project.
 
+* `OVH_DEDICATED_SERVER` - The name of the dedicated server to test dedicated_server_networking resource.
+
 * `OVH_NASHA_SERVICE_TEST` - The name of your HA-NAS service.
 
 * `OVH_ZONE_TEST` - The domain you own to test the domain_zone resource.

--- a/website/docs/r/ovh_dedicated_server_networking.html.markdown
+++ b/website/docs/r/ovh_dedicated_server_networking.html.markdown
@@ -1,0 +1,88 @@
+---
+layout: "ovh"
+page_title: "OVH: ovh_dedicated_server_networking"
+sidebar_current: "docs-ovh-resource-ovh-dedicated-server-networking"
+description: |-
+  Manage dedicated server networking interface
+---
+
+# ovh_dedicated_server_networking
+
+Manage dedicated server networking interface on SCALE and HIGH-GRADE range.
+
+## Example Usage
+
+The following example aims to bind all interfaces in a vRack
+
+```hcl
+locals {
+  dedicated_server = "nsXXXXXX.ip-XX-XXX-XX.eu"
+}
+
+data "ovh_dedicated_server" "server" {
+  service_name = local.dedicated_server
+}
+
+resource "ovh_dedicated_server_networking" "server"{
+  service_name = local.dedicated_server
+  interfaces {
+      macs = sort(flatten(data.ovh_dedicated_server.server.vnis.*.nics)),
+      type = "vrack"
+  }
+} 
+```
+
+The following example aims to attach the server to two different vRack.
+
+```hcl
+locals {
+  dedicated_server = "nsXXXXXX.ip-XX-XXX-XX.eu"
+}
+
+data "ovh_dedicated_server" "server" {
+  service_name = local.dedicated_server
+}
+
+resource "ovh_dedicated_server_networking" "server"{
+  service_name = local.dedicated_server
+  # Bond the two first interfaces in the first vrack
+  interfaces {
+      macs = slice(sort(flatten(data.ovh_dedicated_server.server.vnis.*.nics)), 0, 2)
+      type = "vrack"
+  }
+  # Bond the two last interfaces in the last vrack
+  interfaces {
+      macs = slice(sort(flatten(data.ovh_dedicated_server.server.vnis.*.nics)), 2, 4)
+      type = "vrack"
+  }
+} 
+```
+
+## Arguments Reference
+
+The following arguments are required:
+
+* `service_name` - (String) The service_name of your dedicated server. The full list of available dedicated servers can be found using the `ovh_dedicated_servers` datasource.
+* `interfaces` - (Block List, Min: 1, Max: 2) Interface or interfaces aggregation.
+
+### Nested Schema for interfaces
+
+Required:
+
+* `macs` (List of String) List of mac addresses to bind together.
+* `type` (String) Type of bonding to create.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `description` - Operation description.
+* `status` - status of the networking configuration (should be `active`).
+
+## Import
+
+A dedicated server networking configuration can be imported using the `service_name`.
+
+```bash
+$ terraform import ovh_dedicated_server_networking.server service_name
+```


### PR DESCRIPTION
Tested with my account
```
❯ make testacc TESTARGS="-run TestAccresourceDedicatedServerNetworking"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -run TestAccresourceDedicatedServerNetworking -timeout 240m
?       github.com/ovh/terraform-provider-ovh   [no test files]
=== RUN   TestAccresourceDedicatedServerNetworking
--- PASS: TestAccresourceDedicatedServerNetworking (3468.55s)
PASS
ok      github.com/ovh/terraform-provider-ovh/ovh       3468.986s
?       github.com/ovh/terraform-provider-ovh/ovh/helpers       [no test files]
testing: warning: no tests to run
PASS
ok      github.com/ovh/terraform-provider-ovh/ovh/helpers/hashcode      (cached) [no tests to run]
```