### PR TITLE
feat(loadbalancing): add on-marked-down attribute to (http|tcp)-servers

### DIFF
--- a/ovh/resource_iploadbalancing_http_farm_server.go
+++ b/ovh/resource_iploadbalancing_http_farm_server.go
@@ -71,6 +71,19 @@ func resourceIpLoadbalancingHttpFarmServer() *schema.Resource {
 					return
 				},
 			},
+			"on_marked_down": {
+				Type:     schema.TypeString,
+				Optional: true,
+				// There is only one valid value for now, keep string enum
+				// to be able to add a new value easily.
+				ValidateFunc: func(v interface{}, k string) (ws []string, errors []error) {
+					err := helpers.ValidateStringEnum(v.(string), []string{"shutdown-sessions"})
+					if err != nil {
+						errors = append(errors, err)
+					}
+					return
+				},
+			},
 			"chain": {
 				Type:     schema.TypeString,
 				Optional: true,
@@ -135,6 +148,7 @@ func resourceIpLoadbalancingHttpFarmServerCreate(d *schema.ResourceData, meta in
 		Address:              d.Get("address").(string),
 		Port:                 helpers.GetNilIntPointerFromData(d, "port"),
 		ProxyProtocolVersion: helpers.GetNilStringPointerFromData(d, "proxy_protocol_version"),
+		OnMarkedDown:         helpers.GetNilStringPointerFromData(d, "on_marked_down"),
 		Chain:                helpers.GetNilStringPointerFromData(d, "chain"),
 		Weight:               helpers.GetNilIntPointerFromData(d, "weight"),
 		Probe:                helpers.GetNilBoolPointerFromData(d, "probe"),
@@ -188,6 +202,7 @@ func resourceIpLoadbalancingHttpFarmServerUpdate(d *schema.ResourceData, meta in
 		Address:              helpers.GetNilStringPointerFromData(d, "address"),
 		Port:                 helpers.GetNilIntPointerFromData(d, "port"),
 		ProxyProtocolVersion: helpers.GetNilStringPointerFromData(d, "proxy_protocol_version"),
+		OnMarkedDown:         helpers.GetNilStringPointerFromData(d, "on_marked_down"),
 		Chain:                helpers.GetNilStringPointerFromData(d, "chain"),
 		Weight:               helpers.GetNilIntPointerFromData(d, "weight"),
 		Probe:                helpers.GetNilBoolPointerFromData(d, "probe"),

--- a/ovh/resource_iploadbalancing_http_farm_server_test.go
+++ b/ovh/resource_iploadbalancing_http_farm_server_test.go
@@ -131,6 +131,21 @@ resource ovh_iploadbalancing_http_farm_server testacc {
   backup = true
 }
 `
+	testAccIpLoadbalancingHttpFarmServerConfig_step7 = `
+%s
+
+resource ovh_iploadbalancing_http_farm_server testacc {
+  service_name     = data.ovh_iploadbalancing.iplb.id
+  farm_id = ovh_iploadbalancing_http_farm.testacc.id
+  address = "10.0.0.11"
+  status = "active"
+  display_name = "testBackendB"
+  port = 8080
+  ssl = true
+  backup = true
+  on_marked_down = "shutdown-sessions"
+}
+`
 )
 
 func init() {
@@ -288,6 +303,18 @@ func TestAccIpLoadbalancingHttpFarmServerBasic(t *testing.T) {
 					resource.TestCheckResourceAttr("ovh_iploadbalancing_http_farm_server.testacc", "weight", "1"),
 					resource.TestCheckResourceAttr("ovh_iploadbalancing_http_farm_server.testacc", "ssl", "true"),
 					resource.TestCheckResourceAttr("ovh_iploadbalancing_http_farm_server.testacc", "backup", "true"),
+				),
+			},
+			{
+				Config: fmt.Sprintf(testAccIpLoadbalancingHttpFarmServerConfig_step7, prefix),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("ovh_iploadbalancing_http_farm_server.testacc", "address", "10.0.0.11"),
+					resource.TestCheckResourceAttr("ovh_iploadbalancing_http_farm_server.testacc", "status", "active"),
+					resource.TestCheckResourceAttr("ovh_iploadbalancing_http_farm_server.testacc", "port", "8080"),
+					resource.TestCheckResourceAttr("ovh_iploadbalancing_http_farm_server.testacc", "weight", "1"),
+					resource.TestCheckResourceAttr("ovh_iploadbalancing_http_farm_server.testacc", "ssl", "true"),
+					resource.TestCheckResourceAttr("ovh_iploadbalancing_http_farm_server.testacc", "backup", "true"),
+					resource.TestCheckResourceAttr("ovh_iploadbalancing_http_farm_server.testacc", "on_marked_down", "shutdown-sessions"),
 				),
 			},
 		},

--- a/ovh/resource_iploadbalancing_tcp_farm_server.go
+++ b/ovh/resource_iploadbalancing_tcp_farm_server.go
@@ -67,6 +67,19 @@ func resourceIpLoadbalancingTcpFarmServer() *schema.Resource {
 					return
 				},
 			},
+			"on_marked_down": {
+				Type:     schema.TypeString,
+				Optional: true,
+				// There is only one valid value for now, keep string enum
+				// to be able to add a new value easily.
+				ValidateFunc: func(v interface{}, k string) (ws []string, errors []error) {
+					err := helpers.ValidateStringEnum(v.(string), []string{"shutdown-sessions"})
+					if err != nil {
+						errors = append(errors, err)
+					}
+					return
+				},
+			},
 			"chain": {
 				Type:     schema.TypeString,
 				Optional: true,
@@ -131,6 +144,7 @@ func resourceIpLoadbalancingTcpFarmServerCreate(d *schema.ResourceData, meta int
 		Address:              d.Get("address").(string),
 		Port:                 helpers.GetNilIntPointerFromData(d, "port"),
 		ProxyProtocolVersion: helpers.GetNilStringPointerFromData(d, "proxy_protocol_version"),
+		OnMarkedDown:         helpers.GetNilStringPointerFromData(d, "on_marked_down"),
 		Chain:                helpers.GetNilStringPointerFromData(d, "chain"),
 		Weight:               helpers.GetNilIntPointerFromData(d, "weight"),
 		Probe:                helpers.GetNilBoolPointerFromData(d, "probe"),
@@ -184,6 +198,7 @@ func resourceIpLoadbalancingTcpFarmServerUpdate(d *schema.ResourceData, meta int
 		Address:              helpers.GetNilStringPointerFromData(d, "address"),
 		Port:                 helpers.GetNilIntPointerFromData(d, "port"),
 		ProxyProtocolVersion: helpers.GetNilStringPointerFromData(d, "proxy_protocol_version"),
+		OnMarkedDown:         helpers.GetNilStringPointerFromData(d, "on_marked_down"),
 		Chain:                helpers.GetNilStringPointerFromData(d, "chain"),
 		Weight:               helpers.GetNilIntPointerFromData(d, "weight"),
 		Probe:                helpers.GetNilBoolPointerFromData(d, "probe"),

--- a/ovh/resource_iploadbalancing_tcp_farm_server_test.go
+++ b/ovh/resource_iploadbalancing_tcp_farm_server_test.go
@@ -131,6 +131,21 @@ resource ovh_iploadbalancing_tcp_farm_server testacc {
   backup = true
 }
 `
+	testAccIpLoadbalancingTcpFarmServerConfig_step7 = `
+%s
+
+resource ovh_iploadbalancing_tcp_farm_server testacc {
+  service_name     = data.ovh_iploadbalancing.iplb.id
+  farm_id = ovh_iploadbalancing_tcp_farm.testacc.id
+  address = "10.0.0.11"
+  status = "active"
+  display_name = "testBackendB"
+  port = 8080
+  ssl = true
+  backup = true
+  on_marked_down = "shutdown-sessions"
+}
+`
 )
 
 func init() {
@@ -288,6 +303,18 @@ func TestAccIpLoadbalancingTcpFarmServerBasic(t *testing.T) {
 					resource.TestCheckResourceAttr("ovh_iploadbalancing_tcp_farm_server.testacc", "weight", "1"),
 					resource.TestCheckResourceAttr("ovh_iploadbalancing_tcp_farm_server.testacc", "ssl", "true"),
 					resource.TestCheckResourceAttr("ovh_iploadbalancing_tcp_farm_server.testacc", "backup", "true"),
+				),
+			},
+			{
+				Config: fmt.Sprintf(testAccIpLoadbalancingTcpFarmServerConfig_step7, prefix),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("ovh_iploadbalancing_tcp_farm_server.testacc", "address", "10.0.0.11"),
+					resource.TestCheckResourceAttr("ovh_iploadbalancing_tcp_farm_server.testacc", "status", "active"),
+					resource.TestCheckResourceAttr("ovh_iploadbalancing_tcp_farm_server.testacc", "port", "8080"),
+					resource.TestCheckResourceAttr("ovh_iploadbalancing_tcp_farm_server.testacc", "weight", "1"),
+					resource.TestCheckResourceAttr("ovh_iploadbalancing_tcp_farm_server.testacc", "ssl", "true"),
+					resource.TestCheckResourceAttr("ovh_iploadbalancing_tcp_farm_server.testacc", "backup", "true"),
+					resource.TestCheckResourceAttr("ovh_iploadbalancing_tcp_farm_server.testacc", "on_marked_down", "shutdown-sessions"),
 				),
 			},
 		},

--- a/ovh/types_iploadbalancing.go
+++ b/ovh/types_iploadbalancing.go
@@ -526,6 +526,7 @@ type IpLoadbalancingFarmServerCreateOpts struct {
 	Port                 *int    `json:"port,omitempty"`
 	Probe                *bool   `json:"probe"`
 	ProxyProtocolVersion *string `json:"proxyProtocolVersion,omitempty"`
+	OnMarkedDown         *string `json:"onMarkedDown"`
 	Ssl                  *bool   `json:"ssl"`
 	Status               string  `json:"status"`
 	Weight               *int    `json:"weight,omitempty"`
@@ -540,6 +541,7 @@ type IpLoadbalancingFarmServerUpdateOpts struct {
 	Port                 *int    `json:"port,omitempty"`
 	Probe                *bool   `json:"probe"`
 	ProxyProtocolVersion *string `json:"proxyProtocolVersion"`
+	OnMarkedDown         *string `json:"onMarkedDown"`
 	Ssl                  *bool   `json:"ssl"`
 	Status               *string `json:"status"`
 	Weight               *int    `json:"weight,omitempty"`
@@ -555,6 +557,7 @@ type IpLoadbalancingFarmServer struct {
 	Port                 *int    `json:"port"`
 	Probe                *bool   `json:"probe"`
 	ProxyProtocolVersion *string `json:"proxyProtocolVersion"`
+	OnMarkedDown         *string `json:"onMarkedDown"`
 	ServerId             int     `json:"serverId"`
 	Ssl                  *bool   `json:"ssl"`
 	Status               string  `json:"status"`
@@ -589,6 +592,10 @@ func (v IpLoadbalancingFarmServer) ToMap() map[string]interface{} {
 
 	if v.ProxyProtocolVersion != nil {
 		obj["proxy_protocol_version"] = *v.ProxyProtocolVersion
+	}
+
+	if v.OnMarkedDown != nil {
+		obj["on_marked_down"] = *v.OnMarkedDown
 	}
 
 	if v.Weight != nil {

--- a/website/docs/r/iploadbalancing_http_farm_server.html.markdown
+++ b/website/docs/r/iploadbalancing_http_farm_server.html.markdown
@@ -50,6 +50,7 @@ The following arguments are supported:
 * `status` - backend status - `active` or `inactive`
 * `port` - Port that backend will respond on
 * `proxy_protocol_version` - version of the PROXY protocol used to pass origin connection information from loadbalancer to receiving service (`v1`, `v2`, `v2-ssl`, `v2-ssl-cn`)
+* `on_marked_down` - enable action when backend marked down. (`shutdown-sessions`)
 * `weight` - used in loadbalancing algorithm
 * `probe` - defines if backend will be probed to determine health and keep as active in farm if healthy
 * `ssl` - is the connection ciphered with SSL (TLS)
@@ -66,6 +67,7 @@ The following attributes are exported:
 * `status` - See Argument Reference above.
 * `port` - See Argument Reference above.
 * `proxy_protocol_version` - See Argument Reference above.
+* `on_marked_down` - See Argument Reference above.
 * `weight` - See Argument Reference above.
 * `probe` - See Argument Reference above.
 * `ssl` - See Argument Reference above.

--- a/website/docs/r/iploadbalancing_tcp_farm_server.html.markdown
+++ b/website/docs/r/iploadbalancing_tcp_farm_server.html.markdown
@@ -50,6 +50,7 @@ The following arguments are supported:
 * `status` - backend status - `active` or `inactive`
 * `port` - Port that backend will respond on
 * `proxy_protocol_version` - version of the PROXY protocol used to pass origin connection information from loadbalancer to receiving service (`v1`, `v2`, `v2-ssl`, `v2-ssl-cn`)
+* `on_marked_down` - enable action when backend marked down. (`shutdown-sessions`)
 * `weight` - used in loadbalancing algorithm
 * `probe` - defines if backend will be probed to determine health and keep as active in farm if healthy
 * `ssl` - is the connection ciphered with SSL (TLS)
@@ -66,6 +67,7 @@ The following attributes are exported:
 * `status` - See Argument Reference above.
 * `port` - See Argument Reference above.
 * `proxy_protocol_version` - See Argument Reference above.
+* `on_marked_down` - See Argument Reference above.
 * `weight` - See Argument Reference above.
 * `probe` - See Argument Reference above.
 * `ssl` - See Argument Reference above.


### PR DESCRIPTION
Hello! This PR adds a missing attributes on loadbalancer's (tcp-http)-servers. 
You can find servers accepted payload here:
- https://api.ovh.com/console/#/ipLoadbalancing/%7BserviceName%7D/tcp/farm/%7BfarmId%7D/server~POST
- https://api.ovh.com/console/#/ipLoadbalancing/%7BserviceName%7D/http/farm/%7BfarmId%7D/server~POST

Signed-off-by: tanguy.desreumaux <tanguy.desreumaux@ovhcloud.com>