### PR TITLE
Fix/427

### DIFF
--- a/ovh/resource_cloud_project_kube_nodepool.go
+++ b/ovh/resource_cloud_project_kube_nodepool.go
@@ -154,7 +154,7 @@ func resourceCloudProjectKubeNodePool() *schema.Resource {
 					Schema: map[string]*schema.Schema{
 						"metadata": {
 							Description: "metadata",
-							Optional:    true,
+							Required:    true,
 							Type:        schema.TypeSet,
 							MaxItems:    1,
 							Set:         CustomSchemaSetFunc(),
@@ -162,20 +162,20 @@ func resourceCloudProjectKubeNodePool() *schema.Resource {
 								Schema: map[string]*schema.Schema{
 									"finalizers": {
 										Description: "finalizers",
-										Optional:    true,
+										Required:    true,
 										Type:        schema.TypeList,
 										Elem:        &schema.Schema{Type: schema.TypeString},
 									},
 									"labels": {
 										Description: "labels",
-										Optional:    true,
+										Required:    true,
 										Type:        schema.TypeMap,
 										Elem:        &schema.Schema{Type: schema.TypeString},
 										Set:         schema.HashString,
 									},
 									"annotations": {
 										Description: "annotations",
-										Optional:    true,
+										Required:    true,
 										Type:        schema.TypeMap,
 										Elem:        &schema.Schema{Type: schema.TypeString},
 										Set:         schema.HashString,
@@ -185,7 +185,7 @@ func resourceCloudProjectKubeNodePool() *schema.Resource {
 						},
 						"spec": {
 							Description: "spec",
-							Optional:    true,
+							Required:    true,
 							Type:        schema.TypeSet,
 							MaxItems:    1,
 							Set:         CustomSchemaSetFunc(),
@@ -193,12 +193,12 @@ func resourceCloudProjectKubeNodePool() *schema.Resource {
 								Schema: map[string]*schema.Schema{
 									"unschedulable": {
 										Description: "unschedulable",
-										Optional:    true,
+										Required:    true,
 										Type:        schema.TypeBool,
 									},
 									"taints": {
 										Description: "taints",
-										Optional:    true,
+										Required:    true,
 										Type:        schema.TypeList,
 										Elem: &schema.Schema{
 											Type: schema.TypeMap,

--- a/ovh/resource_cloud_project_kube_nodepool_test.go
+++ b/ovh/resource_cloud_project_kube_nodepool_test.go
@@ -75,100 +75,113 @@ func testSweepCloudProjectKubeNodePool(region string) error {
 
 var testAccCloudProjectKubeNodePoolConfig = `
 resource "ovh_cloud_project_kube" "cluster" {
-	service_name  = "%s"
-	name          = "%s"
-	region        = "%s"
-	version       = "%s"
+  service_name = "%s"
+  name         = "%s"
+  region       = "%s"
+  version      = "%s"
 }
 
 resource "ovh_cloud_project_kube_nodepool" "pool" {
-	service_name  = ovh_cloud_project_kube.cluster.service_name
-	kube_id       = ovh_cloud_project_kube.cluster.id
-	name          = ovh_cloud_project_kube.cluster.name
-	flavor_name   = "b2-7"
-	desired_nodes = 1
-	min_nodes     = 0
-	max_nodes     = 1
-	template {
-		metadata {
-			annotations = {
-				a1 = "av1"
-			}
-			finalizers = ["finalizer.extensions/v1beta1"]
-			labels = {
-				l1 = "lv1"
-			}
-		}
-		spec {
-			unschedulable = false
-			taints = [
-			{
-				effect = "PreferNoSchedule"
-				key    = "t1"
-				value  = "tv1"
-			}
-			]
-		}
-	}
+  service_name  = ovh_cloud_project_kube.cluster.service_name
+  kube_id       = ovh_cloud_project_kube.cluster.id
+  name          = ovh_cloud_project_kube.cluster.name
+  flavor_name   = "b2-7"
+  desired_nodes = 1
+  min_nodes     = 0
+  max_nodes     = 1
+  template {
+    metadata {
+      annotations = {
+        a1 = "av1"
+      }
+      finalizers = ["finalizer.extensions/v1beta1"]
+      labels = {
+        l1 = "lv1"
+      }
+    }
+    spec {
+      unschedulable = false
+      taints = [
+        {
+          effect = "PreferNoSchedule"
+          key    = "t1"
+          value  = "tv1"
+        }
+      ]
+    }
+  }
 }
+
 `
 
 var testAccCloudProjectKubeNodePoolConfigUpdated = `
 resource "ovh_cloud_project_kube" "cluster" {
-	service_name  = "%s"
-	name          = "%s"
-	region        = "%s"
-	version       = "%s"
+  service_name = "%s"
+  name         = "%s"
+  region       = "%s"
+  version      = "%s"
 }
 
 resource "ovh_cloud_project_kube_nodepool" "pool" {
-	service_name	= ovh_cloud_project_kube.cluster.service_name
-	kube_id			= ovh_cloud_project_kube.cluster.id
-	name			= ovh_cloud_project_kube.cluster.name
-	flavor_name		= "b2-7"
-	desired_nodes	= 2
-	min_nodes		= 0
-	max_nodes		= 2
-	template {
-		metadata {
-			annotations = {
-				a2 = "av2"
-			}
-			labels = {
-				l2 = "lv2"
-			}
-		}
-	}
+  service_name  = ovh_cloud_project_kube.cluster.service_name
+  kube_id       = ovh_cloud_project_kube.cluster.id
+  name          = ovh_cloud_project_kube.cluster.name
+  flavor_name   = "b2-7"
+  desired_nodes = 2
+  min_nodes     = 0
+  max_nodes     = 2
+  template {
+    metadata {
+      annotations = {
+        a2 = "av2"
+      }
+      finalizers = []
+      labels = {
+        l2 = "lv2"
+      }
+    }
+    spec {
+      unschedulable = false
+      taints = []
+    }
+  }
 }
+
 `
 
 var testAccCloudProjectKubeNodePoolConfigUpdatedScaleToZero = `
 resource "ovh_cloud_project_kube" "cluster" {
-	service_name  = "%s"
-	name          = "%s"
-	region        = "%s"
-	version       = "%s"
+  service_name = "%s"
+  name         = "%s"
+  region       = "%s"
+  version      = "%s"
 }
 
 resource "ovh_cloud_project_kube_nodepool" "pool" {
-	service_name	= ovh_cloud_project_kube.cluster.service_name
-	kube_id			= ovh_cloud_project_kube.cluster.id
-	name			= ovh_cloud_project_kube.cluster.name
-	flavor_name		= "b2-7"
-	desired_nodes	= 0
-	min_nodes		= 0
-	max_nodes		= 2
-	template {
-		metadata {
-			annotations = {
-				a2 = "av2"
-			}
-			labels = {
-				l2 = "lv2"
-			}
-		}
-	}
+  service_name  = ovh_cloud_project_kube.cluster.service_name
+  kube_id       = ovh_cloud_project_kube.cluster.id
+  name          = ovh_cloud_project_kube.cluster.name
+  flavor_name   = "b2-7"
+  desired_nodes = 0
+  min_nodes     = 0
+  max_nodes     = 2
+  template {
+    metadata {
+      annotations = {
+        a2 = "av2"
+      }
+      finalizers = []
+      labels = {
+        l2 = "lv2"
+      }
+    }
+    spec {
+      unschedulable = false
+      taints = []
+    }
+  }
 }
+
 `
 
 func TestAccCloudProjectKubeNodePool(t *testing.T) {
@@ -218,9 +231,11 @@ func TestAccCloudProjectKubeNodePool(t *testing.T) {
 					resource.TestCheckResourceAttr("ovh_cloud_project_kube_nodepool.pool", "desired_nodes", "1"),
 					resource.TestCheckResourceAttr("ovh_cloud_project_kube_nodepool.pool", "min_nodes", "0"),
 					resource.TestCheckResourceAttr("ovh_cloud_project_kube_nodepool.pool", "max_nodes", "1"),
+
 					resource.TestCheckResourceAttr("ovh_cloud_project_kube_nodepool.pool", "template.0.metadata.0.annotations.a1", "av1"),
 					resource.TestCheckResourceAttr("ovh_cloud_project_kube_nodepool.pool", "template.0.metadata.0.finalizers.0", "finalizer.extensions/v1beta1"),
 					resource.TestCheckResourceAttr("ovh_cloud_project_kube_nodepool.pool", "template.0.metadata.0.labels.l1", "lv1"),
+
 					resource.TestCheckResourceAttr("ovh_cloud_project_kube_nodepool.pool", "template.0.spec.0.taints.0.effect", "PreferNoSchedule"),
 					resource.TestCheckResourceAttr("ovh_cloud_project_kube_nodepool.pool", "template.0.spec.0.taints.0.key", "t1"),
 					resource.TestCheckResourceAttr("ovh_cloud_project_kube_nodepool.pool", "template.0.spec.0.taints.0.value", "tv1"),
@@ -239,10 +254,13 @@ func TestAccCloudProjectKubeNodePool(t *testing.T) {
 					resource.TestCheckResourceAttr("ovh_cloud_project_kube_nodepool.pool", "desired_nodes", "2"),
 					resource.TestCheckResourceAttr("ovh_cloud_project_kube_nodepool.pool", "min_nodes", "0"),
 					resource.TestCheckResourceAttr("ovh_cloud_project_kube_nodepool.pool", "max_nodes", "2"),
+
 					resource.TestCheckResourceAttr("ovh_cloud_project_kube_nodepool.pool", "template.0.metadata.0.annotations.a2", "av2"),
 					resource.TestCheckResourceAttr("ovh_cloud_project_kube_nodepool.pool", "template.0.metadata.0.finalizers.#", "0"),
 					resource.TestCheckResourceAttr("ovh_cloud_project_kube_nodepool.pool", "template.0.metadata.0.labels.l2", "lv2"),
+
 					resource.TestCheckResourceAttr("ovh_cloud_project_kube_nodepool.pool", "template.0.spec.0.taints.#", "0"),
+					resource.TestCheckResourceAttr("ovh_cloud_project_kube_nodepool.pool", "template.0.spec.0.unschedulable", "false"),
 				),
 			},
 			{
@@ -257,10 +275,13 @@ func TestAccCloudProjectKubeNodePool(t *testing.T) {
 					resource.TestCheckResourceAttr("ovh_cloud_project_kube_nodepool.pool", "desired_nodes", "0"),
 					resource.TestCheckResourceAttr("ovh_cloud_project_kube_nodepool.pool", "min_nodes", "0"),
 					resource.TestCheckResourceAttr("ovh_cloud_project_kube_nodepool.pool", "max_nodes", "2"),
+
 					resource.TestCheckResourceAttr("ovh_cloud_project_kube_nodepool.pool", "template.0.metadata.0.annotations.a2", "av2"),
 					resource.TestCheckResourceAttr("ovh_cloud_project_kube_nodepool.pool", "template.0.metadata.0.finalizers.#", "0"),
 					resource.TestCheckResourceAttr("ovh_cloud_project_kube_nodepool.pool", "template.0.metadata.0.labels.l2", "lv2"),
+
 					resource.TestCheckResourceAttr("ovh_cloud_project_kube_nodepool.pool", "template.0.spec.0.taints.#", "0"),
+					resource.TestCheckResourceAttr("ovh_cloud_project_kube_nodepool.pool", "template.0.spec.0.unschedulable", "false"),
 				),
 			},
 			{

--- a/website/docs/r/cloud_project_kube_nodepool.html.markdown
+++ b/website/docs/r/cloud_project_kube_nodepool.html.markdown
@@ -75,13 +75,13 @@ The following arguments are supported:
 * `anti_affinity` - (Optional) should the pool use the anti-affinity feature. Default to `false`. **Changing this value recreates the resource.**
 * `autoscale` - (Optional) Enable auto-scaling for the pool. Default to `false`.
 * `template ` - (Optional) Managed Kubernetes nodepool template, which is a complex object constituted by two main nested objects:
-    * `metadata` - (Optional) Metadata of each node in the pool
-        * `annotations` - (Optional) Annotations to apply to each node
-        * `finalizers` - (Optional) Finalizers to apply to each node
-        * `labels` - (Optional) Labels to apply to each node
-    * `spec` - (Optional) Spec of each node in the pool
-        * `taints` - (Optional) Taints to apply to each node
-        * `unschedulable` - (Optional) If true, set nodes as un-schedulable
+    * `metadata` - Metadata of each node in the pool
+        * `annotations` - Annotations to apply to each node
+        * `finalizers` - Finalizers to apply to each node
+        * `labels` - Labels to apply to each node
+    * `spec` - Spec of each node in the pool
+        * `taints` - Taints to apply to each node
+        * `unschedulable` - If true, set nodes as un-schedulable
 
 ## Attributes Reference
 

--- a/website/docs/r/cloud_project_kube_nodepool.html.markdown
+++ b/website/docs/r/cloud_project_kube_nodepool.html.markdown
@@ -77,7 +77,7 @@ The following arguments are supported:
 * `template ` - (Optional) Managed Kubernetes nodepool template, which is a complex object constituted by two main nested objects:
     * `metadata` - Metadata of each node in the pool
         * `annotations` - Annotations to apply to each node
-        * `finalizers` - Finalizers to apply to each node, kubernetes finalizer format is a FQDN (full qualified domain name) like an api group, the rune '/' and then a version. For example: ovhcloud.com/v1  
+        * `finalizers` - Finalizers to apply to each node. A finalizer name must be fully qualified, e.g. kubernetes.io/pv-protection , where you prefix it with hostname of your service which is related to the controller responsible for the finalizer.
         * `labels` - Labels to apply to each node
     * `spec` - Spec of each node in the pool
         * `taints` - Taints to apply to each node

--- a/website/docs/r/cloud_project_kube_nodepool.html.markdown
+++ b/website/docs/r/cloud_project_kube_nodepool.html.markdown
@@ -39,7 +39,7 @@ resource "ovh_cloud_project_kube_nodepool" "pool" {
         k1 = "v1"
         k2 = "v2"
       }
-      finalizers = ["F1", "F2"]
+      finalizers = ["ovhcloud.com/v1beta1", "ovhcloud.com/v1"]
       labels = {
         k3 = "v3"
         k4 = "v4"
@@ -77,7 +77,7 @@ The following arguments are supported:
 * `template ` - (Optional) Managed Kubernetes nodepool template, which is a complex object constituted by two main nested objects:
     * `metadata` - Metadata of each node in the pool
         * `annotations` - Annotations to apply to each node
-        * `finalizers` - Finalizers to apply to each node
+        * `finalizers` - Finalizers to apply to each node, kubernetes finalizer format is a FQDN (full qualified domain name) like an api group, the rune '/' and then a version. For example: ovhcloud.com/v1  
         * `labels` - Labels to apply to each node
     * `spec` - Spec of each node in the pool
         * `taints` - Taints to apply to each node


### PR DESCRIPTION
# Description

- Fix terraform schema where nodepool template is optional but all its attributes are required, this in order to be conform with the OVH APIs
- Fix serialization/deserialization of the terraform data to let terraform compute correctly the diff
- Fix serialization/deserialization of OVH APIs data to let terraform compute correctly the diff
- workaround of terraform bug https://github.com/hashicorp/terraform-plugin-sdk/pull/1042 

Fixes #427  (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Improvement (improve existing resource(s) or datasource(s))
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Test A: `TF_ACC=1 go test -timeout 60m -v github.com/ovh/terraform-provider-ovh/ovh -run TestAccCloudProjectKubeNodePool`

**Test Configuration**:
* Terraform version: `terraform version`: Terraform v1.3.1
* Existing HCL configuration you used: 
```hcl
resource "" "" {
 xx = "yy"
 zz = "aa"
}
```

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or issues
- [ ] I have added acceptance tests that prove my fix is effective or that my feature works
- [x] New and existing acceptance tests pass locally with my changes
- [ ] I ran succesfully `go mod vendor` if I added or modify `go.mod` file
