### PR TITLE
Add support for HTTP header on resource_iploadbalancing_http_frontend

### DIFF
--- a/ovh/resource_iploadbalancing_http_frontend.go
+++ b/ovh/resource_iploadbalancing_http_frontend.go
@@ -44,6 +44,11 @@ func resourceIpLoadbalancingHttpFrontend() *schema.Resource {
 				Optional: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
+			"http_header": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
 			"default_farm_id": {
 				Type:     schema.TypeInt,
 				Optional: true,
@@ -101,6 +106,7 @@ func resourceIpLoadbalancingHttpFrontendCreate(d *schema.ResourceData, meta inte
 
 	allowedSources, _ := helpers.StringsFromSchema(d, "allowed_source")
 	dedicatedIpFo, _ := helpers.StringsFromSchema(d, "dedicated_ipfo")
+	httpHeader, _ := helpers.StringsFromSchema(d, "http_header")
 
 	for _, s := range allowedSources {
 		if err := helpers.ValidateIpBlock(s); err != nil {
@@ -123,6 +129,7 @@ func resourceIpLoadbalancingHttpFrontendCreate(d *schema.ResourceData, meta inte
 		Ssl:              d.Get("ssl").(bool),
 		RedirectLocation: d.Get("redirect_location").(string),
 		DisplayName:      d.Get("display_name").(string),
+		HttpHeader:       httpHeader,
 	}
 
 	frontend.DefaultFarmId = helpers.GetNilIntPointerFromData(d, "default_farm_id")
@@ -160,6 +167,9 @@ func resourceIpLoadbalancingHttpFrontendRead(d *schema.ResourceData, meta interf
 	dedicatedIpFos := make([]string, 0)
 	dedicatedIpFos = append(dedicatedIpFos, r.DedicatedIpFo...)
 
+	httpHeader := make([]string, 0)
+	httpHeader = append(httpHeader, r.HttpHeader...)
+
 	d.Set("allowed_source", allowedSources)
 	d.Set("dedicated_ipfo", dedicatedIpFos)
 	d.Set("default_farm_id", r.DefaultFarmId)
@@ -170,6 +180,7 @@ func resourceIpLoadbalancingHttpFrontendRead(d *schema.ResourceData, meta interf
 	d.Set("ssl", r.Ssl)
 	d.Set("zone", r.Zone)
 	d.Set("redirect_location", r.RedirectLocation)
+	d.Set("http_header", httpHeader)
 
 	return nil
 }
@@ -181,6 +192,7 @@ func resourceIpLoadbalancingHttpFrontendUpdate(d *schema.ResourceData, meta inte
 
 	allowedSources, _ := helpers.StringsFromSchema(d, "allowed_source")
 	dedicatedIpFo, _ := helpers.StringsFromSchema(d, "dedicated_ipfo")
+	httpHeader, _ := helpers.StringsFromSchema(d, "http_header")
 
 	for _, s := range allowedSources {
 		if err := helpers.ValidateIpBlock(s); err != nil {
@@ -203,6 +215,7 @@ func resourceIpLoadbalancingHttpFrontendUpdate(d *schema.ResourceData, meta inte
 		Ssl:              d.Get("ssl").(bool),
 		RedirectLocation: d.Get("redirect_location").(string),
 		DisplayName:      d.Get("display_name").(string),
+		HttpHeader:       httpHeader,
 	}
 
 	frontend.DefaultFarmId = helpers.GetNilIntPointerFromData(d, "default_farm_id")

--- a/ovh/resource_iploadbalancing_http_frontend_test.go
+++ b/ovh/resource_iploadbalancing_http_frontend_test.go
@@ -159,6 +159,7 @@ resource "ovh_iploadbalancing_http_frontend" "testfrontend" {
    zone           = "all"
    port           = "22280,22443"
    allowed_source = ["8.8.8.8/32"]
+   http_header    = ["X-Ip-Header %%ci", "X-Port-Header %%cp"]
 }
 `
 

--- a/ovh/types_iploadbalancing.go
+++ b/ovh/types_iploadbalancing.go
@@ -514,6 +514,7 @@ type IpLoadbalancingHttpFrontend struct {
 	Ssl              bool     `json:"ssl"`
 	RedirectLocation string   `json:"redirectLocation,omitempty"`
 	DisplayName      string   `json:"displayName,omitempty"`
+	HttpHeader       []string `json:"httpHeader"`
 }
 
 type IpLoadbalancingFarmServerCreateOpts struct {

--- a/website/docs/r/iploadbalancing_http_frontend.html.markdown
+++ b/website/docs/r/iploadbalancing_http_frontend.html.markdown
@@ -34,6 +34,31 @@ resource "ovh_iploadbalancing_http_frontend" "testfrontend" {
 }
 ```
 
+## Example Usage with HTTP header
+
+```
+data "ovh_iploadbalancing" "lb" {
+  service_name = "ip-1.2.3.4"
+  state        = "ok"
+}
+
+resource "ovh_iploadbalancing_http_farm" "farm80" {
+  service_name = "${data.ovh_iploadbalancing.lb.service_name}"
+  display_name = "ingress-8080-gra"
+  zone         = "all"
+  port         = 80
+}
+
+resource "ovh_iploadbalancing_http_frontend" "testfrontend" {
+  service_name    = "${data.ovh_iploadbalancing.lb.service_name}"
+  display_name    = "ingress-8080-gra"
+  zone            = "all"
+  port            = "80,443"
+  default_farm_id = "${ovh_iploadbalancing_http_farm.farm80.id}"
+  http_header     = ["X-Ip-Header %%ci", "X-Port-Header %%cp"]
+}
+```
+
 ## Argument Reference
 
 The following arguments are supported:
@@ -51,12 +76,17 @@ The following arguments are supported:
 * `disabled` - Disable your frontend. Default: 'false'
 * `ssl` - SSL deciphering. Default: 'false'
 * `redirect_location` - Redirection HTTP'
+* `http_header` - HTTP headers to add to the frontend. List of string.
 
 ## Attributes Reference
 
 The following attributes are exported:
 
 * `id` - Id of your frontend
+* `service_name` - See Argument Reference above.
+* `port` - See Argument Reference above.
+* `zone` - See Argument Reference above.
+* `http_header` - See Argument Reference above.
 * `display_name` - See Argument Reference above.
 * `allowed_source` - See Argument Reference above.
 * `dedicated_ipfo` - See Argument Reference above.


### PR DESCRIPTION
This commit adds support for `httpHeader` attribute when manipulating http frontend.

See: https://docs.ovh.com/fr/load-balancer/http-headers