### PR TITLE
fix(dbaas-logs): input tests

### DIFF
--- a/ovh/data_dbaas_logs_input_engine_test.go
+++ b/ovh/data_dbaas_logs_input_engine_test.go
@@ -28,7 +28,8 @@ data "ovh_dbaas_logs_input_engine" "logstash" {
 func TestAccDataSourceDbaasLogsInputEngine_basic(t *testing.T) {
 	serviceName := os.Getenv("OVH_DBAAS_LOGS_SERVICE_TEST")
 	name := "LOGSTASH"
-	version := "7.x"
+	// version := "7.x"
+	version := os.Getenv("OVH_DBAAS_LOGS_LOGSTASH_VERSION_TEST")
 
 	config := fmt.Sprintf(
 		testAccDataSourceDbaasLogsInputEngine_basic,
@@ -38,7 +39,7 @@ func TestAccDataSourceDbaasLogsInputEngine_basic(t *testing.T) {
 	)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck: func() { testAccPreCheckDbaasLogs(t) },
+		PreCheck: func() { testAccPreCheckDbaasLogsInput(t) },
 
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
@@ -53,7 +54,7 @@ func TestAccDataSourceDbaasLogsInputEngine_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"data.ovh_dbaas_logs_input_engine.logstash",
 						"version",
-						"7.x",
+						version,
 					),
 				),
 			},

--- a/ovh/provider_test.go
+++ b/ovh/provider_test.go
@@ -168,6 +168,12 @@ func testAccPreCheckDbaasLogs(t *testing.T) {
 	checkEnvOrSkip(t, "OVH_DBAAS_LOGS_SERVICE_TEST")
 }
 
+func testAccPreCheckDbaasLogsInput(t *testing.T) {
+	testAccPreCheckCredentials(t)
+	checkEnvOrSkip(t, "OVH_DBAAS_LOGS_SERVICE_TEST")
+	checkEnvOrSkip(t, "OVH_DBAAS_LOGS_LOGSTASH_VERSION_TEST")
+}
+
 // Checks that the environment variables needed for the /cloud acceptance tests
 // are set.
 func testAccPreCheckCloud(t *testing.T) {

--- a/ovh/resource_dbaas_logs_input_test.go
+++ b/ovh/resource_dbaas_logs_input_test.go
@@ -154,7 +154,7 @@ func testSweepDbaasInput(region string) error {
 func TestAccResourceDbaasLogsInput_basic(t *testing.T) {
 	serviceName := os.Getenv("OVH_DBAAS_LOGS_SERVICE_TEST")
 	name := "LOGSTASH"
-	version := "7.x"
+	version := os.Getenv("OVH_DBAAS_LOGS_LOGSTASH_VERSION_TEST")
 	title := acctest.RandomWithPrefix(test_prefix)
 	desc := acctest.RandomWithPrefix(test_prefix)
 
@@ -169,7 +169,7 @@ func TestAccResourceDbaasLogsInput_basic(t *testing.T) {
 	)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck: func() { testAccPreCheckDbaasLogs(t) },
+		PreCheck: func() { testAccPreCheckDbaasLogsInput(t) },
 
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{

--- a/ovh/resource_dbaas_logs_input_test.go
+++ b/ovh/resource_dbaas_logs_input_test.go
@@ -14,9 +14,10 @@ import (
 )
 
 const testAccResourceDbaasLogsInput_basic = `
-data "ovh_dbaas_logs_input_engine" "logstash" {
- name          = "logstash"
- version       = "7.x"
+data "ovh_dbaas_logs_input_engine" "logstash" {	
+	service_name  = "%s"
+	name          = "%s"
+	version       = "%s"
 }
 
 resource "ovh_dbaas_logs_output_graylog_stream" "stream" {
@@ -152,11 +153,16 @@ func testSweepDbaasInput(region string) error {
 
 func TestAccResourceDbaasLogsInput_basic(t *testing.T) {
 	serviceName := os.Getenv("OVH_DBAAS_LOGS_SERVICE_TEST")
+	name := "LOGSTASH"
+	version := "7.x"
 	title := acctest.RandomWithPrefix(test_prefix)
 	desc := acctest.RandomWithPrefix(test_prefix)
 
 	config := fmt.Sprintf(
 		testAccResourceDbaasLogsInput_basic,
+		serviceName,
+		name,
+		version,
 		serviceName,
 		title,
 		desc,

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -163,6 +163,8 @@ variables must also be set:
 
 * `OVH_DBAAS_LOGS_SERVICE_TEST` - The name of your Dbaas logs service.
 
+* `OVH_DBAAS_LOGS_LOGSTASH_VERSION_TEST` - The name of your Dbaas logs Logstash version.
+
 * `OVH_TESTACC_ORDER_VRACK` - set this variable to "yes" will order vracks.
 
 * `OVH_TESTACC_ORDER_CLOUDPROJECT` - set this variable to "yes" will order cloud projects.


### PR DESCRIPTION
ref: #OB-4901

Hello,

This PR fix a missing parameter (serviceName) on tests to handle the new endpoint as described here: https://github.com/ovh/terraform-provider-ovh/pull/347

As always, thanks for your time on this.

Signed-off-by: Pierre De Paepe <pierre.de-paepe@ovhcloud.com>