### PR TITLE
Request cluster_id and service_name for a dbaas_logs_cluster resource…

### DIFF
--- a/ovh/data_dbaas_logs_cluster_test.go
+++ b/ovh/data_dbaas_logs_cluster_test.go
@@ -11,15 +11,18 @@ import (
 const testAccDataSourceDbaasLogsCluster = `
 data "ovh_dbaas_logs_cluster" "ldp" {
   service_name = "%s"
+  cluster_id   = "%s"
 }
 `
 
 func TestAccDataSourceDbaasLogsCluster(t *testing.T) {
 	serviceName := os.Getenv("OVH_DBAAS_LOGS_SERVICE_TEST")
+	clusterId := os.Getenv("OVH_DBAAS_LOGS_CLUSTER_ID")
 
 	config := fmt.Sprintf(
 		testAccDataSourceDbaasLogsCluster,
 		serviceName,
+		clusterId,
 	)
 
 	resource.Test(t, resource.TestCase{

--- a/ovh/data_dbaas_logs_clusters.go
+++ b/ovh/data_dbaas_logs_clusters.go
@@ -1,0 +1,63 @@
+package ovh
+
+import (
+	"fmt"
+	"log"
+	"net/url"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/ovh/terraform-provider-ovh/ovh/helpers"
+)
+
+func dataSourceDbaasLogsClusters() *schema.Resource {
+	return &schema.Resource{
+		Read: func(d *schema.ResourceData, meta interface{}) error {
+			return dataSourceDbaasLogsClustersRead(d, meta)
+		},
+		Schema: map[string]*schema.Schema{
+			"service_name": {
+				Type:        schema.TypeString,
+				Description: "The service name",
+				Required:    true,
+			},
+			// Computed
+			"urn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"uuids": {
+				Type: schema.TypeSet,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+				Description: "UUID of clusters",
+				Computed:    true,
+			},
+		},
+	}
+}
+
+func dataSourceDbaasLogsClustersRead(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+
+	serviceName := d.Get("service_name").(string)
+
+	log.Printf("[DEBUG] Will read dbaas logs clusters %s", serviceName)
+
+	d.SetId(serviceName)
+	d.Set("urn", helpers.ServiceURN(config.Plate, "ldp", serviceName))
+
+	endpoint := fmt.Sprintf(
+		"/dbaas/logs/%s/cluster",
+		url.PathEscape(serviceName),
+	)
+
+	res := []string{}
+	if err := config.OVHClient.Get(endpoint, &res); err != nil {
+		return fmt.Errorf("Error calling GET %s:\n\t %q", endpoint, err)
+	}
+
+	d.Set("uuids", res)
+
+	return nil
+}

--- a/ovh/data_dbaas_logs_clusters_test.go
+++ b/ovh/data_dbaas_logs_clusters_test.go
@@ -8,21 +8,19 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
 
-const testAccDataSourceDbaasLogsCluster = `
-data "ovh_dbaas_logs_cluster" "ldp" {
+const testAccDataSourceDbaasLogsClusters = `
+data "ovh_dbaas_logs_clusters" "ldp" {
   service_name = "%s"
-  cluster_id   = "%s"
 }
 `
 
-func TestAccDataSourceDbaasLogsCluster(t *testing.T) {
+func TestAccDataSourceDbaasLogsClusters(t *testing.T) {
 	serviceName := os.Getenv("OVH_DBAAS_LOGS_SERVICE_TEST")
 	clusterId := os.Getenv("OVH_DBAAS_LOGS_CLUSTER_ID")
 
 	config := fmt.Sprintf(
-		testAccDataSourceDbaasLogsCluster,
+		testAccDataSourceDbaasLogsClusters,
 		serviceName,
-		clusterId,
 	)
 
 	resource.Test(t, resource.TestCase{
@@ -34,9 +32,14 @@ func TestAccDataSourceDbaasLogsCluster(t *testing.T) {
 				Config: config,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(
-						"data.ovh_dbaas_logs_cluster.ldp",
+						"data.ovh_dbaas_logs_clusters.ldp",
 						"service_name",
 						serviceName,
+					),
+					resource.TestCheckTypeSetElemAttr(
+						"data.ovh_dbaas_logs_clusters.ldp",
+						"uuids.*",
+						clusterId,
 					),
 				),
 			},

--- a/ovh/provider.go
+++ b/ovh/provider.go
@@ -95,6 +95,7 @@ func Provider() *schema.Provider {
 			"ovh_cloud_project_user_s3_policy":                        dataCloudProjectUserS3Policy(),
 			"ovh_cloud_project_users":                                 datasourceCloudProjectUsers(),
 			"ovh_dbaas_logs_cluster":                                  dataSourceDbaasLogsCluster(),
+			"ovh_dbaas_logs_clusters":                                 dataSourceDbaasLogsClusters(),
 			"ovh_dbaas_logs_input_engine":                             dataSourceDbaasLogsInputEngine(),
 			"ovh_dbaas_logs_output_graylog_stream":                    dataSourceDbaasLogsOutputGraylogStream(),
 			"ovh_dedicated_ceph":                                      dataSourceDedicatedCeph(),

--- a/ovh/provider_test.go
+++ b/ovh/provider_test.go
@@ -174,6 +174,12 @@ func testAccPreCheckDbaasLogsInput(t *testing.T) {
 	checkEnvOrSkip(t, "OVH_DBAAS_LOGS_LOGSTASH_VERSION_TEST")
 }
 
+func testAccPreCheckDbaasLogsCluster(t *testing.T) {
+	testAccPreCheckCredentials(t)
+	checkEnvOrSkip(t, "OVH_DBAAS_LOGS_SERVICE_TEST")
+	checkEnvOrSkip(t, "OVH_DBAAS_LOGS_CLUSTER_ID")
+}
+
 // Checks that the environment variables needed for the /cloud acceptance tests
 // are set.
 func testAccPreCheckCloud(t *testing.T) {

--- a/ovh/resource_dbaas_logs_cluster_test.go
+++ b/ovh/resource_dbaas_logs_cluster_test.go
@@ -33,6 +33,7 @@ func TestAccDbaasLogsCluster(t *testing.T) {
 	config := fmt.Sprintf(
 		testAccDbaasLogsClusterConfig,
 		serviceName,
+		clusterId,
 	)
 
 	resource.Test(t, resource.TestCase{

--- a/website/docs/d/dbaas_logs_cluster.html.markdown
+++ b/website/docs/d/dbaas_logs_cluster.html.markdown
@@ -12,16 +12,18 @@ Use this data source to retrieve informations about a DBaas logs cluster tenant.
 ```hcl
 data "ovh_dbaas_logs_cluster" "logstash" {
   service_name = "ldp-xx-xxxxx"
+  cluster_id   = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
 }
 ```
 
 ## Argument Reference
 
 * `service_name` - The service name. It's the ID of your Logs Data Platform instance.
+* `cluster_id` - Cluster ID. If not provided, the default cluster_id is returned
 
 ## Attributes Reference
 
-* `id` is the input engine ID
+* `id` is the cluster id
 * `urn` is the URN of the DBaas logs instance
 * `cluster_type` is type of cluster (DEDICATED, PRO or TRIAL)
 * `dedicated_input_pem` is PEM for dedicated inputs

--- a/website/docs/d/dbaas_logs_clusters.html.markdown
+++ b/website/docs/d/dbaas_logs_clusters.html.markdown
@@ -1,0 +1,24 @@
+---
+subcategory : "Logs Data Platform"
+---
+
+
+# ovh_dbaas_logs_clusters (Data Source)
+
+Use this data source to retrieve UUIDs of DBaas logs clusters.
+
+## Example Usage
+
+```hcl
+data "ovh_dbaas_logs_clusters" "logstash" {
+  service_name = "ldp-xx-xxxxx"
+}
+```
+
+## Argument Reference
+
+* `service_name` - The service name. It's the ID of your Logs Data Platform instance.
+
+## Attributes Reference
+
+* `uuids` is the cluster id

--- a/website/docs/r/dbaas_logs_cluster.html.markdown
+++ b/website/docs/r/dbaas_logs_cluster.html.markdown
@@ -14,6 +14,7 @@ type.
 ```hcl
 resource "ovh_dbaas_logs_cluster" "ldp" {
   service_name     = "ldp-xx-xxxxx"
+  cluster_id       = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
 
   archive_allowed_networks       = ["10.0.0.0/16"]
   direct_input_allowed_networks  = ["10.0.0.0/16"]
@@ -25,13 +26,15 @@ resource "ovh_dbaas_logs_cluster" "ldp" {
 
 The following arguments are supported:
 
+* `service_name` - (Required) The service name
+* `cluster_id` - Cluster ID. If not provided, the default cluster_id is used
 * `archive_allowed_networks` - List of IP blocks
 * `direct_input_allowed_networks` - List of IP blocks
 * `query_allowed_networks` - List of IP blocks
 
 ## Attributes Reference
 
-Id is set to the input Id. In addition, the following attributes are exported:
+Id is set to a concatenation of service name and cluster Id. In addition, the following attributes are exported:
 * `urn` - URN of the DBaaS
 * `cluster_type` - type of cluster (DEDICATED, PRO or TRIAL)
 * `dedicated_input_pem` - PEM for dedicated inputs
@@ -46,8 +49,8 @@ Id is set to the input Id. In addition, the following attributes are exported:
 
 ## Import
 
-OVHcloud DBaaS Log Data Platform clusters can be imported using the `service_name` and `id` of the cluster, separated by "/" E.g.,
+OVHcloud DBaaS Log Data Platform clusters can be imported using the `service_name` and `cluster_id` of the cluster, separated by "/" E.g.,
 
 ```bash
-$ terraform import ovh_dbaas_logs_cluster.ldp service_name/id
+$ terraform import ovh_dbaas_logs_cluster.ldp service_name/cluster_id
 ```


### PR DESCRIPTION
…/data

You can have more than one cluster_id per service_name

# Description

Instead on blindly selecting the first cluster_id of a service_name in dbaas_logs_cluster resource and data, request the user to give it.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (improve existing resource(s) or datasource(s))
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A: `make testacc TESTARGS="-run TestAccDataSourceXxxxYyyyZzzzz_basic"`
- [ ] Test B: `make testacc TESTARGS="-run TestAccDataSourceXxxxYyyyZzzzz_basic"`

**Test Configuration**:
* Terraform version: `terraform version`: Terraform vx.y.z
* Existing HCL configuration you used: 
```hcl
resource "" "" {
 xx = "yy"
 zz = "aa"
}
```

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or issues
- [ ] I have added acceptance tests that prove my fix is effective or that my feature works
- [ ] New and existing acceptance tests pass locally with my changes
- [ ] I ran succesfully `go mod vendor` if I added or modify `go.mod` file
