### PR TITLE
Fix resource_me_installation_template_test 

### DIFF
--- a/ovh/resource_me_installation_template_test.go
+++ b/ovh/resource_me_installation_template_test.go
@@ -124,11 +124,6 @@ func TestAccMeInstallationTemplateResource_customization(t *testing.T) {
 						"customization.0.post_installation_script_return",
 						"returned_string",
 					),
-					resource.TestCheckResourceAttr(
-						"ovh_me_installation_template.template",
-						"customization.0.use_distribution_kernel",
-						"true",
-					),
 					resource.TestCheckResourceAttrSet(
 						"ovh_me_installation_template.template",
 						"family",
@@ -157,7 +152,6 @@ resource "ovh_me_installation_template" "template" {
      ssh_key_name                    = "test"
      post_installation_script_link   = "http://mylink.org"
      post_installation_script_return = "returned_string"
-     use_distribution_kernel         = true
   }
 }
 `


### PR DESCRIPTION
# Description
The useDistribKernel flag was deprecated (i.e. not used) by the backend 3 years ago. However it was still to possible to set / get this value. This is not anymore the case, breaking the CI test.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)


# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Test A: `make testacc TESTARGS="-run TestAccMeInstallationTemplateResource_customization"`
