### PR TITLE
dedicated_server_networking specificities improvement

### DIFF
--- a/ovh/provider_test.go
+++ b/ovh/provider_test.go
@@ -351,3 +351,8 @@ func testAccPreCheckWorkflowBackup(t *testing.T) {
 	checkEnvOrSkip(t, WORKFLOW_BACKUP_TEST_INSTANCE_ID_ENV_VAR)
 	checkEnvOrSkip(t, WORKFLOW_BACKUP_TEST_REGION_ENV_VAR)
 }
+
+// This variable shall be defined to run the test because it targets an internal route that shall be authorized per user
+func testAccPreCheckDedicatedServerNetworking(t *testing.T) {
+	checkEnvOrSkip(t, "TEST_DEDICATED_SERVER_NETWORKING")
+}

--- a/ovh/resource_dedicated_server_networking_test.go
+++ b/ovh/resource_dedicated_server_networking_test.go
@@ -20,6 +20,7 @@ func TestAccresourceDedicatedServerNetworking(t *testing.T) {
 			PreCheck: func() {
 				testAccPreCheckCredentials(t)
 				testAccPreCheckDedicatedServer(t)
+				testAccPreCheckDedicatedServerNetworking(t)
 			},
 			Providers: testAccProviders,
 			Steps: []resource.TestStep{

--- a/website/docs/r/ovh_dedicated_server_networking.html.markdown
+++ b/website/docs/r/ovh_dedicated_server_networking.html.markdown
@@ -6,6 +6,9 @@ subcategory : "Dedicated Server"
 
 Manage dedicated server networking interface on SCALE and HIGH-GRADE range.
 
+!> The API route targeted by this resource are restricted to OVHCloud users (`Internal API`) with additional restrictions.
+
+
 ## Example Usage
 
 The following example aims to bind all interfaces in a vRack


### PR DESCRIPTION
Improvement in the management of the specificities of dedicated_serve…r_networking which is an `Internal` route that shall be authorized manually.

# Description

- Doc update to state that this is not a 'normal' resource
- Add a specific env variable in order to run the tests : this enables a user that is not authorized to call this route to skip the test easily

## Type of change

Please delete options that are not relevant.


- [ x] Improvement (improve existing resource(s) or datasource(s))
- [ x] Documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Test A: `make testacc TESTARGS="-run TestAccDedicatedServerInstall_basic"`
- [x] Test B: `make testacc TESTARGS="-run TestAccresourceDedicatedServerNetworking"`

