### PR TITLE
Fix typo on attribute name

### DIFF
--- a/website/docs/d/dedicated_server.html.markdown
+++ b/website/docs/d/dedicated_server.html.markdown
@@ -47,7 +47,7 @@ In addition, the following attributes are exported:
   * `server_name` - Server bound to this VirtualNetworkInterface
   * `uuid` - VirtualNetworkInterface unique id
   * `vrack` - vRack name
-  * `ncis` - NetworkInterfaceControllers bound to this VirtualNetworkInterface
+  * `nics` - NetworkInterfaceControllers bound to this VirtualNetworkInterface
 * `enabled_vrack_vnis` - List of enabled vrack VNI uuids
 * `enabled_vrack_aggregation_vnis` - List of enabled vrack_aggregation VNI uuids
 * `enabled_public_vnis` - List of enabled public VNI uuids


### PR DESCRIPTION
# Description

Fix a typo in documentation

Fixes #xx (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (improve existing resource(s) or datasource(s))
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] Documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A: `make testacc TESTARGS="-run TestAccDataSourceXxxxYyyyZzzzz_basic"`
- [ ] Test B: `make testacc TESTARGS="-run TestAccDataSourceXxxxYyyyZzzzz_basic"`

**Test Configuration**:
* Terraform version: `terraform version`: Terraform vx.y.z
* Existing HCL configuration you used: 
```hcl
resource "" "" {
 xx = "yy"
 zz = "aa"
}
```

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings or issues
- [ ] I have added acceptance tests that prove my fix is effective or that my feature works
- [ ] New and existing acceptance tests pass locally with my changes
- [ ] I ran succesfully `go mod vendor` if I added or modify `go.mod` file
