### PR TITLE
feat(kube): Let user configure kube proxy

### DIFF
--- a/ovh/data_cloud_project_kube.go
+++ b/ovh/data_cloud_project_kube.go
@@ -92,8 +92,7 @@ func dataSourceCloudProjectKube() *schema.Resource {
 							Optional: true,
 							ForceNew: false,
 							MaxItems: 1,
-							Set:      CustomIPtablesSchemaSetFunc(false),
-
+							Set:      CustomIPVSIPTablesSchemaSetFunc(),
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
 									"min_sync_period": {
@@ -117,7 +116,7 @@ func dataSourceCloudProjectKube() *schema.Resource {
 							Optional: true,
 							ForceNew: false,
 							MaxItems: 1,
-							Set:      CustomIPVSSchemaSetFunc(true),
+							Set:      CustomIPVSIPTablesSchemaSetFunc(),
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
 									"min_sync_period": {

--- a/ovh/data_cloud_project_kube.go
+++ b/ovh/data_cloud_project_kube.go
@@ -76,7 +76,55 @@ func dataSourceCloudProjectKube() *schema.Resource {
 					},
 				},
 			},
-
+			kubeClusterCustomization: {
+				Type:       schema.TypeSet,
+				Computed:   true,
+				Optional:   true,
+				ForceNew:   false,
+				Set:        CustomSchemaSetFunc(),
+				Deprecated: fmt.Sprintf("Use %s instead", kubeClusterCustomizationApiServerKey),
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"apiserver": {
+							Type:       schema.TypeSet,
+							Computed:   true,
+							Optional:   true,
+							ForceNew:   false,
+							Set:        CustomSchemaSetFunc(),
+							Deprecated: fmt.Sprintf("Use %s instead", kubeClusterCustomizationApiServerKey),
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"admissionplugins": {
+										Type:     schema.TypeSet,
+										Computed: true,
+										Optional: true,
+										ForceNew: false,
+										Set:      CustomSchemaSetFunc(),
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"enabled": {
+													Type:     schema.TypeList,
+													Computed: true,
+													Optional: true,
+													ForceNew: false,
+													Elem:     &schema.Schema{Type: schema.TypeString},
+												},
+												"disabled": {
+													Type:     schema.TypeList,
+													Computed: true,
+													Optional: true,
+													ForceNew: false,
+													Elem:     &schema.Schema{Type: schema.TypeString},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
 			kubeClusterCustomizationKubeProxyKey: {
 				Type:     schema.TypeSet,
 				Computed: false,

--- a/ovh/data_cloud_project_kube.go
+++ b/ovh/data_cloud_project_kube.go
@@ -29,46 +29,46 @@ func dataSourceCloudProjectKube() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 			},
-			kubeClusterCustomizationKey: {
+			kubeClusterProxyModeKey: {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+			kubeClusterCustomizationApiServerKey: {
 				Type:     schema.TypeSet,
 				Computed: true,
 				Optional: true,
+				// Required: true,
 				ForceNew: false,
-				MaxItems: 1,
+				// MaxItems: 1,
+				Set: CustomSchemaSetFunc(false),
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
-						"apiserver": {
+						"admissionplugins": {
 							Type:     schema.TypeSet,
 							Computed: true,
 							Optional: true,
+							// Required: true,
 							ForceNew: false,
-							MaxItems: 1,
+							// MaxItems: 1,
+							Set: CustomSchemaSetFunc(false),
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
-									"admissionplugins": {
-										Type:     schema.TypeSet,
+									"enabled": {
+										Type:     schema.TypeList,
 										Computed: true,
 										Optional: true,
+										// Required: true,
 										ForceNew: false,
-										MaxItems: 1,
-										Elem: &schema.Resource{
-											Schema: map[string]*schema.Schema{
-												"enabled": {
-													Type:     schema.TypeList,
-													Computed: true,
-													Optional: true,
-													ForceNew: false,
-													Elem:     &schema.Schema{Type: schema.TypeString},
-												},
-												"disabled": {
-													Type:     schema.TypeList,
-													Computed: true,
-													Optional: true,
-													ForceNew: false,
-													Elem:     &schema.Schema{Type: schema.TypeString},
-												},
-											},
-										},
+										Elem:     &schema.Schema{Type: schema.TypeString},
+									},
+									"disabled": {
+										Type:     schema.TypeList,
+										Computed: true,
+										Optional: true,
+										// Required: true,
+										ForceNew: false,
+										Elem:     &schema.Schema{Type: schema.TypeString},
 									},
 								},
 							},
@@ -76,6 +76,93 @@ func dataSourceCloudProjectKube() *schema.Resource {
 					},
 				},
 			},
+
+			kubeClusterCustomizationKubeProxyKey: {
+				Type:     schema.TypeSet,
+				Computed: false,
+				Optional: true,
+				ForceNew: false,
+				MaxItems: 1,
+				// Set:      CustomSchemaSetFunc(true),
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"iptables": {
+							Type:     schema.TypeSet,
+							Computed: false,
+							Optional: true,
+							ForceNew: false,
+							MaxItems: 1,
+							Set:      CustomSchemaSetFunc(false),
+
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"min_sync_period": {
+										Type:     schema.TypeString,
+										Computed: false,
+										Optional: true,
+										ForceNew: false,
+									},
+									"sync_period": {
+										Type:     schema.TypeString,
+										Computed: false,
+										Optional: true,
+										ForceNew: false,
+									},
+								},
+							},
+						},
+						"ipvs": {
+							Type:     schema.TypeSet,
+							Computed: false,
+							Optional: true,
+							ForceNew: false,
+							MaxItems: 1,
+							Set:      CustomSchemaSetFunc(false),
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"min_sync_period": {
+										Type:     schema.TypeString,
+										Computed: false,
+										Optional: true,
+										ForceNew: false,
+									},
+									"sync_period": {
+										Type:     schema.TypeString,
+										Computed: false,
+										Optional: true,
+										ForceNew: false,
+									},
+									"scheduler": {
+										Type:     schema.TypeString,
+										Computed: false,
+										Optional: true,
+										ForceNew: false,
+									},
+									"tcp_fin_timeout": {
+										Type:     schema.TypeString,
+										Computed: false,
+										Optional: true,
+										ForceNew: false,
+									},
+									"tcp_timeout": {
+										Type:     schema.TypeString,
+										Computed: false,
+										Optional: true,
+										ForceNew: false,
+									},
+									"udp_timeout": {
+										Type:     schema.TypeString,
+										Computed: false,
+										Optional: true,
+										ForceNew: false,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+
 			"private_network_id": {
 				Type:     schema.TypeString,
 				Computed: true,

--- a/ovh/data_cloud_project_kube.go
+++ b/ovh/data_cloud_project_kube.go
@@ -41,7 +41,7 @@ func dataSourceCloudProjectKube() *schema.Resource {
 				// Required: true,
 				ForceNew: false,
 				// MaxItems: 1,
-				Set: CustomSchemaSetFunc(false),
+				Set: CustomSchemaSetFunc(),
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"admissionplugins": {
@@ -51,7 +51,7 @@ func dataSourceCloudProjectKube() *schema.Resource {
 							// Required: true,
 							ForceNew: false,
 							// MaxItems: 1,
-							Set: CustomSchemaSetFunc(false),
+							Set: CustomSchemaSetFunc(),
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
 									"enabled": {
@@ -92,7 +92,7 @@ func dataSourceCloudProjectKube() *schema.Resource {
 							Optional: true,
 							ForceNew: false,
 							MaxItems: 1,
-							Set:      CustomSchemaSetFunc(false),
+							Set:      CustomIPtablesSchemaSetFunc(false),
 
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
@@ -117,7 +117,7 @@ func dataSourceCloudProjectKube() *schema.Resource {
 							Optional: true,
 							ForceNew: false,
 							MaxItems: 1,
-							Set:      CustomSchemaSetFunc(false),
+							Set:      CustomIPVSSchemaSetFunc(true),
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
 									"min_sync_period": {

--- a/ovh/data_cloud_project_kube.go
+++ b/ovh/data_cloud_project_kube.go
@@ -83,7 +83,6 @@ func dataSourceCloudProjectKube() *schema.Resource {
 				Optional: true,
 				ForceNew: false,
 				MaxItems: 1,
-				// Set:      CustomSchemaSetFunc(true),
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"iptables": {

--- a/ovh/data_cloud_project_kube_test.go
+++ b/ovh/data_cloud_project_kube_test.go
@@ -25,6 +25,8 @@ func TestAccCloudProjectKubeDataSource_basic(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
+			testAccPreCheckCloud(t)
+			testAccCheckCloudProjectExists(t)
 			testAccPreCheckKubernetes(t)
 		},
 		Providers: testAccProviders,
@@ -32,12 +34,49 @@ func TestAccCloudProjectKubeDataSource_basic(t *testing.T) {
 			{
 				Config: config,
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(
-						"data.ovh_cloud_project_kube.cluster", "region", region),
-					resource.TestCheckResourceAttr(
-						"data.ovh_cloud_project_kube.cluster", "name", name),
-					resource.TestMatchResourceAttr(
-						"data.ovh_cloud_project_kube.cluster", "version", matchVersion),
+					resource.TestCheckResourceAttr("data.ovh_cloud_project_kube.cluster", "region", region),
+					resource.TestCheckResourceAttr("data.ovh_cloud_project_kube.cluster", "name", name),
+					resource.TestMatchResourceAttr("data.ovh_cloud_project_kube.cluster", "version", matchVersion),
+				),
+			},
+		},
+	})
+}
+
+func TestAccCloudProjectKubeDataSource_kubeProxy(t *testing.T) {
+	name := acctest.RandomWithPrefix(test_prefix)
+	region := os.Getenv("OVH_CLOUD_PROJECT_KUBE_REGION_TEST")
+	config := fmt.Sprintf(
+		testAccCloudProjectKubeDatasourceKubeProxyConfig,
+		os.Getenv("OVH_CLOUD_PROJECT_SERVICE_TEST"),
+		name,
+		region,
+	)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheckCloud(t)
+			testAccCheckCloudProjectExists(t)
+			testAccPreCheckKubernetes(t)
+		},
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("data.ovh_cloud_project_kube.cluster", "region", region),
+					resource.TestCheckResourceAttr("data.ovh_cloud_project_kube.cluster", "name", name),
+					resource.TestCheckResourceAttr("data.ovh_cloud_project_kube.cluster", "kube_proxy_mode", "ipvs"),
+
+					resource.TestCheckResourceAttr("data.ovh_cloud_project_kube.cluster", "customization_kube_proxy.0.iptables.0.min_sync_period", "PT30S"),
+					resource.TestCheckResourceAttr("data.ovh_cloud_project_kube.cluster", "customization_kube_proxy.0.iptables.0.sync_period", "PT30S"),
+
+					resource.TestCheckResourceAttr("data.ovh_cloud_project_kube.cluster", "customization_kube_proxy.0.ipvs.0.min_sync_period", "PT30S"),
+					resource.TestCheckResourceAttr("data.ovh_cloud_project_kube.cluster", "customization_kube_proxy.0.ipvs.0.sync_period", "PT30S"),
+					resource.TestCheckResourceAttr("data.ovh_cloud_project_kube.cluster", "customization_kube_proxy.0.ipvs.0.scheduler", "rr"),
+					resource.TestCheckResourceAttr("data.ovh_cloud_project_kube.cluster", "customization_kube_proxy.0.ipvs.0.tcp_fin_timeout", "PT30S"),
+					resource.TestCheckResourceAttr("data.ovh_cloud_project_kube.cluster", "customization_kube_proxy.0.ipvs.0.tcp_timeout", "PT30S"),
+					resource.TestCheckResourceAttr("data.ovh_cloud_project_kube.cluster", "customization_kube_proxy.0.ipvs.0.udp_timeout", "PT30S"),
 				),
 			},
 		},
@@ -50,6 +89,36 @@ resource "ovh_cloud_project_kube" "cluster" {
     name          = "%s"
 	region        = "%s"
 	version = "%s"
+}
+
+data "ovh_cloud_project_kube" "cluster" {
+  service_name = ovh_cloud_project_kube.cluster.service_name
+  kube_id = ovh_cloud_project_kube.cluster.id
+}
+`
+
+var testAccCloudProjectKubeDatasourceKubeProxyConfig = `
+resource "ovh_cloud_project_kube" "cluster" {
+	service_name  = "%s"
+	name          = "%s"
+	region        = "%s"
+	
+	kube_proxy_mode = "ipvs"
+	customization_kube_proxy {
+		iptables {
+      		min_sync_period = "PT30S"
+			sync_period = "PT30S"
+    	}
+    	
+		ipvs {
+      		min_sync_period = "PT30S"
+			sync_period = "PT30S"
+			scheduler = "rr"
+			tcp_fin_timeout = "PT30S"
+			tcp_timeout = "PT30S"
+			udp_timeout = "PT30S"
+    	}
+  	}
 }
 
 data "ovh_cloud_project_kube" "cluster" {

--- a/ovh/resource_cloud_project_kube.go
+++ b/ovh/resource_cloud_project_kube.go
@@ -262,8 +262,16 @@ func resourceCloudProjectKube() *schema.Resource {
 	}
 }
 
-// CustomIPVSIPTablesSchemaSetFunc is a custom schema set function for IPVS and IPTables.
-// It is required because the API returns "P0D" and we want PT0S.
+// CustomIPVSIPTablesSchemaSetFunc is a custom schema.SchemaSetFunc for IPVS and IPTables
+// block configuration.
+//
+// Even if setting in the API `PT0S`, it returns `P0D` which is exactly the same duration but
+// induce issue when calculating hashset.
+//
+// Moreover, we cannot use DiffSuppressFunc because even if the diff is removed the hashset is still different.
+//
+// Using schema.StateFunc does not help because of internal terraform execution diff calculation
+// order.
 func CustomIPVSIPTablesSchemaSetFunc() schema.SchemaSetFunc {
 	return func(i interface{}) int {
 		for k, v := range i.(map[string]interface{}) {

--- a/ovh/resource_cloud_project_kube.go
+++ b/ovh/resource_cloud_project_kube.go
@@ -65,11 +65,12 @@ func resourceCloudProjectKube() *schema.Resource {
 				ForceNew: false,
 			},
 			kubeClusterCustomizationApiServerKey: {
-				Type:     schema.TypeSet,
-				Computed: true,
-				Optional: true,
-				ForceNew: false,
-				Set:      CustomSchemaSetFunc(),
+				Type:          schema.TypeSet,
+				Computed:      true,
+				Optional:      true,
+				ForceNew:      false,
+				Set:           CustomSchemaSetFunc(),
+				ConflictsWith: []string{kubeClusterCustomization},
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"admissionplugins": {
@@ -101,12 +102,13 @@ func resourceCloudProjectKube() *schema.Resource {
 				},
 			},
 			kubeClusterCustomization: {
-				Type:       schema.TypeSet,
-				Computed:   true,
-				Optional:   true,
-				ForceNew:   false,
-				Set:        CustomSchemaSetFunc(),
-				Deprecated: fmt.Sprintf("Use %s instead", kubeClusterCustomizationApiServerKey),
+				Type:          schema.TypeSet,
+				Computed:      true,
+				Optional:      true,
+				ForceNew:      false,
+				Set:           CustomSchemaSetFunc(),
+				ConflictsWith: []string{kubeClusterCustomizationApiServerKey},
+				Deprecated:    fmt.Sprintf("Use %s instead", kubeClusterCustomizationApiServerKey),
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"apiserver": {
@@ -460,8 +462,9 @@ func resourceCloudProjectKubeUpdate(d *schema.ResourceData, meta interface{}) er
 	if d.HasChange(kubeClusterCustomizationApiServerKey) || d.HasChange(kubeClusterCustomizationKubeProxyKey) {
 		_, apiServerAdmissionPlugins := d.GetChange(kubeClusterCustomizationApiServerKey)
 		_, kubeProxyCustomization := d.GetChange(kubeClusterCustomizationKubeProxyKey)
+		_, oldApiServerCustomization := d.GetChange(kubeClusterCustomization)
 
-		customization := loadCustomization(apiServerAdmissionPlugins, kubeProxyCustomization)
+		customization := loadCustomization(oldApiServerCustomization, apiServerAdmissionPlugins, kubeProxyCustomization)
 
 		params := &CloudProjectKubeUpdateCustomizationOpts{
 			APIServer: customization.APIServer,

--- a/ovh/resource_cloud_project_kube.go
+++ b/ovh/resource_cloud_project_kube.go
@@ -22,6 +22,7 @@ const (
 
 	kubeClusterProxyModeKey = "kube_proxy_mode"
 
+	kubeClusterCustomization             = "customization" // Deprecated
 	kubeClusterCustomizationApiServerKey = "customization_apiserver"
 	kubeClusterCustomizationKubeProxyKey = "customization_kube_proxy"
 )
@@ -99,7 +100,55 @@ func resourceCloudProjectKube() *schema.Resource {
 					},
 				},
 			},
-
+			kubeClusterCustomization: {
+				Type:       schema.TypeSet,
+				Computed:   true,
+				Optional:   true,
+				ForceNew:   false,
+				Set:        CustomSchemaSetFunc(),
+				Deprecated: fmt.Sprintf("Use %s instead", kubeClusterCustomizationApiServerKey),
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"apiserver": {
+							Type:       schema.TypeSet,
+							Computed:   true,
+							Optional:   true,
+							ForceNew:   false,
+							Set:        CustomSchemaSetFunc(),
+							Deprecated: fmt.Sprintf("Use %s instead", kubeClusterCustomizationApiServerKey),
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"admissionplugins": {
+										Type:     schema.TypeSet,
+										Computed: true,
+										Optional: true,
+										ForceNew: false,
+										Set:      CustomSchemaSetFunc(),
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"enabled": {
+													Type:     schema.TypeList,
+													Computed: true,
+													Optional: true,
+													ForceNew: false,
+													Elem:     &schema.Schema{Type: schema.TypeString},
+												},
+												"disabled": {
+													Type:     schema.TypeList,
+													Computed: true,
+													Optional: true,
+													ForceNew: false,
+													Elem:     &schema.Schema{Type: schema.TypeString},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
 			kubeClusterCustomizationKubeProxyKey: {
 				Type:     schema.TypeSet,
 				Computed: false,

--- a/ovh/resource_cloud_project_kube.go
+++ b/ovh/resource_cloud_project_kube.go
@@ -72,7 +72,7 @@ func resourceCloudProjectKube() *schema.Resource {
 				// Required: true,
 				ForceNew: false,
 				// MaxItems: 1,
-				Set: CustomSchemaSetFunc(false),
+				Set: CustomSchemaSetFunc(),
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"admissionplugins": {
@@ -82,7 +82,7 @@ func resourceCloudProjectKube() *schema.Resource {
 							// Required: true,
 							ForceNew: false,
 							// MaxItems: 1,
-							Set: CustomSchemaSetFunc(false),
+							Set: CustomSchemaSetFunc(),
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
 									"enabled": {
@@ -203,6 +203,7 @@ func resourceCloudProjectKube() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 				ForceNew: true,
+				Computed: true,
 			},
 			kubeClusterPrivateNetworkConfigurationKey: {
 				Type:     schema.TypeSet,
@@ -308,22 +309,14 @@ func CustomIPVSSchemaSetFunc(output bool) schema.SchemaSetFunc {
 		}
 
 		out := fmt.Sprintf("%#v", i)
-		hash := schema.HashString(out)
-		if output {
-			log.Printf(">>>>>>>%d %s\n", hash, out)
-		}
-		return hash
+		return schema.HashString(out)
 	}
 }
 
-func CustomSchemaSetFunc(output bool) schema.SchemaSetFunc {
+func CustomSchemaSetFunc() schema.SchemaSetFunc {
 	return func(i interface{}) int {
 		out := fmt.Sprintf("%#v", i)
-		hash := schema.HashString(out)
-		if output {
-			log.Printf(">>>>>>>%d %s\n", hash, out)
-		}
-		return hash
+		return schema.HashString(out)
 	}
 }
 

--- a/ovh/resource_cloud_project_kube_nodepool.go
+++ b/ovh/resource_cloud_project_kube_nodepool.go
@@ -149,7 +149,7 @@ func resourceCloudProjectKubeNodePool() *schema.Resource {
 				Optional:    true,
 				Type:        schema.TypeSet,
 				MaxItems:    1,
-				Set:         CustomSchemaSetFunc(false),
+				Set:         CustomSchemaSetFunc(),
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"metadata": {
@@ -157,7 +157,7 @@ func resourceCloudProjectKubeNodePool() *schema.Resource {
 							Optional:    true,
 							Type:        schema.TypeSet,
 							MaxItems:    1,
-							Set:         CustomSchemaSetFunc(false),
+							Set:         CustomSchemaSetFunc(),
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
 									"finalizers": {
@@ -188,7 +188,7 @@ func resourceCloudProjectKubeNodePool() *schema.Resource {
 							Optional:    true,
 							Type:        schema.TypeSet,
 							MaxItems:    1,
-							Set:         CustomSchemaSetFunc(false),
+							Set:         CustomSchemaSetFunc(),
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
 									"unschedulable": {

--- a/ovh/resource_cloud_project_kube_nodepool.go
+++ b/ovh/resource_cloud_project_kube_nodepool.go
@@ -149,11 +149,7 @@ func resourceCloudProjectKubeNodePool() *schema.Resource {
 				Optional:    true,
 				Type:        schema.TypeSet,
 				MaxItems:    1,
-				Set: func(i interface{}) int {
-					out := fmt.Sprintf("%#v", i)
-					hash := int(schema.HashString(out))
-					return hash
-				},
+				Set:         CustomSchemaSetFunc(false),
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"metadata": {
@@ -161,11 +157,7 @@ func resourceCloudProjectKubeNodePool() *schema.Resource {
 							Optional:    true,
 							Type:        schema.TypeSet,
 							MaxItems:    1,
-							Set: func(i interface{}) int {
-								out := fmt.Sprintf("%#v", i)
-								hash := int(schema.HashString(out))
-								return hash
-							},
+							Set:         CustomSchemaSetFunc(false),
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
 									"finalizers": {
@@ -196,11 +188,7 @@ func resourceCloudProjectKubeNodePool() *schema.Resource {
 							Optional:    true,
 							Type:        schema.TypeSet,
 							MaxItems:    1,
-							Set: func(i interface{}) int {
-								out := fmt.Sprintf("%#v", i)
-								hash := int(schema.HashString(out))
-								return hash
-							},
+							Set:         CustomSchemaSetFunc(false),
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
 									"unschedulable": {
@@ -322,7 +310,7 @@ func resourceCloudProjectKubeNodePoolUpdate(d *schema.ResourceData, meta interfa
 	log.Printf("[DEBUG] Will update nodepool: %#v", *params)
 	err = config.OVHClient.Put(endpoint, params, nil)
 	if err != nil {
-		return fmt.Errorf("calling Put %s with params %#v:\n\t %w", endpoint, *params, err)
+		return fmt.Errorf("calling Put %s with params %v:\n\t %w", endpoint, *params, err)
 	}
 
 	log.Printf("[DEBUG] Waiting for nodepool %s to be READY", d.Id())

--- a/ovh/resource_cloud_project_kube_test.go
+++ b/ovh/resource_cloud_project_kube_test.go
@@ -172,6 +172,114 @@ resource "ovh_cloud_project_kube" "cluster" {
 }
 `
 
+var testAccCloudProjectKubeKubeProxyIPVS = `
+resource "ovh_cloud_project_kube" "cluster" {
+	service_name  = "%s"
+	name          = "%s"
+	region        = "%s"
+
+	kube_proxy_mode = "ipvs"
+	customization {
+		kube_proxy {
+			ipvs {
+				min_sync_period = "PT0S"
+				sync_period = "PT30S"
+				scheduler = "rr"
+				tcp_fin_timeout = "PT0S"
+				tcp_timeout = "PT0S"
+				udp_timeout = "PT0S"
+			}
+
+			iptables {
+				sync_period = "PT30S"
+				min_sync_period = "PT0S"
+			}
+		}
+	}
+}
+`
+
+var testAccCloudProjectKubeUpdatedKubeProxyIPVS = `
+resource "ovh_cloud_project_kube" "cluster" {
+	service_name  = "%s"
+	name          = "%s"
+	region        = "%s"
+
+	kube_proxy_mode = "ipvs"
+	customization {
+		kube_proxy {
+			ipvs {
+				min_sync_period = "PT30S"
+				sync_period = "PT10S"
+				scheduler = "rr"
+				tcp_fin_timeout = "PT30S"
+				tcp_timeout = "PT30S"
+				udp_timeout = "PT30S"
+			}
+
+			iptables {
+				sync_period = "PT30S"
+				min_sync_period = "PT0S"
+			}
+		}
+	}
+}
+`
+
+var testAccCloudProjectKubeKubeProxyIPTables = `
+resource "ovh_cloud_project_kube" "cluster" {
+	service_name  = "%s"
+	name          = "%s"
+	region        = "%s"
+
+	kube_proxy_mode = "iptables"
+	customization {
+		kube_proxy {
+			ipvs {
+				min_sync_period = "PT0S"
+				sync_period = "PT30S"
+				scheduler = "rr"
+				tcp_fin_timeout = "PT0S"
+				tcp_timeout = "PT0S"
+				udp_timeout = "PT0S"
+			}
+
+			iptables {
+				sync_period = "PT30S"
+				min_sync_period = "PT0S"
+			}
+		}
+	}
+}
+`
+
+var testAccCloudProjectKubeUpdatedKubeProxyIPTables = `
+resource "ovh_cloud_project_kube" "cluster" {
+	service_name  = "%s"
+	name          = "%s"
+	region        = "%s"
+
+	kube_proxy_mode = "iptables"
+	customization {
+		kube_proxy {
+			ipvs {
+				min_sync_period = "PT0S"
+				sync_period = "PT30S"
+				scheduler = "rr"
+				tcp_fin_timeout = "PT0S"
+				tcp_timeout = "PT0S"
+				udp_timeout = "PT0S"
+			}
+
+			iptables {
+				sync_period = "PT60S"
+				min_sync_period = "PT10S"
+			}
+		}
+	}
+}
+`
+
 type configData struct {
 	Region                         string
 	Regions                        string
@@ -328,6 +436,116 @@ func TestAccCloudProjectKube_basic(t *testing.T) {
 					resource.TestCheckResourceAttrSet("ovh_cloud_project_kube.cluster", "kubeconfig"),
 					resource.TestCheckResourceAttr("ovh_cloud_project_kube.cluster", kubeClusterNameKey, name),
 					resource.TestCheckResourceAttr("ovh_cloud_project_kube.cluster", "version", version),
+				),
+			},
+		},
+	})
+}
+
+func TestAccCloudProjectKube_kube_proxy_ipvs(t *testing.T) {
+	name := acctest.RandomWithPrefix(test_prefix)
+	region := os.Getenv("OVH_CLOUD_PROJECT_KUBE_REGION_TEST")
+	config := fmt.Sprintf(
+		testAccCloudProjectKubeKubeProxyIPVS,
+		os.Getenv("OVH_CLOUD_PROJECT_SERVICE_TEST"),
+		name,
+		region,
+	)
+
+	updatableConfig := fmt.Sprintf(
+		testAccCloudProjectKubeUpdatedKubeProxyIPVS,
+		os.Getenv("OVH_CLOUD_PROJECT_SERVICE_TEST"),
+		name,
+		region,
+	)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheckCloud(t)
+			testAccCheckCloudProjectExists(t)
+			testAccPreCheckKubernetes(t)
+		},
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("ovh_cloud_project_kube.cluster", "region", region),
+					resource.TestCheckResourceAttrSet("ovh_cloud_project_kube.cluster", "kubeconfig"),
+					resource.TestCheckResourceAttr("ovh_cloud_project_kube.cluster", kubeClusterNameKey, name),
+					resource.TestCheckResourceAttr("ovh_cloud_project_kube.cluster", "kube_proxy_mode", "ipvs"),
+					resource.TestCheckResourceAttr("ovh_cloud_project_kube.cluster", "customization.0.kube_proxy.0.ipvs.0.min_sync_period", "PT0S"),
+					resource.TestCheckResourceAttr("ovh_cloud_project_kube.cluster", "customization.0.kube_proxy.0.ipvs.0.sync_period", "PT30S"),
+					resource.TestCheckResourceAttr("ovh_cloud_project_kube.cluster", "customization.0.kube_proxy.0.ipvs.0.scheduler", "rr"),
+					resource.TestCheckResourceAttr("ovh_cloud_project_kube.cluster", "customization.0.kube_proxy.0.ipvs.0.tcp_fin_timeout", "PT0S"),
+					resource.TestCheckResourceAttr("ovh_cloud_project_kube.cluster", "customization.0.kube_proxy.0.ipvs.0.tcp_timeout", "PT0S"),
+					resource.TestCheckResourceAttr("ovh_cloud_project_kube.cluster", "customization.0.kube_proxy.0.ipvs.0.udp_timeout", "PT0S"),
+				),
+			},
+			{
+				Config: updatableConfig,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("ovh_cloud_project_kube.cluster", "region", region),
+					resource.TestCheckResourceAttrSet("ovh_cloud_project_kube.cluster", "kubeconfig"),
+					resource.TestCheckResourceAttr("ovh_cloud_project_kube.cluster", kubeClusterNameKey, name),
+					resource.TestCheckResourceAttr("ovh_cloud_project_kube.cluster", "kube_proxy_mode", "ipvs"),
+					resource.TestCheckResourceAttr("ovh_cloud_project_kube.cluster", "customization.0.kube_proxy.0.ipvs.0.min_sync_period", "PT30S"),
+					resource.TestCheckResourceAttr("ovh_cloud_project_kube.cluster", "customization.0.kube_proxy.0.ipvs.0.sync_period", "PT10S"),
+					resource.TestCheckResourceAttr("ovh_cloud_project_kube.cluster", "customization.0.kube_proxy.0.ipvs.0.scheduler", "rr"),
+					resource.TestCheckResourceAttr("ovh_cloud_project_kube.cluster", "customization.0.kube_proxy.0.ipvs.0.tcp_fin_timeout", "PT30S"),
+					resource.TestCheckResourceAttr("ovh_cloud_project_kube.cluster", "customization.0.kube_proxy.0.ipvs.0.tcp_timeout", "PT30S"),
+					resource.TestCheckResourceAttr("ovh_cloud_project_kube.cluster", "customization.0.kube_proxy.0.ipvs.0.udp_timeout", "PT30S"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccCloudProjectKube_kube_proxy_iptables(t *testing.T) {
+	name := acctest.RandomWithPrefix(test_prefix)
+	region := os.Getenv("OVH_CLOUD_PROJECT_KUBE_REGION_TEST")
+	config := fmt.Sprintf(
+		testAccCloudProjectKubeKubeProxyIPTables,
+		os.Getenv("OVH_CLOUD_PROJECT_SERVICE_TEST"),
+		name,
+		region,
+	)
+
+	updatedConfig := fmt.Sprintf(
+		testAccCloudProjectKubeUpdatedKubeProxyIPTables,
+		os.Getenv("OVH_CLOUD_PROJECT_SERVICE_TEST"),
+		name,
+		region,
+	)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheckCloud(t)
+			testAccCheckCloudProjectExists(t)
+			testAccPreCheckKubernetes(t)
+		},
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("ovh_cloud_project_kube.cluster", "region", region),
+					resource.TestCheckResourceAttrSet("ovh_cloud_project_kube.cluster", "kubeconfig"),
+					resource.TestCheckResourceAttr("ovh_cloud_project_kube.cluster", kubeClusterNameKey, name),
+					resource.TestCheckResourceAttr("ovh_cloud_project_kube.cluster", "kube_proxy_mode", "iptables"),
+					resource.TestCheckResourceAttr("ovh_cloud_project_kube.cluster", "customization.0.kube_proxy.0.iptables.0.min_sync_period", "PT0S"),
+					resource.TestCheckResourceAttr("ovh_cloud_project_kube.cluster", "customization.0.kube_proxy.0.iptables.0.sync_period", "PT30S"),
+				),
+			},
+			{
+				Config: updatedConfig,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("ovh_cloud_project_kube.cluster", "region", region),
+					resource.TestCheckResourceAttrSet("ovh_cloud_project_kube.cluster", "kubeconfig"),
+					resource.TestCheckResourceAttr("ovh_cloud_project_kube.cluster", kubeClusterNameKey, name),
+					resource.TestCheckResourceAttr("ovh_cloud_project_kube.cluster", "kube_proxy_mode", "iptables"),
+					resource.TestCheckResourceAttr("ovh_cloud_project_kube.cluster", "customization.0.kube_proxy.0.iptables.0.min_sync_period", "PT10S"),
+					resource.TestCheckResourceAttr("ovh_cloud_project_kube.cluster", "customization.0.kube_proxy.0.iptables.0.sync_period", "PT60S"),
 				),
 			},
 		},

--- a/ovh/types_cloud_project_kube.go
+++ b/ovh/types_cloud_project_kube.go
@@ -206,77 +206,81 @@ func (v CloudProjectKubeResponse) ToMap() map[string]interface{} {
 	obj["version"] = v.Version[:strings.LastIndex(v.Version, ".")]
 	obj[kubeClusterProxyModeKey] = v.KubeProxyMode
 
-	obj["customization_apiserver"] = []map[string]interface{}{
-		{
-			"admissionplugins": []map[string]interface{}{
-				{
-					"enabled":  v.Customization.APIServer.AdmissionPlugins.Enabled,
-					"disabled": v.Customization.APIServer.AdmissionPlugins.Disabled,
+	if v.Customization.APIServer != nil {
+		obj["customization_apiserver"] = []map[string]interface{}{
+			{
+				"admissionplugins": []map[string]interface{}{
+					{
+						"enabled":  v.Customization.APIServer.AdmissionPlugins.Enabled,
+						"disabled": v.Customization.APIServer.AdmissionPlugins.Disabled,
+					},
 				},
 			},
-		},
+		}
 	}
 
-	obj["customization_kube_proxy"] = []map[string]interface{}{
-		{
-			"iptables": []map[string]interface{}{
-				{
-					"min_sync_period": v.Customization.KubeProxy.IPTables.MinSyncPeriod,
-					"sync_period":     v.Customization.KubeProxy.IPTables.SyncPeriod,
-				},
+	if v.Customization.KubeProxy != nil {
+		obj["customization_kube_proxy"] = []map[string]interface{}{
+			{
+				"iptables": nil,
+				"ipvs":     nil,
 			},
-			"ipvs": []map[string]interface{}{
-				{
-					"min_sync_period": v.Customization.KubeProxy.IPVS.MinSyncPeriod,
-					"scheduler":       v.Customization.KubeProxy.IPVS.Scheduler,
-					"sync_period":     v.Customization.KubeProxy.IPVS.SyncPeriod,
-					"tcp_fin_timeout": v.Customization.KubeProxy.IPVS.TCPFinTimeout,
-					"tcp_timeout":     v.Customization.KubeProxy.IPVS.TCPTimeout,
-					"udp_timeout":     v.Customization.KubeProxy.IPVS.UDPTimeout,
-				},
-			},
-		},
-	}
+		}
 
-	if len(obj["customization_kube_proxy"].([]map[string]interface{})) > 0 {
+		if v.Customization.KubeProxy.IPTables != nil {
+			data := make(map[string]interface{})
+			if d := v.Customization.KubeProxy.IPTables.MinSyncPeriod; d != nil && *d != "" {
+				data["min_sync_period"] = d
+			}
 
-		if len(obj["customization_kube_proxy"].([]map[string]interface{})[0]["iptables"].([]map[string]interface{})) > 0 {
-			if obj["customization_kube_proxy"].([]map[string]interface{})[0]["iptables"].([]map[string]interface{})[0]["min_sync_period"].(*string) == nil {
-				delete(obj["customization_kube_proxy"].([]map[string]interface{})[0]["iptables"].([]map[string]interface{})[0], "min_sync_period")
+			if d := v.Customization.KubeProxy.IPTables.SyncPeriod; d != nil && *d != "" {
+				data["sync_period"] = d
 			}
-			if obj["customization_kube_proxy"].([]map[string]interface{})[0]["iptables"].([]map[string]interface{})[0]["sync_period"].(*string) == nil {
-				delete(obj["customization_kube_proxy"].([]map[string]interface{})[0]["iptables"].([]map[string]interface{})[0], "sync_period")
-			}
-			if len(obj["customization_kube_proxy"].([]map[string]interface{})[0]["iptables"].([]map[string]interface{})[0]) == 0 {
-				delete(obj["customization_kube_proxy"].([]map[string]interface{})[0], "iptables")
+
+			if len(data) > 0 {
+				obj["customization_kube_proxy"].([]map[string]interface{})[0]["iptables"] = []map[string]interface{}{data}
 			}
 		}
 
-		if len(obj["customization_kube_proxy"].([]map[string]interface{})[0]["ipvs"].([]map[string]interface{})) > 0 {
-			if obj["customization_kube_proxy"].([]map[string]interface{})[0]["ipvs"].([]map[string]interface{})[0]["min_sync_period"].(*string) == nil ||
-				*obj["customization_kube_proxy"].([]map[string]interface{})[0]["ipvs"].([]map[string]interface{})[0]["min_sync_period"].(*string) == "" {
-				delete(obj["customization_kube_proxy"].([]map[string]interface{})[0]["ipvs"].([]map[string]interface{})[0], "min_sync_period")
+		if v.Customization.KubeProxy.IPVS != nil {
+			data := make(map[string]interface{})
+			if d := v.Customization.KubeProxy.IPVS.MinSyncPeriod; d != nil && *d != "" {
+				data["min_sync_period"] = d
 			}
-			if obj["customization_kube_proxy"].([]map[string]interface{})[0]["ipvs"].([]map[string]interface{})[0]["scheduler"].(*string) == nil {
-				delete(obj["customization_kube_proxy"].([]map[string]interface{})[0]["ipvs"].([]map[string]interface{})[0], "scheduler")
+
+			if d := v.Customization.KubeProxy.IPVS.Scheduler; d != nil && *d != "" {
+				data["scheduler"] = d
 			}
-			if obj["customization_kube_proxy"].([]map[string]interface{})[0]["ipvs"].([]map[string]interface{})[0]["sync_period"].(*string) == nil {
-				delete(obj["customization_kube_proxy"].([]map[string]interface{})[0]["ipvs"].([]map[string]interface{})[0], "sync_period")
+
+			if d := v.Customization.KubeProxy.IPVS.SyncPeriod; d != nil && *d != "" {
+				data["sync_period"] = d
 			}
-			if obj["customization_kube_proxy"].([]map[string]interface{})[0]["ipvs"].([]map[string]interface{})[0]["tcp_fin_timeout"].(*string) == nil {
-				delete(obj["customization_kube_proxy"].([]map[string]interface{})[0]["ipvs"].([]map[string]interface{})[0], "tcp_fin_timeout")
+
+			if d := v.Customization.KubeProxy.IPVS.TCPFinTimeout; d != nil && *d != "" {
+				data["tcp_fin_timeout"] = d
 			}
-			if obj["customization_kube_proxy"].([]map[string]interface{})[0]["ipvs"].([]map[string]interface{})[0]["tcp_timeout"].(*string) == nil {
-				delete(obj["customization_kube_proxy"].([]map[string]interface{})[0]["ipvs"].([]map[string]interface{})[0], "tcp_timeout")
+
+			if d := v.Customization.KubeProxy.IPVS.TCPTimeout; d != nil && *d != "" {
+				data["tcp_timeout"] = d
 			}
-			if obj["customization_kube_proxy"].([]map[string]interface{})[0]["ipvs"].([]map[string]interface{})[0]["udp_timeout"].(*string) == nil {
-				delete(obj["customization_kube_proxy"].([]map[string]interface{})[0]["ipvs"].([]map[string]interface{})[0], "udp_timeout")
+
+			if d := v.Customization.KubeProxy.IPVS.UDPTimeout; d != nil && *d != "" {
+				data["udp_timeout"] = d
 			}
-			if len(obj["customization_kube_proxy"].([]map[string]interface{})[0]["ipvs"].([]map[string]interface{})[0]) == 0 {
-				delete(obj["customization_kube_proxy"].([]map[string]interface{})[0], "ipvs")
+
+			if len(data) > 0 {
+				obj["customization_kube_proxy"].([]map[string]interface{})[0]["ipvs"] = []map[string]interface{}{data}
 			}
 		}
 
+		// Remove empty fields
+		for k, x := range obj["customization_kube_proxy"].([]map[string]interface{})[0] {
+			if x == nil {
+				delete(obj["customization_kube_proxy"].([]map[string]interface{})[0], k)
+			}
+		}
+
+		// Delete entire customization_kube_proxy if empty
 		if len(obj["customization_kube_proxy"].([]map[string]interface{})[0]) == 0 {
 			delete(obj, "customization_kube_proxy")
 		}

--- a/ovh/types_cloud_project_kube.go
+++ b/ovh/types_cloud_project_kube.go
@@ -1,9 +1,7 @@
 package ovh
 
 import (
-	"encoding/json"
 	"fmt"
-	"log"
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -32,7 +30,7 @@ type CloudProjectKubeCreateOpts struct {
 	Version                     *string                      `json:"version,omitempty"`
 	UpdatePolicy                *string                      `json:"updatePolicy,omitempty"`
 	Customization               *Customization               `json:"customization,omitempty"`
-	KubeProxyMode               *string                      `json:"kubeProxyMode"`
+	KubeProxyMode               *string                      `json:"kubeProxyMode,omitempty"`
 }
 
 type Customization struct {
@@ -283,11 +281,6 @@ func (v CloudProjectKubeResponse) ToMap() map[string]interface{} {
 			delete(obj, "customization_kube_proxy")
 		}
 	}
-
-	i, _ := json.MarshalIndent(v, "", "  ")
-	o, _ := json.MarshalIndent(obj, "", "  ")
-
-	log.Printf("##### %s\n\n%s\n\n%s\n\n", i, o)
 
 	return obj
 }

--- a/ovh/types_cloud_project_kube_test.go
+++ b/ovh/types_cloud_project_kube_test.go
@@ -1,0 +1,362 @@
+package ovh
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestCloudProjectKubeResponse_ToMap(t *testing.T) {
+	type fields struct {
+		ControlPlaneIsUpToDate bool
+		Id                     string
+		IsUpToDate             bool
+		Name                   string
+		NextUpgradeVersions    []string
+		NodesUrl               string
+		PrivateNetworkId       string
+		Region                 string
+		Status                 string
+		UpdatePolicy           string
+		Url                    string
+		Version                string
+		Customization          Customization
+		KubeProxyMode          string
+	}
+
+	pointerArray := func(s []string) *[]string { return &s }
+
+	tests := []struct {
+		name   string
+		fields fields
+		want   map[string]interface{}
+	}{
+		{
+			name: "No customization",
+			fields: fields{
+				ControlPlaneIsUpToDate: false,
+				Id:                     "",
+				IsUpToDate:             false,
+				Name:                   "",
+				NextUpgradeVersions:    nil,
+				NodesUrl:               "",
+				PrivateNetworkId:       "",
+				Region:                 "",
+				Status:                 "",
+				UpdatePolicy:           "",
+				Url:                    "",
+				Version:                "1.0.0",
+				Customization:          Customization{},
+				KubeProxyMode:          "",
+			},
+			want: map[string]interface{}{
+				"control_plane_is_up_to_date": false,
+				"id":                          "",
+				"is_up_to_date":               false,
+				"name":                        "",
+				"next_upgrade_versions":       []string(nil),
+				"nodes_url":                   "",
+				"private_network_id":          "",
+				"region":                      "",
+				"status":                      "",
+				"update_policy":               "",
+				"url":                         "",
+				"version":                     "1.0",
+				kubeClusterProxyModeKey:       "",
+			},
+		},
+		{
+			name: "Expected apiserver customization",
+			fields: fields{
+				ControlPlaneIsUpToDate: false,
+				Id:                     "",
+				IsUpToDate:             false,
+				Name:                   "",
+				NextUpgradeVersions:    nil,
+				NodesUrl:               "",
+				PrivateNetworkId:       "",
+				Region:                 "",
+				Status:                 "",
+				UpdatePolicy:           "",
+				Url:                    "",
+				Version:                "1.0.0",
+				Customization: Customization{
+					APIServer: &APIServer{
+						AdmissionPlugins: &AdmissionPlugins{
+							Enabled:  pointerArray([]string{"foo"}),
+							Disabled: pointerArray([]string{"bar"}),
+						},
+					},
+					KubeProxy: nil,
+				},
+				KubeProxyMode: "",
+			},
+			want: map[string]interface{}{
+				"control_plane_is_up_to_date": false,
+				"id":                          "",
+				"is_up_to_date":               false,
+				"name":                        "",
+				"next_upgrade_versions":       []string(nil),
+				"nodes_url":                   "",
+				"private_network_id":          "",
+				"region":                      "",
+				"status":                      "",
+				"update_policy":               "",
+				"url":                         "",
+				"version":                     "1.0",
+				kubeClusterProxyModeKey:       "",
+				"customization_apiserver": []map[string]interface{}{
+					{
+						"admissionplugins": []map[string]interface{}{
+							{
+								"enabled":  pointerArray([]string{"foo"}),
+								"disabled": pointerArray([]string{"bar"}),
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "IPTables customization with one field",
+			fields: fields{
+				ControlPlaneIsUpToDate: false,
+				Id:                     "",
+				IsUpToDate:             false,
+				Name:                   "",
+				NextUpgradeVersions:    nil,
+				NodesUrl:               "",
+				PrivateNetworkId:       "",
+				Region:                 "",
+				Status:                 "",
+				UpdatePolicy:           "",
+				Url:                    "",
+				Version:                "1.0.0",
+				Customization: Customization{
+					APIServer: nil,
+					KubeProxy: &kubeProxyCustomization{
+						IPTables: &kubeProxyCustomizationIPTables{
+							MinSyncPeriod: strPtr("PT30S"),
+						},
+						IPVS: nil,
+					},
+				},
+				KubeProxyMode: "iptables",
+			},
+			want: map[string]interface{}{
+				"control_plane_is_up_to_date": false,
+				"id":                          "",
+				"is_up_to_date":               false,
+				"name":                        "",
+				"next_upgrade_versions":       []string(nil),
+				"nodes_url":                   "",
+				"private_network_id":          "",
+				"region":                      "",
+				"status":                      "",
+				"update_policy":               "",
+				"url":                         "",
+				"version":                     "1.0",
+				kubeClusterProxyModeKey:       "iptables",
+				"customization_kube_proxy": []map[string]interface{}{
+					{
+						"iptables": []map[string]interface{}{
+							{
+								"min_sync_period": strPtr("PT30S"),
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "IPTables customization",
+			fields: fields{
+				ControlPlaneIsUpToDate: false,
+				Id:                     "",
+				IsUpToDate:             false,
+				Name:                   "",
+				NextUpgradeVersions:    nil,
+				NodesUrl:               "",
+				PrivateNetworkId:       "",
+				Region:                 "",
+				Status:                 "",
+				UpdatePolicy:           "",
+				Url:                    "",
+				Version:                "1.0.0",
+				Customization: Customization{
+					APIServer: nil,
+					KubeProxy: &kubeProxyCustomization{
+						IPTables: &kubeProxyCustomizationIPTables{
+							MinSyncPeriod: strPtr("PT30S"),
+							SyncPeriod:    strPtr("PT30S"),
+						},
+						IPVS: nil,
+					},
+				},
+				KubeProxyMode: "iptables",
+			},
+			want: map[string]interface{}{
+				"control_plane_is_up_to_date": false,
+				"id":                          "",
+				"is_up_to_date":               false,
+				"name":                        "",
+				"next_upgrade_versions":       []string(nil),
+				"nodes_url":                   "",
+				"private_network_id":          "",
+				"region":                      "",
+				"status":                      "",
+				"update_policy":               "",
+				"url":                         "",
+				"version":                     "1.0",
+				kubeClusterProxyModeKey:       "iptables",
+				"customization_kube_proxy": []map[string]interface{}{
+					{
+						"iptables": []map[string]interface{}{
+							{
+								"min_sync_period": strPtr("PT30S"),
+								"sync_period":     strPtr("PT30S"),
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "IPVS customization with one field",
+			fields: fields{
+				ControlPlaneIsUpToDate: false,
+				Id:                     "",
+				IsUpToDate:             false,
+				Name:                   "",
+				NextUpgradeVersions:    nil,
+				NodesUrl:               "",
+				PrivateNetworkId:       "",
+				Region:                 "",
+				Status:                 "",
+				UpdatePolicy:           "",
+				Url:                    "",
+				Version:                "1.0.0",
+				Customization: Customization{
+					APIServer: nil,
+					KubeProxy: &kubeProxyCustomization{
+						IPTables: nil,
+						IPVS: &kubeProxyCustomizationIPVS{
+							MinSyncPeriod: strPtr("PT30S"),
+						},
+					},
+				},
+				KubeProxyMode: "ipvs",
+			},
+			want: map[string]interface{}{
+				"control_plane_is_up_to_date": false,
+				"id":                          "",
+				"is_up_to_date":               false,
+				"name":                        "",
+				"next_upgrade_versions":       []string(nil),
+				"nodes_url":                   "",
+				"private_network_id":          "",
+				"region":                      "",
+				"status":                      "",
+				"update_policy":               "",
+				"url":                         "",
+				"version":                     "1.0",
+				kubeClusterProxyModeKey:       "ipvs",
+				"customization_kube_proxy": []map[string]interface{}{
+					{
+						"ipvs": []map[string]interface{}{
+							{
+								"min_sync_period": strPtr("PT30S"),
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "IPVS customization",
+			fields: fields{
+				ControlPlaneIsUpToDate: false,
+				Id:                     "",
+				IsUpToDate:             false,
+				Name:                   "",
+				NextUpgradeVersions:    nil,
+				NodesUrl:               "",
+				PrivateNetworkId:       "",
+				Region:                 "",
+				Status:                 "",
+				UpdatePolicy:           "",
+				Url:                    "",
+				Version:                "1.0.0",
+				Customization: Customization{
+					APIServer: nil,
+					KubeProxy: &kubeProxyCustomization{
+						IPTables: nil,
+						IPVS: &kubeProxyCustomizationIPVS{
+							MinSyncPeriod: strPtr("PT30S"),
+							SyncPeriod:    strPtr("PT30S"),
+							Scheduler:     strPtr("rr"),
+							TCPFinTimeout: strPtr("PT30S"),
+							TCPTimeout:    strPtr("PT30S"),
+							UDPTimeout:    strPtr("PT30S"),
+						},
+					},
+				},
+				KubeProxyMode: "ipvs",
+			},
+			want: map[string]interface{}{
+				"control_plane_is_up_to_date": false,
+				"id":                          "",
+				"is_up_to_date":               false,
+				"name":                        "",
+				"next_upgrade_versions":       []string(nil),
+				"nodes_url":                   "",
+				"private_network_id":          "",
+				"region":                      "",
+				"status":                      "",
+				"update_policy":               "",
+				"url":                         "",
+				"version":                     "1.0",
+				kubeClusterProxyModeKey:       "ipvs",
+				"customization_kube_proxy": []map[string]interface{}{
+					{
+						"ipvs": []map[string]interface{}{
+							{
+								"min_sync_period": strPtr("PT30S"),
+								"sync_period":     strPtr("PT30S"),
+								"scheduler":       strPtr("rr"),
+								"tcp_fin_timeout": strPtr("PT30S"),
+								"tcp_timeout":     strPtr("PT30S"),
+								"udp_timeout":     strPtr("PT30S"),
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			v := CloudProjectKubeResponse{
+				ControlPlaneIsUpToDate: tt.fields.ControlPlaneIsUpToDate,
+				Id:                     tt.fields.Id,
+				IsUpToDate:             tt.fields.IsUpToDate,
+				Name:                   tt.fields.Name,
+				NextUpgradeVersions:    tt.fields.NextUpgradeVersions,
+				NodesUrl:               tt.fields.NodesUrl,
+				PrivateNetworkId:       tt.fields.PrivateNetworkId,
+				Region:                 tt.fields.Region,
+				Status:                 tt.fields.Status,
+				UpdatePolicy:           tt.fields.UpdatePolicy,
+				Url:                    tt.fields.Url,
+				Version:                tt.fields.Version,
+				Customization:          tt.fields.Customization,
+				KubeProxyMode:          tt.fields.KubeProxyMode,
+			}
+
+			got := v.ToMap()
+			if diff := cmp.Diff(tt.want, got); diff != "" {
+				t.Errorf("ToMap() mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}

--- a/website/docs/d/cloud_project_kube.html.markdown
+++ b/website/docs/d/cloud_project_kube.html.markdown
@@ -27,7 +27,7 @@ output "version" {
 
 The following arguments are supported:
 
-* `service_name` - (Optional) The id of the public cloud project. If omitted,
+* `service_name` - The id of the public cloud project. If omitted,
     the `OVH_CLOUD_PROJECT_SERVICE` environment variable is used.
 
 * `kube_id` - The id of the managed kubernetes cluster.
@@ -49,8 +49,20 @@ The following attributes are exported:
 * `status` - Cluster status. Should be normally set to 'READY'.
 * `update_policy` - Cluster update policy. Choose between [ALWAYS_UPDATE,MINIMAL_DOWNTIME,NEVER_UPDATE]'.
 * `url` - Management URL of your cluster.
+* `kube_proxy_mode` - Selected mode for kube-proxy.
 * `customization` - Customer customization object
-    * apiserver - Kubernetes API server customization
-        * admissionplugins - Kubernetes API server admission plugins customization
-            * enabled - Array of admission plugins enabled, default is ["NodeRestriction","AlwaysPulImages"] and only these admission plugins can be enabled at this time.
-            * disabled - Array of admission plugins disabled, default is [] and only AlwaysPulImages can be disabled at this time.
+    * `apiserver` - Kubernetes API server customization
+        * `admissionplugins` - Kubernetes API server admission plugins customization
+            * `enabled` - Array of admission plugins enabled, default is ["NodeRestriction","AlwaysPulImages"] and only these admission plugins can be enabled at this time.
+            * `disabled` - Array of admission plugins disabled, default is [] and only AlwaysPulImages can be disabled at this time.
+  * `kube_proxy` - Kubernetes kube-proxy customization
+    * `iptables` - Kubernetes cluster kube-proxy customization of iptables specific config.
+        * `sync_period` - Minimum period that iptables rules are refreshed, in [RFC3339](https://www.rfc-editor.org/rfc/rfc3339) duration format.
+        * `min_sync_period` - Period that iptables rules are refreshed, in [RFC3339](https://www.rfc-editor.org/rfc/rfc3339) duration format.
+    * `ipvs` - Kubernetes cluster kube-proxy customization of IPVS specific config (durations format is [RFC3339](https://www.rfc-editor.org/rfc/rfc3339) duration.
+        * `sync_period` - Minimum period that IPVS rules are refreshed, in [RFC3339](https://www.rfc-editor.org/rfc/rfc3339) duration format.
+        * `min_sync_period` - Minimum period that IPVS rules are refreshed in [RFC3339](https://www.rfc-editor.org/rfc/rfc3339) duration.
+        * `scheduler` - IPVS scheduler.
+        * `tcp_timeout` - Timeout value used for idle IPVS TCP sessions in [RFC3339](https://www.rfc-editor.org/rfc/rfc3339) duration.
+        * `tcp_fin_timeout` - Timeout value used for IPVS TCP sessions after receiving a FIN in RFC3339 duration.
+        * `udp_timeout` - timeout value used for IPVS UDP packets in [RFC3339](https://www.rfc-editor.org/rfc/rfc3339) duration.

--- a/website/docs/d/cloud_project_kube.html.markdown
+++ b/website/docs/d/cloud_project_kube.html.markdown
@@ -50,19 +50,18 @@ The following attributes are exported:
 * `update_policy` - Cluster update policy. Choose between [ALWAYS_UPDATE,MINIMAL_DOWNTIME,NEVER_UPDATE]'.
 * `url` - Management URL of your cluster.
 * `kube_proxy_mode` - Selected mode for kube-proxy.
-* `customization` - Customer customization object
-    * `apiserver` - Kubernetes API server customization
-        * `admissionplugins` - Kubernetes API server admission plugins customization
-            * `enabled` - Array of admission plugins enabled, default is ["NodeRestriction","AlwaysPulImages"] and only these admission plugins can be enabled at this time.
-            * `disabled` - Array of admission plugins disabled, default is [] and only AlwaysPulImages can be disabled at this time.
-  * `kube_proxy` - Kubernetes kube-proxy customization
-    * `iptables` - Kubernetes cluster kube-proxy customization of iptables specific config.
-        * `sync_period` - Minimum period that iptables rules are refreshed, in [RFC3339](https://www.rfc-editor.org/rfc/rfc3339) duration format.
-        * `min_sync_period` - Period that iptables rules are refreshed, in [RFC3339](https://www.rfc-editor.org/rfc/rfc3339) duration format.
-    * `ipvs` - Kubernetes cluster kube-proxy customization of IPVS specific config (durations format is [RFC3339](https://www.rfc-editor.org/rfc/rfc3339) duration.
-        * `sync_period` - Minimum period that IPVS rules are refreshed, in [RFC3339](https://www.rfc-editor.org/rfc/rfc3339) duration format.
-        * `min_sync_period` - Minimum period that IPVS rules are refreshed in [RFC3339](https://www.rfc-editor.org/rfc/rfc3339) duration.
-        * `scheduler` - IPVS scheduler.
-        * `tcp_timeout` - Timeout value used for idle IPVS TCP sessions in [RFC3339](https://www.rfc-editor.org/rfc/rfc3339) duration.
-        * `tcp_fin_timeout` - Timeout value used for IPVS TCP sessions after receiving a FIN in RFC3339 duration.
-        * `udp_timeout` - timeout value used for IPVS UDP packets in [RFC3339](https://www.rfc-editor.org/rfc/rfc3339) duration.
+* `customization_apiserver` - Kubernetes API server customization
+    * `admissionplugins` - Kubernetes API server admission plugins customization
+      * `enabled` - Array of admission plugins enabled, default is ["NodeRestriction","AlwaysPulImages"] and only these admission plugins can be enabled at this time.
+      * `disabled` - Array of admission plugins disabled, default is [] and only AlwaysPulImages can be disabled at this time.
+* `customization_kube_proxy` - Kubernetes kube-proxy customization
+  * `iptables` - Kubernetes cluster kube-proxy customization of iptables specific config.
+      * `sync_period` - Minimum period that iptables rules are refreshed, in [RFC3339](https://www.rfc-editor.org/rfc/rfc3339) duration format.
+      * `min_sync_period` - Period that iptables rules are refreshed, in [RFC3339](https://www.rfc-editor.org/rfc/rfc3339) duration format.
+  * `ipvs` - Kubernetes cluster kube-proxy customization of IPVS specific config (durations format is [RFC3339](https://www.rfc-editor.org/rfc/rfc3339) duration.
+      * `sync_period` - Minimum period that IPVS rules are refreshed, in [RFC3339](https://www.rfc-editor.org/rfc/rfc3339) duration format.
+      * `min_sync_period` - Minimum period that IPVS rules are refreshed in [RFC3339](https://www.rfc-editor.org/rfc/rfc3339) duration.
+      * `scheduler` - IPVS scheduler.
+      * `tcp_timeout` - Timeout value used for idle IPVS TCP sessions in [RFC3339](https://www.rfc-editor.org/rfc/rfc3339) duration.
+      * `tcp_fin_timeout` - Timeout value used for IPVS TCP sessions after receiving a FIN in RFC3339 duration.
+      * `udp_timeout` - timeout value used for IPVS UDP packets in [RFC3339](https://www.rfc-editor.org/rfc/rfc3339) duration.

--- a/website/docs/d/cloud_project_kube.html.markdown
+++ b/website/docs/d/cloud_project_kube.html.markdown
@@ -42,14 +42,17 @@ The following attributes are exported:
 * `region` - The OVHcloud public cloud region ID of the managed kubernetes cluster.
 * `version` - Kubernetes version of the managed kubernetes cluster.
 * `private_network_id` - OpenStack private network (or vrack) ID to use.
-* `control_plane_is_up_to_date` - True if control-plane is up to date.
-* `is_up_to_date` - True if all nodes and control-plane are up to date.
+* `control_plane_is_up_to_date` - True if control-plane is up-to-date.
+* `is_up_to_date` - True if all nodes and control-plane are up-to-date.
 * `next_upgrade_versions` - Kubernetes versions available for upgrade.
 * `nodes_url` - Cluster nodes URL.
 * `status` - Cluster status. Should be normally set to 'READY'.
 * `update_policy` - Cluster update policy. Choose between [ALWAYS_UPDATE,MINIMAL_DOWNTIME,NEVER_UPDATE]'.
 * `url` - Management URL of your cluster.
 * `kube_proxy_mode` - Selected mode for kube-proxy.
+* `customization` - **Deprecated** (Optional) Use `customization_apiserver` and `customization_kube_proxy` instead. Kubernetes cluster customization
+    * `apiserver` - Kubernetes API server customization
+    * `kube_proxy` - Kubernetes kube-proxy customization
 * `customization_apiserver` - Kubernetes API server customization
     * `admissionplugins` - Kubernetes API server admission plugins customization
       * `enabled` - Array of admission plugins enabled, default is ["NodeRestriction","AlwaysPulImages"] and only these admission plugins can be enabled at this time.

--- a/website/docs/r/cloud_project_kube.html.markdown
+++ b/website/docs/r/cloud_project_kube.html.markdown
@@ -124,11 +124,25 @@ The following arguments are supported:
 * `version` - (Optional) kubernetes version to use.
    Changing this value updates the resource. Defaults to latest available.
 
+* `kube_proxy_mode` - (Optional) Selected mode for kube-proxy.
+   Changing this value recreates the resource.
+
 * `customization` - (Optional) Customer customization object
-  * apiserver - Kubernetes API server customization
-    * admissionplugins - (Optional) Kubernetes API server admission plugins customization
-        * enabled - (Optional) Array of admission plugins enabled, default is ["NodeRestriction","AlwaysPulImages"] and only these admission plugins can be enabled at this time. 
-        * disabled - (Optional) Array of admission plugins disabled, default is [] and only AlwaysPulImages can be disabled at this time.
+  * `apiserver` - Kubernetes API server customization
+    * `admissionplugins` - (Optional) Kubernetes API server admission plugins customization
+        * `enabled` - (Optional) Array of admission plugins enabled, default is ["NodeRestriction","AlwaysPulImages"] and only these admission plugins can be enabled at this time. 
+        * `disabled` - (Optional) Array of admission plugins disabled, default is [] and only AlwaysPulImages can be disabled at this time.
+  * `kube_proxy` - Kubernetes kube-proxy customization
+    * `iptables` - (Optional) Kubernetes cluster kube-proxy customization of iptables specific config (durations format is RFC3339 duration, e.g. `PT60S`)
+        * `sync_period` - (Optional) Minimum period that iptables rules are refreshed, in [RFC3339](https://www.rfc-editor.org/rfc/rfc3339) duration format (e.g. `PT60S`).
+        * `min_sync_period` - (Optional) Period that iptables rules are refreshed, in [RFC3339](https://www.rfc-editor.org/rfc/rfc3339) duration format (e.g. `PT60S`). Must be greater than 0.
+    * `ipvs` - (Optional) Kubernetes cluster kube-proxy customization of IPVS specific config (durations format is [RFC3339](https://www.rfc-editor.org/rfc/rfc3339) duration, e.g. `PT60S`)
+        * `sync_period` - (Optional) Minimum period that IPVS rules are refreshed, in [RFC3339](https://www.rfc-editor.org/rfc/rfc3339) duration format (e.g. `PT60S`).
+        * `min_sync_period` - (Optional) Minimum period that IPVS rules are refreshed in [RFC3339](https://www.rfc-editor.org/rfc/rfc3339) duration (e.g. `PT60S`).
+        * `scheduler` - (Optional) IPVS scheduler.
+        * `tcp_timeout` - (Optional) Timeout value used for idle IPVS TCP sessions in [RFC3339](https://www.rfc-editor.org/rfc/rfc3339) duration (e.g. `PT60S`). The default value is `PT0S`, which preserves the current timeout value on the system.
+        * `tcp_fin_timeout` - (Optional) Timeout value used for IPVS TCP sessions after receiving a FIN in RFC3339 duration (e.g. `PT60S`). The default value is `PT0S`, which preserves the current timeout value on the system.
+        * `udp_timeout` - (Optional) timeout value used for IPVS UDP packets in [RFC3339](https://www.rfc-editor.org/rfc/rfc3339) duration (e.g. `PT60S`). The default value is `PT0S`, which preserves the current timeout value on the system.
 
 * `private_network_id` - (Optional) OpenStack private network (or vrack) ID to use.
    Changing this value delete the resource(including ETCD user data). Defaults - not use private network.

--- a/website/docs/r/cloud_project_kube.html.markdown
+++ b/website/docs/r/cloud_project_kube.html.markdown
@@ -135,19 +135,14 @@ resource "ovh_cloud_project_kube" "mycluster" {
 
 The following arguments are supported:
 
-* `service_name` - (Optional) The id of the public cloud project. If omitted,
-    the `OVH_CLOUD_PROJECT_SERVICE` environment variable is used.
-
+* `service_name` - (Optional) The id of the public cloud project. If omitted, the `OVH_CLOUD_PROJECT_SERVICE` environment variable is used.
 * `name` - (Optional) The name of the kubernetes cluster.
-
-* `region` - a valid OVHcloud public cloud region ID in which the kubernetes
-   cluster will be available. Ex.: "GRA1". Defaults to all public cloud regions.
-   Changing this value recreates the resource.
-
+* `region` - a valid OVHcloud public cloud region ID in which the kubernetes cluster will be available. Ex.: "GRA1". Defaults to all public cloud regions. Changing this value recreates the resource.
 * `version` - (Optional) kubernetes version to use. Changing this value updates the resource. Defaults to the latest available.
-
 * `kube_proxy_mode` - (Optional) Selected mode for kube-proxy. **Changing this value recreates the resource. This will result in the loss of all data stored in the etcd.** Defaults to `iptables`.
-
+* `customization` - **Deprecated** (Optional) Use `customization_apiserver` and `customization_kube_proxy` instead. Kubernetes cluster customization
+  * `apiserver` - Kubernetes API server customization
+  * `kube_proxy` - Kubernetes kube-proxy customization
 * `customization_apiserver` - Kubernetes API server customization
   * `admissionplugins` - (Optional) Kubernetes API server admission plugins customization
       * `enabled` - (Optional) Array of admission plugins enabled, default is ["NodeRestriction","AlwaysPulImages"] and only these admission plugins can be enabled at this time. 
@@ -163,7 +158,6 @@ The following arguments are supported:
       * `tcp_timeout` - (Optional) Timeout value used for idle IPVS TCP sessions in [RFC3339](https://www.rfc-editor.org/rfc/rfc3339) duration (e.g. `PT60S`). The default value is `PT0S`, which preserves the current timeout value on the system.
       * `tcp_fin_timeout` - (Optional) Timeout value used for IPVS TCP sessions after receiving a FIN in RFC3339 duration (e.g. `PT60S`). The default value is `PT0S`, which preserves the current timeout value on the system.
       * `udp_timeout` - (Optional) timeout value used for IPVS UDP packets in [RFC3339](https://www.rfc-editor.org/rfc/rfc3339) duration (e.g. `PT60S`). The default value is `PT0S`, which preserves the current timeout value on the system.
-
 * `private_network_id` - (Optional) OpenStack private network (or vrack) ID to use.
    Changing this value delete the resource(including ETCD user data). Defaults - not use private network.
    
@@ -172,7 +166,6 @@ The following arguments are supported:
 * `private_network_configuration` - (Optional) The private network configuration
   * default_vrack_gateway - If defined, all egress traffic will be routed towards this IP address, which should belong to the private network. Empty string means disabled.
   * private_network_routing_as_default - Defines whether routing should default to using the nodes' private interface, instead of their public interface. Default is false.
-
 * `update_policy` - Cluster update policy. Choose between [ALWAYS_UPDATE, MINIMAL_DOWNTIME, NEVER_UPDATE].
 
 ## Attributes Reference

--- a/website/docs/r/cloud_project_kube.html.markdown
+++ b/website/docs/r/cloud_project_kube.html.markdown
@@ -121,28 +121,25 @@ The following arguments are supported:
    cluster will be available. Ex.: "GRA1". Defaults to all public cloud regions.
    Changing this value recreates the resource.
 
-* `version` - (Optional) kubernetes version to use.
-   Changing this value updates the resource. Defaults to latest available.
+* `version` - (Optional) kubernetes version to use. Changing this value updates the resource. Defaults to the latest available.
 
-* `kube_proxy_mode` - (Optional) Selected mode for kube-proxy.
-   Changing this value recreates the resource.
+* `kube_proxy_mode` - (Optional) Selected mode for kube-proxy. **Changing this value recreates the resource. This will result in the loss of all data stored in the etcd.** Defaults to `iptables`.
 
-* `customization` - (Optional) Customer customization object
-  * `apiserver` - Kubernetes API server customization
-    * `admissionplugins` - (Optional) Kubernetes API server admission plugins customization
-        * `enabled` - (Optional) Array of admission plugins enabled, default is ["NodeRestriction","AlwaysPulImages"] and only these admission plugins can be enabled at this time. 
-        * `disabled` - (Optional) Array of admission plugins disabled, default is [] and only AlwaysPulImages can be disabled at this time.
-  * `kube_proxy` - Kubernetes kube-proxy customization
-    * `iptables` - (Optional) Kubernetes cluster kube-proxy customization of iptables specific config (durations format is RFC3339 duration, e.g. `PT60S`)
-        * `sync_period` - (Optional) Minimum period that iptables rules are refreshed, in [RFC3339](https://www.rfc-editor.org/rfc/rfc3339) duration format (e.g. `PT60S`).
-        * `min_sync_period` - (Optional) Period that iptables rules are refreshed, in [RFC3339](https://www.rfc-editor.org/rfc/rfc3339) duration format (e.g. `PT60S`). Must be greater than 0.
-    * `ipvs` - (Optional) Kubernetes cluster kube-proxy customization of IPVS specific config (durations format is [RFC3339](https://www.rfc-editor.org/rfc/rfc3339) duration, e.g. `PT60S`)
-        * `sync_period` - (Optional) Minimum period that IPVS rules are refreshed, in [RFC3339](https://www.rfc-editor.org/rfc/rfc3339) duration format (e.g. `PT60S`).
-        * `min_sync_period` - (Optional) Minimum period that IPVS rules are refreshed in [RFC3339](https://www.rfc-editor.org/rfc/rfc3339) duration (e.g. `PT60S`).
-        * `scheduler` - (Optional) IPVS scheduler.
-        * `tcp_timeout` - (Optional) Timeout value used for idle IPVS TCP sessions in [RFC3339](https://www.rfc-editor.org/rfc/rfc3339) duration (e.g. `PT60S`). The default value is `PT0S`, which preserves the current timeout value on the system.
-        * `tcp_fin_timeout` - (Optional) Timeout value used for IPVS TCP sessions after receiving a FIN in RFC3339 duration (e.g. `PT60S`). The default value is `PT0S`, which preserves the current timeout value on the system.
-        * `udp_timeout` - (Optional) timeout value used for IPVS UDP packets in [RFC3339](https://www.rfc-editor.org/rfc/rfc3339) duration (e.g. `PT60S`). The default value is `PT0S`, which preserves the current timeout value on the system.
+* `customization_apiserver` - Kubernetes API server customization
+  * `admissionplugins` - (Optional) Kubernetes API server admission plugins customization
+      * `enabled` - (Optional) Array of admission plugins enabled, default is ["NodeRestriction","AlwaysPulImages"] and only these admission plugins can be enabled at this time. 
+      * `disabled` - (Optional) Array of admission plugins disabled, default is [] and only AlwaysPulImages can be disabled at this time.
+* `customization_kube_proxy` - Kubernetes kube-proxy customization
+  * `iptables` - (Optional) Kubernetes cluster kube-proxy customization of iptables specific config (durations format is RFC3339 duration, e.g. `PT60S`)
+      * `sync_period` - (Optional) Minimum period that iptables rules are refreshed, in [RFC3339](https://www.rfc-editor.org/rfc/rfc3339) duration format (e.g. `PT60S`).
+      * `min_sync_period` - (Optional) Period that iptables rules are refreshed, in [RFC3339](https://www.rfc-editor.org/rfc/rfc3339) duration format (e.g. `PT60S`). Must be greater than 0.
+  * `ipvs` - (Optional) Kubernetes cluster kube-proxy customization of IPVS specific config (durations format is [RFC3339](https://www.rfc-editor.org/rfc/rfc3339) duration, e.g. `PT60S`)
+      * `sync_period` - (Optional) Minimum period that IPVS rules are refreshed, in [RFC3339](https://www.rfc-editor.org/rfc/rfc3339) duration format (e.g. `PT60S`).
+      * `min_sync_period` - (Optional) Minimum period that IPVS rules are refreshed in [RFC3339](https://www.rfc-editor.org/rfc/rfc3339) duration (e.g. `PT60S`).
+      * `scheduler` - (Optional) IPVS scheduler.
+      * `tcp_timeout` - (Optional) Timeout value used for idle IPVS TCP sessions in [RFC3339](https://www.rfc-editor.org/rfc/rfc3339) duration (e.g. `PT60S`). The default value is `PT0S`, which preserves the current timeout value on the system.
+      * `tcp_fin_timeout` - (Optional) Timeout value used for IPVS TCP sessions after receiving a FIN in RFC3339 duration (e.g. `PT60S`). The default value is `PT0S`, which preserves the current timeout value on the system.
+      * `udp_timeout` - (Optional) timeout value used for IPVS UDP packets in [RFC3339](https://www.rfc-editor.org/rfc/rfc3339) duration (e.g. `PT60S`). The default value is `PT0S`, which preserves the current timeout value on the system.
 
 * `private_network_id` - (Optional) OpenStack private network (or vrack) ID to use.
    Changing this value delete the resource(including ETCD user data). Defaults - not use private network.
@@ -159,9 +156,9 @@ The following arguments are supported:
 
 The following attributes are exported:
 
-* `control_plane_is_up_to_date` - True if control-plane is up to date.
+* `control_plane_is_up_to_date` - True if control-plane is up-to-date.
 * `id` - Managed Kubernetes Service ID
-* `is_up_to_date` - True if all nodes and control-plane are up to date.
+* `is_up_to_date` - True if all nodes and control-plane are up-to-date.
 * `kubeconfig` - The kubeconfig file. Use this file to connect to your kubernetes cluster.
 * `name` - See Argument Reference above.
 * `next_upgrade_versions` - Kubernetes versions available for upgrade.


### PR DESCRIPTION
- Added a new argument in resource `ovh_cloud_project_kube` called `customization_kube_proxy` to customize whether to use `iptabes` or `ipvs` and related settings
- Add a new argument `kube_proxy_mode` to choose between `iptables` or `ipvs`
- TypeSet `customization.apiserver` is now `customization_apiserver`