### PR TITLE
fix(doc) Add base64 decode

### DIFF
--- a/website/docs/r/cloud_project_kube.html.markdown
+++ b/website/docs/r/cloud_project_kube.html.markdown
@@ -81,9 +81,9 @@ resource "ovh_cloud_project_kube" "mycluster" {
 provider "helm" {
   kubernetes {
     host                    = ovh_cloud_project_kube.mycluster.kubeconfig_attributes[0].host
-    client_certificate      = ovh_cloud_project_kube.mycluster.kubeconfig_attributes[0].client_certificate
-    client_key              = ovh_cloud_project_kube.mycluster.kubeconfig_attributes[0].client_key
-    cluster_ca_certificate  = ovh_cloud_project_kube.mycluster.kubeconfig_attributes[0].cluster_ca_certificate
+    client_certificate      = base64decode(ovh_cloud_project_kube.mycluster.kubeconfig_attributes[0].client_certificate)
+    client_key              = base64decode(ovh_cloud_project_kube.mycluster.kubeconfig_attributes[0].client_key)
+    cluster_ca_certificate  = base64decode(ovh_cloud_project_kube.mycluster.kubeconfig_attributes[0].cluster_ca_certificate)
   }
 }
 


### PR DESCRIPTION
# Description

The certificate attributes of the kubeconfig are base64 encoded. Therefore you can't use them as is with the Helm provider and you need to base64 decode them before use.

## Type of change

- [x] Documentation update
