### PR TITLE
Validate TTL in zone_record to >=60

### DIFF
--- a/ovh/resource_domain_zone_record.go
+++ b/ovh/resource_domain_zone_record.go
@@ -75,7 +75,7 @@ func resourceOvhDomainZoneRecord() *schema.Resource {
 				ValidateFunc: func(val interface{}, key string) (warns []string, errs []error) {
 					v := val.(int)
 					if v < 60 {
-						errs = append(errs, fmt.Errorf("%q must be above 60 inclusive, got: %d", key, v))
+						errs = append(errs, fmt.Errorf("%q must be greater than or equal to 60, got: %d", key, v))		
 					}
 					return
 				},

--- a/ovh/resource_domain_zone_record.go
+++ b/ovh/resource_domain_zone_record.go
@@ -72,6 +72,13 @@ func resourceOvhDomainZoneRecord() *schema.Resource {
 				Type:     schema.TypeInt,
 				Optional: true,
 				Default:  3600,
+				ValidateFunc: func(val interface{}, key string) (warns []string, errs []error) {
+					v := val.(int)
+					if v < 60 {
+						errs = append(errs, fmt.Errorf("%q must be above 60 inclusive, got: %d", key, v))
+					}
+					return
+				},
 			},
 			"fieldtype": {
 				Type:     schema.TypeString,

--- a/ovh/resource_domain_zone_record.go
+++ b/ovh/resource_domain_zone_record.go
@@ -75,7 +75,7 @@ func resourceOvhDomainZoneRecord() *schema.Resource {
 				ValidateFunc: func(val interface{}, key string) (warns []string, errs []error) {
 					v := val.(int)
 					if v < 60 {
-						errs = append(errs, fmt.Errorf("%q must be greater than or equal to 60, got: %d", key, v))		
+						errs = append(errs, fmt.Errorf("%q must be greater than or equal to 60, got: %d", key, v))
 					}
 					return
 				},

--- a/ovh/resource_domain_zone_record_test.go
+++ b/ovh/resource_domain_zone_record_test.go
@@ -108,7 +108,7 @@ func TestAccDomainZoneRecord_Basic(t *testing.T) {
 			// provider shall send an error if the TTL is less than 60
 			{
 				Config:      testAccCheckOvhDomainZoneRecordConfig_CNAME(zone, subdomain, "google.com.", 10),
-				ExpectError: regexp.MustCompile(`must be above`),
+				ExpectError: regexp.MustCompile(`must be greater`),
 			},
 			{
 				Config: testAccCheckOvhDomainZoneRecordConfig_A(zone, subdomain, "192.168.0.10", 3600),

--- a/ovh/resource_domain_zone_record_test.go
+++ b/ovh/resource_domain_zone_record_test.go
@@ -6,12 +6,14 @@ import (
 	"strconv"
 	"testing"
 
+	"log"
+	"regexp"
+	"strings"
+	"time"
+
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"log"
-	"strings"
-	"time"
 )
 
 func init() {
@@ -103,6 +105,11 @@ func TestAccDomainZoneRecord_Basic(t *testing.T) {
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckOvhDomainZoneRecordDestroy,
 		Steps: []resource.TestStep{
+			// provider shall send an error if the TTL is less than 60
+			{
+				Config:      testAccCheckOvhDomainZoneRecordConfig_CNAME(zone, subdomain, "google.com.", 10),
+				ExpectError: regexp.MustCompile(`must be above`),
+			},
 			{
 				Config: testAccCheckOvhDomainZoneRecordConfig_A(zone, subdomain, "192.168.0.10", 3600),
 				Check: resource.ComposeTestCheckFunc(

--- a/website/docs/r/ovh_domain_zone_record.html.markdown
+++ b/website/docs/r/ovh_domain_zone_record.html.markdown
@@ -31,7 +31,7 @@ The following arguments are supported:
 * `subdomain` - (Required) The name of the record
 * `target` - (Required) The value of the record
 * `fieldtype` - (Required) The type of the record
-* `ttl` - (Optional) The TTL of the record
+* `ttl` - (Optional) The TTL of the record, it shall be >= to 60.
 
 
 ## Attributes Reference


### PR DESCRIPTION
# Description

the zone record route sets the TTL to 60 (and return 200) even if the request contains a value below. This cause terraform to update the record at each `apply`.

This patch validates that the TTL set by the user in his script is >= to 60.

## Type of change

Please delete options that are not relevant.
- [x ] Bug fix (non-breaking change which fixes an issue)

This will be a breaking for user that set TTL to a value below 60. However, in that case, their value is not set since the server set the value to 60 

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [X ] Test A: `make testacc TESTARGS="-run TestAccDomainZoneRecord_Basic"`

# Checklist:

- [x ] My code follows the style guidelines of this project
- [ x] I have performed a self-review of my code
- [ x] I have commented my code, particularly in hard-to-understand areas
- [ x] I have made corresponding changes to the documentation
- [ x] My changes generate no new warnings or issues
- [ x] I have added acceptance tests that prove my fix is effective or that my feature works
- [ x] New and existing acceptance tests pass locally with my changes => TestAccDomainZoneRecord_updateType TestAccDomainZoneRecord_Updated
- [x ] I ran succesfully `go mod vendor` if I added or modify `go.mod` file
