### PR TITLE
Fix TestAccDataCloudProjectUserS3Policy_basic

### DIFF
--- a/ovh/data_cloud_project_user_s3_policy_test.go
+++ b/ovh/data_cloud_project_user_s3_policy_test.go
@@ -38,7 +38,7 @@ data "ovh_cloud_project_user_s3_policy" "policy" {
 }
 `
 
-const normalizedPolicyRWBucket = "{\"Statement\":[{\"Sid\":\"RWContainer\",\"Effect\":\"Allow\",\"Action\":[\"s3:GetObject\",\"s3:PutObject\",\"s3:DeleteObject\",\"s3:ListBucket\",\"s3:ListMultipartUploadParts\",\"s3:ListBucketMultipartUploads\",\"s3:AbortMultipartUpload\",\"s3:GetBucketLocation\"],\"Resource\":[\"arn:aws:s3:::hp-bucket\",\"arn:aws:s3:::hp-bucket/*\"]}]}"
+const normalizedPolicyRWBucket = "{\"Statement\":[{\"Sid\":\"RWContainer\",\"Effect\":\"Allow\",\"Action\":[\"s3:GetObject\",\"s3:PutObject\",\"s3:DeleteObject\",\"s3:ListBucket\",\"s3:ListMultipartUploadParts\",\"s3:ListBucketMultipartUploads\",\"s3:AbortMultipartUpload\",\"s3:GetBucketLocation\"],\"Resource\":[\"arn:aws:s3:::hp-bucket\",\"arn:aws:s3:::hp-bucket/*\"],\"Condition\":null}]}"
 
 func TestAccDataCloudProjectUserS3Policy_basic(t *testing.T) {
 	serviceName := os.Getenv("OVH_CLOUD_PROJECT_SERVICE_TEST")


### PR DESCRIPTION
# Description
due to a change in the default S3 policy the test TestAccDataCloudProjectUserS3Policy_basic was failing. The expected value has been update to be compliant with that change

## Type of change

Please delete options that are not relevant.

- [X ] Bug fix (non-breaking change which fixes an issue)
- 
# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A: `make testacc TESTARGS="-run TestAccDataCloudProjectUserS3Policy_basic"`

# Checklist:
N/A