### PR TITLE
Fix kafka schema registry tests add import test

### DIFF
--- a/ovh/data_cloud_project_database_kafka_schemaregistryacl.go
+++ b/ovh/data_cloud_project_database_kafka_schemaregistryacl.go
@@ -13,7 +13,7 @@ import (
 
 func dataSourceCloudProjectDatabaseKafkaSchemaRegistryAcl() *schema.Resource {
 	return &schema.Resource{
-		ReadContext: dataSourceCloudProjectDatabaseKafkaSchemaregistryaclRead,
+		ReadContext: dataSourceCloudProjectDatabaseKafkaSchemaRegistryAclRead,
 		Schema: map[string]*schema.Schema{
 			"service_name": {
 				Type:        schema.TypeString,
@@ -51,7 +51,7 @@ func dataSourceCloudProjectDatabaseKafkaSchemaRegistryAcl() *schema.Resource {
 	}
 }
 
-func dataSourceCloudProjectDatabaseKafkaSchemaregistryaclRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func dataSourceCloudProjectDatabaseKafkaSchemaRegistryAclRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	config := meta.(*Config)
 	serviceName := d.Get("service_name").(string)
 	clusterID := d.Get("cluster_id").(string)

--- a/ovh/data_cloud_project_database_kafka_schemaregistryacls.go
+++ b/ovh/data_cloud_project_database_kafka_schemaregistryacls.go
@@ -15,7 +15,7 @@ import (
 
 func dataSourceCloudProjectDatabaseKafkaSchemaRegistryAcls() *schema.Resource {
 	return &schema.Resource{
-		ReadContext: dataSourceCloudProjectDatabaseKafkaSchemaregistryclsRead,
+		ReadContext: dataSourceCloudProjectDatabaseKafkaSchemaRegistryAclsRead,
 		Schema: map[string]*schema.Schema{
 			"service_name": {
 				Type:        schema.TypeString,
@@ -39,7 +39,7 @@ func dataSourceCloudProjectDatabaseKafkaSchemaRegistryAcls() *schema.Resource {
 	}
 }
 
-func dataSourceCloudProjectDatabaseKafkaSchemaregistryclsRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func dataSourceCloudProjectDatabaseKafkaSchemaRegistryAclsRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	config := meta.(*Config)
 	serviceName := d.Get("service_name").(string)
 	clusterId := d.Get("cluster_id").(string)

--- a/ovh/data_cloud_project_database_kafka_schemaregistryacls_test.go
+++ b/ovh/data_cloud_project_database_kafka_schemaregistryacls_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
 
-const testAccCloudProjectDatabaseKafkaSchemaregistryaclsDatasourceConfig_Basic = `
+const testAccCloudProjectDatabaseKafkaSchemaRegistryAclsDatasourceConfig_Basic = `
 resource "ovh_cloud_project_database" "db" {
 	service_name = "%s"
 	description  = "%s"
@@ -37,12 +37,12 @@ resource "ovh_cloud_project_database_kafka_schemaregistryacl" "schemaRegistryAcl
 }
 
 data "ovh_cloud_project_database_kafka_schemaregistryacls" "schemaRegistryAcls" {
-  service_name = ovh_cloud_project_database_kafka_acl.acl.service_name
-  cluster_id   = ovh_cloud_project_database_kafka_acl.acl.cluster_id
+  service_name = ovh_cloud_project_database_kafka_schemaregistryacl.schemaRegistryAcl.service_name
+  cluster_id   = ovh_cloud_project_database_kafka_schemaregistryacl.schemaRegistryAcl.cluster_id
 }
 `
 
-func TestAccCloudProjectDatabaseKafkaSchemaregistryaclsDataSource_basic(t *testing.T) {
+func TestAccCloudProjectDatabaseKafkaSchemaRegistryAclsDataSource_basic(t *testing.T) {
 	serviceName := os.Getenv("OVH_CLOUD_PROJECT_SERVICE_TEST")
 	version := os.Getenv("OVH_CLOUD_PROJECT_DATABASE_KAFKA_VERSION_TEST")
 	if version == "" {
@@ -56,7 +56,7 @@ func TestAccCloudProjectDatabaseKafkaSchemaregistryaclsDataSource_basic(t *testi
 	username := "johnDoe"
 
 	config := fmt.Sprintf(
-		testAccCloudProjectDatabaseKafkaAclsDatasourceConfig_Basic,
+		testAccCloudProjectDatabaseKafkaSchemaRegistryAclsDatasourceConfig_Basic,
 		serviceName,
 		description,
 		version,

--- a/ovh/import_cloud_project_database_kafka_schemaregistryacl_test.go
+++ b/ovh/import_cloud_project_database_kafka_schemaregistryacl_test.go
@@ -1,0 +1,70 @@
+package ovh
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
+
+func TestAccCloudProjectDatabaseKafkaSchemaRegistryAcl_importBasic(t *testing.T) {
+	serviceName := os.Getenv("OVH_CLOUD_PROJECT_SERVICE_TEST")
+	version := os.Getenv("OVH_CLOUD_PROJECT_DATABASE_KAFKA_VERSION_TEST")
+	if version == "" {
+		version = os.Getenv("OVH_CLOUD_PROJECT_DATABASE_VERSION_TEST")
+	}
+	region := os.Getenv("OVH_CLOUD_PROJECT_DATABASE_REGION_TEST")
+	flavor := os.Getenv("OVH_CLOUD_PROJECT_DATABASE_FLAVOR_TEST")
+	description := acctest.RandomWithPrefix(test_prefix)
+	permission := "schema_registry_read"
+	aclResource := "Subject:myResource"
+	username := "johnDoe"
+
+	config := fmt.Sprintf(
+		testAccCloudProjectDatabaseKafkaSchemaRegistryAclConfig,
+		serviceName,
+		description,
+		version,
+		region,
+		region,
+		region,
+		flavor,
+		permission,
+		aclResource,
+		username,
+	)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheckCloudDatabaseNoEngine(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+			},
+			{
+				ResourceName:      "ovh_cloud_project_database_kafka_schemaregistryacl.schemaRegistryAcl",
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testAccCloudProjectDatabaseKafkaAclImportId("ovh_cloud_project_database_kafka_schemaregistryacl.schemaRegistryAcl"),
+			},
+		},
+	})
+}
+
+func testAccCloudProjectDatabaseKafkaSchemaRegistryAclImportId(resourceName string) resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		testKafkaAcl, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return "", fmt.Errorf("ovh_cloud_project_database_kafka_schemaregistryacl not found: %s", resourceName)
+		}
+		return fmt.Sprintf(
+			"%s/%s/%s",
+			testKafkaAcl.Primary.Attributes["service_name"],
+			testKafkaAcl.Primary.Attributes["cluster_id"],
+			testKafkaAcl.Primary.Attributes["id"],
+		), nil
+	}
+}

--- a/ovh/provider.go
+++ b/ovh/provider.go
@@ -148,7 +148,7 @@ func Provider() *schema.Provider {
 			"ovh_cloud_project_database_integration":                      resourceCloudProjectDatabaseIntegration(),
 			"ovh_cloud_project_database_ip_restriction":                   resourceCloudProjectDatabaseIpRestriction(),
 			"ovh_cloud_project_database_kafka_acl":                        resourceCloudProjectDatabaseKafkaAcl(),
-			"ovh_cloud_project_database_kafka_schemaregistryacl":          resourceCloudProjectDatabaseKafkaSchemaregistryacl(),
+			"ovh_cloud_project_database_kafka_schemaregistryacl":          resourceCloudProjectDatabaseKafkaSchemaRegistryAcl(),
 			"ovh_cloud_project_database_kafka_topic":                      resourceCloudProjectDatabaseKafkaTopic(),
 			"ovh_cloud_project_database_m3db_namespace":                   resourceCloudProjectDatabaseM3dbNamespace(),
 			"ovh_cloud_project_database_m3db_user":                        resourceCloudProjectDatabaseM3dbUser(),

--- a/ovh/resource_cloud_project_database_kafka_schemaregistryacl.go
+++ b/ovh/resource_cloud_project_database_kafka_schemaregistryacl.go
@@ -13,14 +13,14 @@ import (
 	"github.com/ovh/terraform-provider-ovh/ovh/helpers"
 )
 
-func resourceCloudProjectDatabaseKafkaSchemaregistryacl() *schema.Resource {
+func resourceCloudProjectDatabaseKafkaSchemaRegistryAcl() *schema.Resource {
 	return &schema.Resource{
-		CreateContext: resourceCloudProjectDatabaseKafkaSchemaregistryaclCreate,
-		ReadContext:   resourceCloudProjectDatabaseKafkaSchemaregistryaclRead,
-		DeleteContext: resourceCloudProjectDatabaseKafkaSchemaregistryaclDelete,
+		CreateContext: resourceCloudProjectDatabaseKafkaSchemaRegistryAclCreate,
+		ReadContext:   resourceCloudProjectDatabaseKafkaSchemaRegistryAclRead,
+		DeleteContext: resourceCloudProjectDatabaseKafkaSchemaRegistryAclDelete,
 
 		Importer: &schema.ResourceImporter{
-			State: resourceCloudProjectDatabaseKafkaSchemaregistryaclImportState,
+			State: resourceCloudProjectDatabaseKafkaSchemaRegistryAclImportState,
 		},
 
 		Timeouts: &schema.ResourceTimeout{
@@ -63,7 +63,7 @@ func resourceCloudProjectDatabaseKafkaSchemaregistryacl() *schema.Resource {
 	}
 }
 
-func resourceCloudProjectDatabaseKafkaSchemaregistryaclImportState(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+func resourceCloudProjectDatabaseKafkaSchemaRegistryAclImportState(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
 	givenId := d.Id()
 	n := 3
 	splitId := strings.SplitN(givenId, "/", n)
@@ -82,7 +82,7 @@ func resourceCloudProjectDatabaseKafkaSchemaregistryaclImportState(d *schema.Res
 	return results, nil
 }
 
-func resourceCloudProjectDatabaseKafkaSchemaregistryaclCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceCloudProjectDatabaseKafkaSchemaRegistryAclCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	config := meta.(*Config)
 	serviceName := d.Get("service_name").(string)
 	clusterId := d.Get("cluster_id").(string)
@@ -91,8 +91,8 @@ func resourceCloudProjectDatabaseKafkaSchemaregistryaclCreate(ctx context.Contex
 		url.PathEscape(serviceName),
 		url.PathEscape(clusterId),
 	)
-	params := (&CloudProjectDatabaseKafkaSchemaregistryaclCreateOpts{}).FromResource(d)
-	res := &CloudProjectDatabaseKafkaSchemaregistryaclResponse{}
+	params := (&CloudProjectDatabaseKafkaSchemaRegistryAclCreateOpts{}).FromResource(d)
+	res := &CloudProjectDatabaseKafkaSchemaRegistryAclResponse{}
 
 	log.Printf("[DEBUG] Will create schema registry acl: %+v for cluster %s from project %s", params, clusterId, serviceName)
 	err := config.OVHClient.Post(endpoint, params, res)
@@ -101,7 +101,7 @@ func resourceCloudProjectDatabaseKafkaSchemaregistryaclCreate(ctx context.Contex
 	}
 
 	log.Printf("[DEBUG] Waiting for schema registry acl %s to be READY", res.Id)
-	err = waitForCloudProjectDatabaseKafkaSchemaregistryaclReady(ctx, config.OVHClient, serviceName, clusterId, res.Id, d.Timeout(schema.TimeoutCreate))
+	err = waitForCloudProjectDatabaseKafkaSchemaRegistryAclReady(ctx, config.OVHClient, serviceName, clusterId, res.Id, d.Timeout(schema.TimeoutCreate))
 	if err != nil {
 		return diag.Errorf("timeout while waiting schema registry ACL %s to be READY: %s", res.Id, err.Error())
 	}
@@ -109,10 +109,10 @@ func resourceCloudProjectDatabaseKafkaSchemaregistryaclCreate(ctx context.Contex
 
 	d.SetId(res.Id)
 
-	return resourceCloudProjectDatabaseKafkaSchemaregistryaclRead(ctx, d, meta)
+	return resourceCloudProjectDatabaseKafkaSchemaRegistryAclRead(ctx, d, meta)
 }
 
-func resourceCloudProjectDatabaseKafkaSchemaregistryaclRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceCloudProjectDatabaseKafkaSchemaRegistryAclRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	config := meta.(*Config)
 	serviceName := d.Get("service_name").(string)
 	clusterId := d.Get("cluster_id").(string)
@@ -123,7 +123,7 @@ func resourceCloudProjectDatabaseKafkaSchemaregistryaclRead(ctx context.Context,
 		url.PathEscape(clusterId),
 		url.PathEscape(id),
 	)
-	res := &CloudProjectDatabaseKafkaSchemaregistryaclResponse{}
+	res := &CloudProjectDatabaseKafkaSchemaRegistryAclResponse{}
 
 	log.Printf("[DEBUG] Will read schema registry acl %s from cluster %s from project %s", id, clusterId, serviceName)
 	if err := config.OVHClient.Get(endpoint, res); err != nil {
@@ -142,7 +142,7 @@ func resourceCloudProjectDatabaseKafkaSchemaregistryaclRead(ctx context.Context,
 	return nil
 }
 
-func resourceCloudProjectDatabaseKafkaSchemaregistryaclDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceCloudProjectDatabaseKafkaSchemaRegistryAclDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	config := meta.(*Config)
 	serviceName := d.Get("service_name").(string)
 	clusterId := d.Get("cluster_id").(string)
@@ -161,7 +161,7 @@ func resourceCloudProjectDatabaseKafkaSchemaregistryaclDelete(ctx context.Contex
 	}
 
 	log.Printf("[DEBUG] Waiting for schema registry acl %s to be DELETED", id)
-	err = waitForCloudProjectDatabaseKafkaSchemaregistryaclDeleted(ctx, config.OVHClient, serviceName, clusterId, id, d.Timeout(schema.TimeoutDelete))
+	err = waitForCloudProjectDatabaseKafkaSchemaRegistryAclDeleted(ctx, config.OVHClient, serviceName, clusterId, id, d.Timeout(schema.TimeoutDelete))
 	if err != nil {
 		return diag.Errorf("timeout while waiting schema registry ACL %s to be DELETED: %s", id, err.Error())
 	}

--- a/ovh/resource_cloud_project_database_kafka_schemaregistryacl_test.go
+++ b/ovh/resource_cloud_project_database_kafka_schemaregistryacl_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
 
-const testAccCloudProjectDatabaseKafkaSchemaregistryaclConfig = `
+const testAccCloudProjectDatabaseKafkaSchemaRegistryAclConfig = `
 resource "ovh_cloud_project_database" "db" {
 	service_name = "%s"
 	description  = "%s"
@@ -37,7 +37,7 @@ resource "ovh_cloud_project_database_kafka_schemaregistryacl" "schemaRegistryAcl
 }
 `
 
-func TestAccCloudProjectDatabaseKafkaSchemaregistryacl_basic(t *testing.T) {
+func TestAccCloudProjectDatabaseKafkaSchemaRegistryAcl_basic(t *testing.T) {
 	serviceName := os.Getenv("OVH_CLOUD_PROJECT_SERVICE_TEST")
 	version := os.Getenv("OVH_CLOUD_PROJECT_DATABASE_KAFKA_VERSION_TEST")
 	if version == "" {
@@ -51,7 +51,7 @@ func TestAccCloudProjectDatabaseKafkaSchemaregistryacl_basic(t *testing.T) {
 	username := "johnDoe"
 
 	config := fmt.Sprintf(
-		testAccCloudProjectDatabaseKafkaSchemaregistryaclConfig,
+		testAccCloudProjectDatabaseKafkaSchemaRegistryAclConfig,
 		serviceName,
 		description,
 		version,

--- a/ovh/types_cloud_project_database.go
+++ b/ovh/types_cloud_project_database.go
@@ -1872,14 +1872,14 @@ func waitForCloudProjectDatabaseKafkaAclDeleted(ctx context.Context, client *ovh
 
 // // Schema Registry ACL
 
-type CloudProjectDatabaseKafkaSchemaregistryaclResponse struct {
+type CloudProjectDatabaseKafkaSchemaRegistryAclResponse struct {
 	Id         string `json:"id"`
 	Permission string `json:"permission"`
 	Resource   string `json:"resource"`
 	Username   string `json:"username"`
 }
 
-func (p *CloudProjectDatabaseKafkaSchemaregistryaclResponse) String() string {
+func (p *CloudProjectDatabaseKafkaSchemaRegistryAclResponse) String() string {
 	return fmt.Sprintf(
 		"Id: %s, Permission: %s, affected User: %s, affected Topic %s",
 		p.Id,
@@ -1889,7 +1889,7 @@ func (p *CloudProjectDatabaseKafkaSchemaregistryaclResponse) String() string {
 	)
 }
 
-func (v CloudProjectDatabaseKafkaSchemaregistryaclResponse) ToMap() map[string]interface{} {
+func (v CloudProjectDatabaseKafkaSchemaRegistryAclResponse) ToMap() map[string]interface{} {
 	obj := make(map[string]interface{})
 
 	obj["id"] = v.Id
@@ -1900,13 +1900,13 @@ func (v CloudProjectDatabaseKafkaSchemaregistryaclResponse) ToMap() map[string]i
 	return obj
 }
 
-type CloudProjectDatabaseKafkaSchemaregistryaclCreateOpts struct {
+type CloudProjectDatabaseKafkaSchemaRegistryAclCreateOpts struct {
 	Permission string `json:"permission"`
 	Resource   string `json:"resource"`
 	Username   string `json:"username"`
 }
 
-func (opts *CloudProjectDatabaseKafkaSchemaregistryaclCreateOpts) FromResource(d *schema.ResourceData) *CloudProjectDatabaseKafkaSchemaregistryaclCreateOpts {
+func (opts *CloudProjectDatabaseKafkaSchemaRegistryAclCreateOpts) FromResource(d *schema.ResourceData) *CloudProjectDatabaseKafkaSchemaRegistryAclCreateOpts {
 	opts.Permission = d.Get("permission").(string)
 	opts.Resource = d.Get("resource").(string)
 	opts.Username = d.Get("username").(string)
@@ -1914,7 +1914,7 @@ func (opts *CloudProjectDatabaseKafkaSchemaregistryaclCreateOpts) FromResource(d
 	return opts
 }
 
-func waitForCloudProjectDatabaseKafkaSchemaregistryaclReady(ctx context.Context, client *ovh.Client, serviceName, databaseId string, schemaRegistryAclId string, timeOut time.Duration) error {
+func waitForCloudProjectDatabaseKafkaSchemaRegistryAclReady(ctx context.Context, client *ovh.Client, serviceName, databaseId string, schemaRegistryAclId string, timeOut time.Duration) error {
 	stateConf := &resource.StateChangeConf{
 		Pending: []string{"PENDING"},
 		Target:  []string{"READY"},
@@ -1943,7 +1943,7 @@ func waitForCloudProjectDatabaseKafkaSchemaregistryaclReady(ctx context.Context,
 	return err
 }
 
-func waitForCloudProjectDatabaseKafkaSchemaregistryaclDeleted(ctx context.Context, client *ovh.Client, serviceName, databaseId string, schemaRegistryAclId string, timeOut time.Duration) error {
+func waitForCloudProjectDatabaseKafkaSchemaRegistryAclDeleted(ctx context.Context, client *ovh.Client, serviceName, databaseId string, schemaRegistryAclId string, timeOut time.Duration) error {
 	stateConf := &resource.StateChangeConf{
 		Pending: []string{"DELETING"},
 		Target:  []string{"DELETED"},


### PR DESCRIPTION
# Description

Fixes Kafka schema registry data source test
Add Kafka schema registry import test

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Improvement (improve existing resource(s) or datasource(s))


# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Test A: `make testacc TESTARGS="-run TestAccCloudProjectDatabaseKafkaSchemaregistryacl_importBasic""`
- [x] Test B: `make testacc TESTARGS="-run make testacc TESTARGS="-run TestAccCloudProjectDatabaseKafkaSchemaregistryaclsDataSource_basic""`
- [x] Test c: `make testacc TESTARGS="-run TestAccCloudProjectDatabaseKafkaSchemaregistryacl_basic""`


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or issues
- [x] I have added acceptance tests that prove my fix is effective or that my feature works
- [x] New and existing acceptance tests pass locally with my changes
- [x] I ran succesfully `go mod vendor` if I added or modify `go.mod` file
