### PR TITLE
add grafana user

### DIFF
--- a/ovh/data_cloud_project_database_user.go
+++ b/ovh/data_cloud_project_database_user.go
@@ -22,7 +22,7 @@ func dataSourceCloudProjectDatabaseUser() *schema.Resource {
 				Type:         schema.TypeString,
 				Description:  "Name of the engine of the service",
 				Required:     true,
-				ValidateFunc: helpers.ValidateEnum([]string{"cassandra", "mysql", "kafka", "kafkaConnect"}),
+				ValidateFunc: helpers.ValidateEnum([]string{"cassandra", "mysql", "kafka", "kafkaConnect", "grafana"}),
 			},
 			"cluster_id": {
 				Type:        schema.TypeString,

--- a/ovh/data_cloud_project_database_user_test.go
+++ b/ovh/data_cloud_project_database_user_test.go
@@ -45,6 +45,9 @@ func TestAccCloudProjectDatabaseUserDataSource_basic(t *testing.T) {
 	flavor := os.Getenv("OVH_CLOUD_PROJECT_DATABASE_FLAVOR_TEST")
 	description := acctest.RandomWithPrefix(test_prefix)
 	name := "johndoe"
+	if engine == "grafana" {
+		name = "avnadmin"
+	}
 
 	config := fmt.Sprintf(
 		testAccCloudProjectDatabaseUserDatasourceConfig_Basic,

--- a/ovh/data_cloud_project_database_users_test.go
+++ b/ovh/data_cloud_project_database_users_test.go
@@ -43,6 +43,10 @@ func TestAccCloudProjectDatabaseUsersDataSource_basic(t *testing.T) {
 	region := os.Getenv("OVH_CLOUD_PROJECT_DATABASE_REGION_TEST")
 	flavor := os.Getenv("OVH_CLOUD_PROJECT_DATABASE_FLAVOR_TEST")
 	description := acctest.RandomWithPrefix(test_prefix)
+	name := "johndoe"
+	if engine == "grafana" {
+		name = "avnadmin"
+	}
 
 	config := fmt.Sprintf(
 		testAccCloudProjectDatabaseUsersDatasourceConfig_Basic,
@@ -52,7 +56,7 @@ func TestAccCloudProjectDatabaseUsersDataSource_basic(t *testing.T) {
 		version,
 		region,
 		flavor,
-		"johndoe",
+		name,
 	)
 
 	resource.Test(t, resource.TestCase{

--- a/ovh/resource_cloud_project_database_user.go
+++ b/ovh/resource_cloud_project_database_user.go
@@ -40,7 +40,7 @@ func resourceCloudProjectDatabaseUser() *schema.Resource {
 				Description:  "Name of the engine of the service",
 				ForceNew:     true,
 				Required:     true,
-				ValidateFunc: helpers.ValidateEnum([]string{"cassandra", "mysql", "kafka", "kafkaConnect"}),
+				ValidateFunc: helpers.ValidateEnum([]string{"cassandra", "mysql", "kafka", "kafkaConnect", "grafana"}),
 			},
 			"cluster_id": {
 				Type:        schema.TypeString,

--- a/ovh/resource_cloud_project_database_user_test.go
+++ b/ovh/resource_cloud_project_database_user_test.go
@@ -38,6 +38,9 @@ func TestAccCloudProjectDatabaseUser_basic(t *testing.T) {
 	flavor := os.Getenv("OVH_CLOUD_PROJECT_DATABASE_FLAVOR_TEST")
 	description := acctest.RandomWithPrefix(test_prefix)
 	name := "johndoe"
+	if engine == "grafana" {
+		name = "avnadmin"
+	}
 
 	config := fmt.Sprintf(
 		testAccCloudProjectDatabaseUserConfig,

--- a/ovh/types_cloud_project_database.go
+++ b/ovh/types_cloud_project_database.go
@@ -569,6 +569,9 @@ func postCloudProjectDatabaseUser(d *schema.ResourceData, meta interface{}, engi
 		}
 		return updateFunc(d, meta)
 	}
+	if engine == "grafana" && name != "avnadmin" {
+		return fmt.Errorf("The Grafana engine does not allow to create a user resource other than avnadmin")
+	}
 
 	serviceName := d.Get("service_name").(string)
 	clusterId := d.Get("cluster_id").(string)

--- a/website/docs/d/cloud_project_database_user.html.markdown
+++ b/website/docs/d/cloud_project_database_user.html.markdown
@@ -33,6 +33,7 @@ Available engines:
   * `kafka`
   * `kafkaConnect`
   * `mysql`
+  * `grafana`
 
 * `cluster_id` - (Required) Cluster ID
 

--- a/website/docs/r/cloud_project_database_user.html.markdown
+++ b/website/docs/r/cloud_project_database_user.html.markdown
@@ -6,12 +6,13 @@ subcategory : "Managed Databases"
 
 Creates an user for a database cluster associated with a public cloud project.
 
-With this resource you can create a user for the following database engine:
+With this resource you can create a user and map "avnadmin" for the following database engine:
 
   * `cassandra`
   * `kafka`
   * `kafkaConnect`
   * `mysql`
+  * `grafana`
 
 ## Example Usage
 
@@ -74,10 +75,12 @@ Available engines:
   * `kafka`
   * `kafkaConnect`
   * `mysql`
+  * `grafana`
+
 
 * `cluster_id` - (Required, Forces new resource) Cluster ID.
 
-* `name` - (Required, Forces new resource) Name of the user. A user named "avnadmin" is map with already created admin user and reset his password instead of create a new user.
+* `name` - (Required, Forces new resource) Name of the user. A user named "avnadmin" is map with already created admin user and reset his password instead of create a new user. The "Grafana" engine only allows the "avnadmin" mapping.
 
 * `password_reset` - (Optional) Arbitrary string to change to trigger a password update. Use the `terraform refresh` command after executing `terraform apply` to update the output with the new password.
 


### PR DESCRIPTION
# Description

Manage grafana in the generic database user resources.
Grafana do not allow to create user but now you can map the already created "avnadmin" user with a resource to reset it password

Fixes #407 

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- `make testacc TESTARGS="-run TestAccCloudProjectDatabaseUser_basic"`
- `make testacc TESTARGS="-run TestAccCloudProjectDatabaseUserDataSource_basic"`
- `make testacc TESTARGS="-run TestAccCloudProjectDatabaseUsersDataSource_basic"`

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or issues
- [x] I have added acceptance tests that prove my fix is effective or that my feature works
- [x] New and existing acceptance tests pass locally with my changes
- [x] I ran succesfully `go mod vendor` if I added or modify `go.mod` file
