### PR TITLE
Update separator for  ip reverse import test 

### DIFF
--- a/ovh/resource_ip_reverse_test.go
+++ b/ovh/resource_ip_reverse_test.go
@@ -122,7 +122,7 @@ func testAccIpReverseImportId(resourceName string) resource.ImportStateIdFunc {
 		}
 
 		return fmt.Sprintf(
-			"%s:%s",
+			"%s|%s",
 			subnet.Primary.Attributes["ip"],
 			subnet.Primary.Attributes["ip_reverse"],
 		), nil

--- a/website/docs/r/ip_reverse.html.markdown
+++ b/website/docs/r/ip_reverse.html.markdown
@@ -35,8 +35,8 @@ The id is set to the value of ip_reverse.
 
 ## Import
 
-The resource can be imported using the `ip`, `ip_reverse` of the address, separated by "|" E.g.,
+The resource can be imported using the `ip`, `ip_reverse` of the address, separated by ":" E.g.,
 
 ```bash
-$ terraform import ovh_ip_reverse.my_reverse '2001:0db8:c0ff:ee::/64|2001:0db8:c0ff:ee::42'
+$ terraform import ovh_ip_reverse.my_reverse '192.0.2.0/24:192.0.2.1'
 ```

--- a/website/docs/r/ip_reverse.html.markdown
+++ b/website/docs/r/ip_reverse.html.markdown
@@ -35,8 +35,8 @@ The id is set to the value of ip_reverse.
 
 ## Import
 
-The resource can be imported using the `ip`, `ip_reverse` of the address, separated by ":" E.g.,
+The resource can be imported using the `ip`, `ip_reverse` of the address, separated by "|" E.g.,
 
 ```bash
-$ terraform import ovh_ip_reverse.my_reverse '192.0.2.0/24:192.0.2.1'
+$ terraform import ovh_ip_reverse.my_reverse '2001:0db8:c0ff:ee::/64|2001:0db8:c0ff:ee::42'
 ```


### PR DESCRIPTION
# Description
Separator for import have been updated from `:` to `|` 
However the test TestAccIpReverse_importBasic was still using `:` so was failing
Related to #380  

## Type of change

- [ x] (Test) Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [ ] Test A: `TF_LOG=DEBUG make testacc TESTARGS="-run TestAccIpReverse_importBasic"`


