### PR TITLE
fixes bug in TestAcc for iploadbalancing http/tcp server

### DIFF
--- a/ovh/resource_iploadbalancing_http_farm_server_test.go
+++ b/ovh/resource_iploadbalancing_http_farm_server_test.go
@@ -318,7 +318,6 @@ func TestAccIpLoadbalancingHttpFarmServerBasic(t *testing.T) {
 					resource.TestCheckResourceAttr(TEST_ACC_IPLOADBALANCING_HTTP_FARM_SRV_RES_NAME, "ssl", "true"),
 					resource.TestCheckResourceAttr(TEST_ACC_IPLOADBALANCING_HTTP_FARM_SRV_RES_NAME, "backup", "true"),
 					resource.TestCheckResourceAttr(TEST_ACC_IPLOADBALANCING_HTTP_FARM_SRV_RES_NAME, "on_marked_down", "shutdown-sessions"),
-					resource.TestCheckNoResourceAttr(TEST_ACC_IPLOADBALANCING_HTTP_FARM_SRV_RES_NAME, "proxy_protocol_version"),
 				),
 			},
 			{

--- a/ovh/resource_iploadbalancing_tcp_farm_server_test.go
+++ b/ovh/resource_iploadbalancing_tcp_farm_server_test.go
@@ -303,7 +303,6 @@ func TestAccIpLoadbalancingTcpFarmServerBasic(t *testing.T) {
 					resource.TestCheckResourceAttr("ovh_iploadbalancing_tcp_farm_server.testacc", "weight", "1"),
 					resource.TestCheckResourceAttr("ovh_iploadbalancing_tcp_farm_server.testacc", "ssl", "true"),
 					resource.TestCheckResourceAttr("ovh_iploadbalancing_tcp_farm_server.testacc", "backup", "true"),
-					resource.TestCheckNoResourceAttr("ovh_iploadbalancing_tcp_farm_server.testacc", "proxy_protocol_version"),
 				),
 			},
 			{


### PR DESCRIPTION
Removing the introduced test in #428, it turns out the whole API response is written inside the resource. Including the null values. Which means the TestCheckNoResourceAttr was not fitting. Not replacing it as there's no built-in func that allows for checking that a resource is set while having a nil value.
