### PR TITLE
fix(docs) ovh_domain_zone_record: remove quote for ttl value in example

### DIFF
--- a/website/docs/r/ovh_domain_zone_record.html.markdown
+++ b/website/docs/r/ovh_domain_zone_record.html.markdown
@@ -18,7 +18,7 @@ resource "ovh_domain_zone_record" "test" {
   zone      = "testdemo.ovh"
   subdomain = "test"
   fieldtype = "A"
-  ttl       = "3600"
+  ttl       = 3600
   target    = "0.0.0.0"
 }
 ```


### PR DESCRIPTION
It should be an int but example can be misleading.

# Description

Updating example inside documentation for ttl value in ovh_domain_zone_record.

## Type of change

Please delete options that are not relevant.
- Documentation update


