### PR TITLE
Fix issue to be able to order with BankAccount or CreditCard

### DIFF
--- a/ovh/data_hosting_privatedatabase_database_test.go
+++ b/ovh/data_hosting_privatedatabase_database_test.go
@@ -24,7 +24,6 @@ data "ovh_order_cart" "mycart" {
 	
   resource "ovh_hosting_privatedatabase" "database" {
 	ovh_subsidiary = data.ovh_order_cart.mycart.ovh_subsidiary
-	payment_mean   = "ovh-account"
 	display_name   = "%s"
   
 	plan {

--- a/ovh/data_hosting_privatedatabase_test.go
+++ b/ovh/data_hosting_privatedatabase_test.go
@@ -24,7 +24,6 @@ data "ovh_order_cart" "mycart" {
 	
   resource "ovh_hosting_privatedatabase" "database" {
 	ovh_subsidiary = data.ovh_order_cart.mycart.ovh_subsidiary
-	payment_mean   = "ovh-account"
 	display_name   = "%s"
   
 	plan {

--- a/ovh/data_hosting_privatedatabase_user_grant_test.go
+++ b/ovh/data_hosting_privatedatabase_user_grant_test.go
@@ -24,7 +24,6 @@ data "ovh_order_cart" "mycart" {
 	
   resource "ovh_hosting_privatedatabase" "database" {
 	ovh_subsidiary = data.ovh_order_cart.mycart.ovh_subsidiary
-	payment_mean   = "ovh-account"
 	display_name   = "%s"
   
 	plan {

--- a/ovh/data_hosting_privatedatabase_user_test.go
+++ b/ovh/data_hosting_privatedatabase_user_test.go
@@ -24,7 +24,6 @@ data "ovh_order_cart" "mycart" {
 	
   resource "ovh_hosting_privatedatabase" "database" {
 	ovh_subsidiary = data.ovh_order_cart.mycart.ovh_subsidiary
-	payment_mean   = "ovh-account"
 	display_name   = "%s"
   
 	plan {

--- a/ovh/data_hosting_privatedatabase_whitelist_test.go
+++ b/ovh/data_hosting_privatedatabase_whitelist_test.go
@@ -24,7 +24,6 @@ data "ovh_order_cart_product_plan" "database" {
 	
 resource "ovh_hosting_privatedatabase" "database" {
 	ovh_subsidiary = data.ovh_order_cart.mycart.ovh_subsidiary
-	payment_mean   = "ovh-account"
 	display_name   = "%s"
   
 	plan {

--- a/ovh/data_ip_service_test.go
+++ b/ovh/data_ip_service_test.go
@@ -23,7 +23,6 @@ data "ovh_order_cart_product_plan" "ipblock" {
 
 resource "ovh_ip_service" "ipblock" {
   ovh_subsidiary = data.ovh_order_cart.mycart.ovh_subsidiary
-  payment_mean   = "ovh-account"
   description   = "%s"
 
  plan {

--- a/ovh/data_me_paymentmean_bankaccount.go
+++ b/ovh/data_me_paymentmean_bankaccount.go
@@ -60,6 +60,7 @@ func dataSourceMePaymentmeanBankaccount() *schema.Resource {
 				Computed: true,
 			},
 		},
+		DeprecationMessage: "paymentmean API is deprecated. In order process, the account default payment method is used.",
 	}
 }
 

--- a/ovh/data_me_paymentmean_creditcard.go
+++ b/ovh/data_me_paymentmean_creditcard.go
@@ -62,6 +62,7 @@ func dataSourceMePaymentmeanCreditcard() *schema.Resource {
 				Computed: true,
 			},
 		},
+		DeprecationMessage: "paymentmean API is deprecated. In order process, the account default payment method is used.",
 	}
 }
 

--- a/ovh/resource_cloud_project_test.go
+++ b/ovh/resource_cloud_project_test.go
@@ -29,8 +29,7 @@ data "ovh_order_cart_product_plan" "cloud" {
 resource "ovh_cloud_project" "cloud" {
  ovh_subsidiary = data.ovh_order_cart.mycart.ovh_subsidiary
  description    = "%s"
- payment_mean   = "fidelity"
-
+ 
  plan {
    duration     = data.ovh_order_cart_product_plan.cloud.selected_price.0.duration
    plan_code    = data.ovh_order_cart_product_plan.cloud.plan_code

--- a/ovh/resource_domain_zone_test.go
+++ b/ovh/resource_domain_zone_test.go
@@ -28,7 +28,6 @@ data "ovh_order_cart_product_plan" "zone" {
 
 resource "ovh_domain_zone" "zone" {
  ovh_subsidiary = data.ovh_order_cart.mycart.ovh_subsidiary
- payment_mean   = "fidelity"
 
  plan {
    duration     = data.ovh_order_cart_product_plan.zone.selected_price.0.duration

--- a/ovh/resource_hosting_privatedatabase_test.go
+++ b/ovh/resource_hosting_privatedatabase_test.go
@@ -28,7 +28,6 @@ data "ovh_order_cart_product_plan" "database" {
   
 resource "ovh_hosting_privatedatabase" "database" {
   ovh_subsidiary = data.ovh_order_cart.mycart.ovh_subsidiary
-  payment_mean   = "ovh-account"
   display_name   = "%s"
 
   plan {

--- a/ovh/resource_ip_service_test.go
+++ b/ovh/resource_ip_service_test.go
@@ -28,7 +28,6 @@ data "ovh_order_cart_product_plan" "ipblock" {
 
 resource "ovh_ip_service" "ipblock" {
   ovh_subsidiary = data.ovh_order_cart.mycart.ovh_subsidiary
-  payment_mean   = "ovh-account"
   description   = "%s"
 
  plan {

--- a/ovh/resource_iploadbalancing_test.go
+++ b/ovh/resource_iploadbalancing_test.go
@@ -37,7 +37,6 @@ data "ovh_order_cart_product_options_plan" "bhs" {
 resource "ovh_iploadbalancing" "iplb-lb1" {
  ovh_subsidiary = data.ovh_order_cart.mycart.ovh_subsidiary
  display_name   = "%s"
- payment_mean   = "ovh-account"
 
  plan {
    duration     = data.ovh_order_cart_product_plan.iplb.selected_price.0.duration
@@ -57,7 +56,6 @@ const testAccIpLoadbalancingInternal = `
 resource "ovh_iploadbalancing" "iplb-internal" {
  ovh_subsidiary = "fr"
  display_name   = "%s"
- payment_mean   = "fidelity"
 
  plan {
    catalog_name = "iplb_private_beta"

--- a/ovh/resource_vrack_ip_test.go
+++ b/ovh/resource_vrack_ip_test.go
@@ -30,7 +30,6 @@ resource "ovh_vrack" "vrack" {
  description    = data.ovh_order_cart.mycart.description
  name           = data.ovh_order_cart.mycart.description
  ovh_subsidiary = data.ovh_order_cart.mycart.ovh_subsidiary
- payment_mean   = "fidelity"
 
  plan {
    duration     = data.ovh_order_cart_product_plan.vrack.selected_price.0.duration
@@ -48,7 +47,6 @@ data "ovh_order_cart_product_plan" "ipblock" {
 
 resource "ovh_ip_service" "ipblock" {
   ovh_subsidiary = data.ovh_order_cart.mycart.ovh_subsidiary
-  payment_mean   = "ovh-account"
   description    = data.ovh_order_cart.mycart.description
 
   plan {

--- a/ovh/resource_vrack_test.go
+++ b/ovh/resource_vrack_test.go
@@ -24,7 +24,6 @@ data "ovh_order_cart_product_plan" "vrack" {
 resource "ovh_vrack" "vrack" {
  ovh_subsidiary = data.ovh_order_cart.mycart.ovh_subsidiary
  name          = "%s"
- payment_mean  = "fidelity"
  description   = "%s"
 
  plan {

--- a/ovh/types_me_order.go
+++ b/ovh/types_me_order.go
@@ -34,3 +34,9 @@ type MeOrderPaymentOpts struct {
 	PaymentMean   string `json:"paymentMean"`
 	PaymentMeanId *int64 `json:"paymentMeanId,omitEmpty"`
 }
+type MeOrderPaymentMethodOpts struct {
+	PaymentMethod PaymentMethod `json:"paymentMethod"`
+}
+type PaymentMethod struct {
+	Id int64 `json:"id"`
+}

--- a/website/docs/r/cloud_project.html.markdown
+++ b/website/docs/r/cloud_project.html.markdown
@@ -32,7 +32,6 @@ data "ovh_order_cart_product_plan" "cloud" {
 resource "ovh_cloud_project" "my_cloud_project" {
   ovh_subsidiary = data.ovh_order_cart.mycart.ovh_subsidiary
   description    = "my cloud project"
-  payment_mean   = "fidelity"
 
   plan {
     duration     = data.ovh_order_cart_product_plan.cloud.selected_price.0.duration
@@ -48,7 +47,6 @@ The following arguments are supported:
 
 * `description` - A description associated with the user.
 * `ovh_subsidiary` - (Required) OVHcloud Subsidiary
-* `payment_mean` - (Required) OVHcloud payment mode (One of "default-payment-mean", "fidelity", "ovh-account")
 * `plan` - (Required) Product Plan to order
   * `duration` - (Required) duration
   * `plan_code` - (Required) Plan code

--- a/website/docs/r/hosting_privatedatabase.html.markdown
+++ b/website/docs/r/hosting_privatedatabase.html.markdown
@@ -27,7 +27,6 @@ data "ovh_order_cart_product_plan" "database" {
 
 resource "ovh_hosting_privatedatabase" "database" {
   ovh_subsidiary = data.ovh_order_cart.mycart.ovh_subsidiary
-  payment_mean   = "ovh-account"
   display_name   = "Postgresql-12"
 
   plan {
@@ -58,7 +57,6 @@ The following arguments are supported:
 
 * `description` - Custom description on your privatedatabase order.
 * `ovh_subsidiary` - (Required) OVHcloud Subsidiary
-* `payment_mean` - (Required) OVHcloud payment mode (One of "default-payment-mean", "fidelity", "ovh-account")
 * `plan` - (Required) Product Plan to order
   * `duration` - (Required) duration.
   * `plan_code` - (Required) Plan code.
@@ -93,7 +91,6 @@ The following attributes are exported:
     * `quantity` - quantity
 * `quantity` - quantity
 * `ovh_subsidiary` - OVHcloud Subsidiary
-* `payment_mean` - OVHcloud payment mode
 * `plan` - Product Plan
   * `catalog_name` - Catalog name
   * `configuration` - Representation of a configuration item for personalizing product

--- a/website/docs/r/ip_service.html.markdown
+++ b/website/docs/r/ip_service.html.markdown
@@ -38,7 +38,6 @@ data "ovh_order_cart_product_plan" "ipblock" {
 
 resource "ovh_ip_service" "ipblock" {
   ovh_subsidiary = data.ovh_order_cart.mycart.ovh_subsidiary
-  payment_mean   = "ovh-account"
   description    = "my ip block"
 
  plan {
@@ -60,7 +59,6 @@ The following arguments are supported:
 
 * `description` - Custom description on your ip.
 * `ovh_subsidiary` - (Required) OVHcloud Subsidiary
-* `payment_mean` - (Required) OVHcloud payment mode (One of "default-payment-mean", "fidelity", "ovh-account")
 * `plan` - (Required) Product Plan to order
   * `duration` - (Required) duration
   * `plan_code` - (Required) Plan code

--- a/website/docs/r/iploadbalancing.html.markdown
+++ b/website/docs/r/iploadbalancing.html.markdown
@@ -43,7 +43,6 @@ data "ovh_order_cart_product_options_plan" "bhs" {
 resource "ovh_iploadbalancing" "iplb-lb1" {
   ovh_subsidiary = data.ovh_order_cart.mycart.ovh_subsidiary
   display_name   = "my ip loadbalancing"
-  payment_mean   = "ovh-account"
 
   plan {
     duration     = data.ovh_order_cart_product_plan.iplb.selected_price.0.duration
@@ -65,7 +64,6 @@ The following arguments are supported:
 
 * `display_name` - Set the name displayed in ManagerV6 for your iplb (max 50 chars)
 * `ovh_subsidiary` - (Required) OVHcloud Subsidiary
-* `payment_mean` - (Required) OVHcloud payment mode (One of "default-payment-mean", "fidelity", "ovh-account")
 * `plan` - (Required) Product Plan to order
   * `duration` - (Required) duration
   * `plan_code` - (Required) Plan code

--- a/website/docs/r/ovh_domain_zone.html.markdown
+++ b/website/docs/r/ovh_domain_zone.html.markdown
@@ -30,7 +30,6 @@ data "ovh_order_cart_product_plan" "zone" {
 
 resource "ovh_domain_zone" "zone" {
   ovh_subsidiary = data.ovh_order_cart.mycart.ovh_subsidiary
-  payment_mean   = "fidelity"
 
   plan {
     duration     = data.ovh_order_cart_product_plan.zone.selected_price.0.duration
@@ -55,7 +54,6 @@ resource "ovh_domain_zone" "zone" {
 The following arguments are supported:
 
 * `ovh_subsidiary` - (Required) OVHcloud Subsidiary
-* `payment_mean` - (Required) OVHcloud payment mode (One of "default-payment-mean", "fidelity", "ovh-account")
 * `plan` - (Required) Product Plan to order
   * `duration` - (Required) duration
   * `plan_code` - (Required) Plan code

--- a/website/docs/r/vrack.html.markdown
+++ b/website/docs/r/vrack.html.markdown
@@ -34,7 +34,6 @@ data "ovh_order_cart_product_plan" "vrack" {
 resource "ovh_vrack" "vrack" {
   ovh_subsidiary = data.ovh_order_cart.mycart.ovh_subsidiary
   name           = "my vrack"
-  payment_mean   = "fidelity"
   description    = "my vrack"
 
   plan {
@@ -51,7 +50,6 @@ The following arguments are supported:
 * `description` - yourvrackdescription
 * `name` - yourvrackname
 * `ovh_subsidiary` - (Required) OVHcloud Subsidiary
-* `payment_mean` - (Required) OVHcloud payment mode (One of "default-payment-mean", "fidelity", "ovh-account")
 * `plan` - (Required) Product Plan to order
   * `duration` - (Required) duration
   * `plan_code` - (Required) Plan code

--- a/website/docs/r/vrack_ip.html.markdown
+++ b/website/docs/r/vrack_ip.html.markdown
@@ -29,7 +29,6 @@ resource "ovh_vrack" "vrack" {
   description    = data.ovh_order_cart.mycart.description
   name           = data.ovh_order_cart.mycart.description
   ovh_subsidiary = data.ovh_order_cart.mycart.ovh_subsidiary
-  payment_mean   = "fidelity"
 
   plan {
     duration     = data.ovh_order_cart_product_plan.vrack.selected_price.0.duration
@@ -47,7 +46,6 @@ data "ovh_order_cart_product_plan" "ipblock" {
 
 resource "ovh_ip_service" "ipblock" {
   ovh_subsidiary = data.ovh_order_cart.mycart.ovh_subsidiary
-  payment_mean   = "ovh-account"
   description    = data.ovh_order_cart.mycart.description
 
   plan {


### PR DESCRIPTION
# Description
The issue has been raised [here](https://github.com/ovh/terraform-provider-ovh/issues/376) 


## Type of change
- [ x] Bug fix (non-breaking change which fixes an issue)

After investigation, the API route [/me/paymentMean/bankAccount](https://api.ovh.com/console/#/me/paymentMean/bankAccount~GET) is deprecated and [/me/paymentMean/creditCard](https://api.ovh.com/console/#/me/paymentMean/creditCard~GET) will be soon. 

The following [/me/payment/method](https://api.ovh.com/console/#/me/payment/method~GET) is replacing these.

The attribute `payment_mean` has been set as deprecated and the documentation has been updated accordingly. 

Note that to simplify the implementation, the order now uses the default payment method defined by the account. The terraform user cannot choose a specific payment method.

# How Has This Been Tested?

- [ ] Test A: `make testacc TESTARGS="-run TestAccDataSourceHostingPrivateDatabase_basic"`
- [ ] Test B: `OVH_TESTACC_ORDER_CLOUD_PROJECT=1 make testacc TESTARGS="-run TestAccResourceCloudProject_basic"`

with multiple configuration :  credit card, bank account and Deferred payment account

**Test Configuration**:
* Terraform version: `terraform version`: Terraform v1.3.7

# Checklist:

- [ x] My code follows the style guidelines of this project
- [ x] I have performed a self-review of my code
- [ x] I have commented my code, particularly in hard-to-understand areas
- [ x] I have made corresponding changes to the documentation
- [ x] My changes generate no new warnings or issues
- [ x] I have added acceptance tests that prove my fix is effective or that my feature works
- [ x] New and existing acceptance tests pass locally with my changes
- [ x] I ran succesfully `go mod vendor` if I added or modify `go.mod` file
