### PR TITLE
resource_iploadbalancing_tcp_farm_server: skip validate func for prox…

### DIFF
--- a/ovh/resource_iploadbalancing_http_farm_server.go
+++ b/ovh/resource_iploadbalancing_http_farm_server.go
@@ -64,9 +64,11 @@ func resourceIpLoadbalancingHttpFarmServer() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 				ValidateFunc: func(v interface{}, k string) (ws []string, errors []error) {
-					err := helpers.ValidateStringEnum(v.(string), []string{"v1", "v2", "v2-ssl", "v2-ssl-cn"})
-					if err != nil {
-						errors = append(errors, err)
+					if v != nil {
+						err := helpers.ValidateStringEnum(v.(string), []string{"v1", "v2", "v2-ssl", "v2-ssl-cn"})
+						if err != nil {
+							errors = append(errors, err)
+						}
 					}
 					return
 				},

--- a/ovh/resource_iploadbalancing_http_farm_server_test.go
+++ b/ovh/resource_iploadbalancing_http_farm_server_test.go
@@ -318,6 +318,7 @@ func TestAccIpLoadbalancingHttpFarmServerBasic(t *testing.T) {
 					resource.TestCheckResourceAttr(TEST_ACC_IPLOADBALANCING_HTTP_FARM_SRV_RES_NAME, "ssl", "true"),
 					resource.TestCheckResourceAttr(TEST_ACC_IPLOADBALANCING_HTTP_FARM_SRV_RES_NAME, "backup", "true"),
 					resource.TestCheckResourceAttr(TEST_ACC_IPLOADBALANCING_HTTP_FARM_SRV_RES_NAME, "on_marked_down", "shutdown-sessions"),
+					resource.TestCheckNoResourceAttr(TEST_ACC_IPLOADBALANCING_HTTP_FARM_SRV_RES_NAME, "proxy_protocol_version"),
 				),
 			},
 			{

--- a/ovh/resource_iploadbalancing_tcp_farm_server.go
+++ b/ovh/resource_iploadbalancing_tcp_farm_server.go
@@ -60,9 +60,11 @@ func resourceIpLoadbalancingTcpFarmServer() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 				ValidateFunc: func(v interface{}, k string) (ws []string, errors []error) {
-					err := helpers.ValidateStringEnum(v.(string), []string{"v1", "v2", "v2-ssl", "v2-ssl-cn"})
-					if err != nil {
-						errors = append(errors, err)
+					if v != nil {
+						err := helpers.ValidateStringEnum(v.(string), []string{"v1", "v2", "v2-ssl", "v2-ssl-cn"})
+						if err != nil {
+							errors = append(errors, err)
+						}
 					}
 					return
 				},

--- a/ovh/resource_iploadbalancing_tcp_farm_server_test.go
+++ b/ovh/resource_iploadbalancing_tcp_farm_server_test.go
@@ -303,6 +303,7 @@ func TestAccIpLoadbalancingTcpFarmServerBasic(t *testing.T) {
 					resource.TestCheckResourceAttr("ovh_iploadbalancing_tcp_farm_server.testacc", "weight", "1"),
 					resource.TestCheckResourceAttr("ovh_iploadbalancing_tcp_farm_server.testacc", "ssl", "true"),
 					resource.TestCheckResourceAttr("ovh_iploadbalancing_tcp_farm_server.testacc", "backup", "true"),
+					resource.TestCheckNoResourceAttr("ovh_iploadbalancing_tcp_farm_server.testacc", "proxy_protocol_version"),
 				),
 			},
 			{


### PR DESCRIPTION
resource_iploadbalancing_tcp_farm_server: skip validate func for proxy_protocol_version if nil

# Description

Hello, this change skips the validate checks for the proxy_protocol_version on resource_iploadbalancing_tcp_farm_server if the user sends a null argument. 
As [Terraform docs says](https://developer.hashicorp.com/terraform/language/expressions/types#null) the null is used to represent absence or omission. It is typically used with variables so a resource can or can not be configured with the desired argument without using artificial conditions with `count`.
