### PR TITLE
fix(iplb): service_name instead of id

### DIFF
--- a/website/docs/r/iploadbalancing_http_farm.html.markdown
+++ b/website/docs/r/iploadbalancing_http_farm.html.markdown
@@ -19,7 +19,7 @@ data "ovh_iploadbalancing" "lb" {
 }
 
 resource "ovh_iploadbalancing_http_farm" "farmname" {
-  service_name = "${data.ovh_iploadbalancing.lb.id}"
+  service_name = "${data.ovh_iploadbalancing.lb.service_name}"
   display_name = "ingress-8080-gra"
   zone         = "GRA"
 }

--- a/website/docs/r/iploadbalancing_http_farm_server.html.markdown
+++ b/website/docs/r/iploadbalancing_http_farm_server.html.markdown
@@ -19,13 +19,13 @@ data "ovh_iploadbalancing" "lb" {
 }
 
 resource "ovh_iploadbalancing_http_farm" "farmname" {
-  service_name = "${data.ovh_iploadbalancing.lb.id}"
+  service_name = "${data.ovh_iploadbalancing.lb.service_name}"
   port         = 8080
   zone         = "all"
 }
 
 resource "ovh_iploadbalancing_http_farm_server" "backend" {
-  service_name           = "${data.ovh_iploadbalancing.lb.id}"
+  service_name           = "${data.ovh_iploadbalancing.lb.service_name}"
   farm_id                = "${ovh_iploadbalancing_http_farm.farmname.id}"
   display_name           = "mybackend"
   address                = "4.5.6.7"

--- a/website/docs/r/iploadbalancing_refresh.html.markdown
+++ b/website/docs/r/iploadbalancing_refresh.html.markdown
@@ -19,13 +19,13 @@ data "ovh_iploadbalancing" "lb" {
 }
 
 resource "ovh_iploadbalancing_tcp_farm" "farmname" {
-  service_name = "${data.ovh_iploadbalancing.lb.id}"
+  service_name = "${data.ovh_iploadbalancing.lb.service_name}"
   port         = 8080
   zone         = "all"
 }
 
 resource "ovh_iploadbalancing_tcp_farm_server" "backend" {
-  service_name           = "${data.ovh_iploadbalancing.lb.id}"
+  service_name           = "${data.ovh_iploadbalancing.lb.service_name}"
   farm_id                = "${ovh_iploadbalancing_tcp_farm.farmname.id}"
   display_name           = "mybackend"
   address                = "4.5.6.7"
@@ -39,7 +39,7 @@ resource "ovh_iploadbalancing_tcp_farm_server" "backend" {
 }
 
 resource "ovh_iploadbalancing_refresh" "mylb" {
-  service_name = "${data.ovh_iploadbalancing.lb.id}"
+  service_name = "${data.ovh_iploadbalancing.lb.service_name}"
   keepers = [
     "${ovh_iploadbalancing_tcp_farm_server.backend.*.address}",
   ]

--- a/website/docs/r/iploadbalancing_tcp_farm.html.markdown
+++ b/website/docs/r/iploadbalancing_tcp_farm.html.markdown
@@ -19,7 +19,7 @@ data "ovh_iploadbalancing" "lb" {
 }
 
 resource "ovh_iploadbalancing_tcp_farm" "farmname" {
-  service_name = "${data.ovh_iploadbalancing.lb.id}"
+  service_name = "${data.ovh_iploadbalancing.lb.service_name}"
   display_name = "ingress-8080-gra"
   zone         = "GRA"
 }

--- a/website/docs/r/iploadbalancing_tcp_farm_server.html.markdown
+++ b/website/docs/r/iploadbalancing_tcp_farm_server.html.markdown
@@ -19,13 +19,13 @@ data "ovh_iploadbalancing" "lb" {
 }
 
 resource "ovh_iploadbalancing_tcp_farm" "farmname" {
-  service_name = "${data.ovh_iploadbalancing.lb.id}"
+  service_name = "${data.ovh_iploadbalancing.lb.service_name}"
   port         = 8080
   zone         = "all"
 }
 
 resource "ovh_iploadbalancing_tcp_farm_server" "backend" {
-  service_name           = "${data.ovh_iploadbalancing.lb.id}"
+  service_name           = "${data.ovh_iploadbalancing.lb.service_name}"
   farm_id                = "${ovh_iploadbalancing_tcp_farm.farmname.id}"
   display_name           = "mybackend"
   address                = "4.5.6.7"


### PR DESCRIPTION
# Description

This fix documentation issues around ovh_iploadbalancing. At several places, examples were providing load balancer ID, while the provider expects service name.

This change aims at fixing that and enabling basic copy paste to have examples working.

## Type of change

- [x] Documentation update

# How Has This Been Tested?

No tests on documentation.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
