### PR TITLE
Fix workflow backup resource name that was wrong in the doc page

### DIFF
--- a/website/docs/r/cloud_project_workflow_backup.html.markdown
+++ b/website/docs/r/cloud_project_workflow_backup.html.markdown
@@ -6,7 +6,7 @@ description: |-
   Manage a workflow that schedules backups of public cloud instance 
 ---
 
-# ovh_cloud_project_user
+# ovh_cloud_project_workflow_backup
 
 Manage a worflow that schedules backups of public cloud instance.
 Note that upon deletion, the workflow is deleted but any backups that have been created by this workflow are not. 


### PR DESCRIPTION
# Description
Name of the resource was wrong 

## Type of change

- [ x] Documentation update

# How Has This Been Tested?
N/A


# Checklist:
N/A
