### PR TITLE
improvement: allow retry on install task creation and add import

### DIFF
--- a/website/docs/r/dedicated_server_install_task.html.markdown
+++ b/website/docs/r/dedicated_server_install_task.html.markdown
@@ -83,3 +83,11 @@ The following attributes are exported:
 * `last_update` - Last update in RFC3339 format.
 * `start_date` - Task creation date in RFC3339 format.
 * `status` - Task status (should be `done`)
+
+## Import
+
+Installation task can be imported using the `service_name` (`nsXXXX.ip...`) of the baremetal server, the `template_name` used  and ths `task_id`, separated by "/" E.g.,
+
+```bash
+$ terraform import ovh_dedicated_server_install_task nsXXXX.ipXXXX/template_name/12345
+```


### PR DESCRIPTION
# Description

Improves error handling when creating a dedicated server install task by allowing the POST to fail and be retried.
Adds import on ovh_dedicated_server_install_task resource

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] Improvement (improve existing resource(s) or datasource(s))
- [x] Documentation update

# How Has This Been Tested?

Import has been tested using the following configuration:
```hcl
resource "ovh_dedicated_server_install_task" "test" {
  service_name = "nsXXXX.ip-XXXX.net"
  template_name = "my_custom_template"
}
```

And using the following command to import the task:
```shell
terraform import ovh_dedicated_server_install_task.test nsXXXX.ip-XXXX.net/my_custom_template/YYYYYY
```

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or issues
- [ ] I have added acceptance tests that prove my fix is effective or that my feature works
- [x] New and existing acceptance tests pass locally with my changes
- [ ] I ran succesfully `go mod vendor` if I added or modify `go.mod` file
