### PR TITLE
fix(cloudProject): creation and import for cloudProject in the US

### DIFF
--- a/ovh/order.go
+++ b/ovh/order.go
@@ -494,3 +494,25 @@ func waitForOrder(c *ovh.Client, id int64) resource.StateRefreshFunc {
 		return r, r, nil
 	}
 }
+
+func orderDetailOperations(c *ovh.Client, orderId int64, orderDetailId int64) ([]*MeOrderDetailOperation, error) {
+	log.Printf("[DEBUG] Will list order detail operations %d/%d", orderId, orderDetailId)
+	operationsIds := []int64{}
+	endpoint := fmt.Sprintf("/me/order/%d/details/%d/operations", orderId, orderDetailId)
+	if err := c.Get(endpoint, &operationsIds); err != nil {
+		return nil, fmt.Errorf("calling get %s:\n\t %q", endpoint, err)
+	}
+
+	operations := make([]*MeOrderDetailOperation, len(operationsIds))
+	for i, operationId := range operationsIds {
+		operation := &MeOrderDetailOperation{}
+		log.Printf("[DEBUG] Will read order detail operations %d/%d/%d", orderId, orderDetailId, operationId)
+		endpoint := fmt.Sprintf("/me/order/%d/details/%d/operations/%d", orderId, orderDetailId, operationId)
+		if err := c.Get(endpoint, operation); err != nil {
+			return nil, fmt.Errorf("calling get %s:\n\t %q", endpoint, err)
+		}
+
+		operations[i] = operation
+	}
+	return operations, nil
+}

--- a/ovh/types_me_order.go
+++ b/ovh/types_me_order.go
@@ -30,6 +30,20 @@ func (v MeOrderDetail) ToMap() map[string]interface{} {
 	return obj
 }
 
+type MeOrderDetailOperation struct {
+	Status   string                         `json:"status"`
+	ID       int                            `json:"id"`
+	Type     string                         `json:"type"`
+	Resource MeOrderDetailOperationResource `json:"resource"`
+	Quantity int                            `json:"quantity"`
+}
+
+type MeOrderDetailOperationResource struct {
+	Name        string `json:"name"`
+	State       string `json:"state"`
+	DisplayName string `json:"displayName"`
+}
+
 type MeOrderPaymentOpts struct {
 	PaymentMean   string `json:"paymentMean"`
 	PaymentMeanId *int64 `json:"paymentMeanId,omitEmpty"`

--- a/website/docs/r/cloud_project.html.markdown
+++ b/website/docs/r/cloud_project.html.markdown
@@ -23,6 +23,7 @@ data "ovh_order_cart_product_plan" "cloud" {
   price_capacity = "renew"
   product        = "cloud"
   plan_code      = "project.2018"
+  # plan_code    = "project" # when running in the US
 }
 
 resource "ovh_cloud_project" "my_cloud_project" {
@@ -37,6 +38,8 @@ resource "ovh_cloud_project" "my_cloud_project" {
 }
 ```
 
+-> __WARNING__ Currently, the OVHcloud Terraform provider does not support deletion of a public cloud project in the US. Removal is possible by manually deleting the project and then manually removing the public cloud project from terraform state.
+
 ## Argument Reference
 
 The following arguments are supported:
@@ -46,7 +49,7 @@ The following arguments are supported:
 * `ovh_subsidiary` - (Required) OVHcloud Subsidiary
 * `plan` - (Required) Product Plan to order
   * `duration` - (Required) duration
-  * `plan_code` - (Required) Plan code
+  * `plan_code` - (Required) Plan code. This value must be adapted depending on your `OVH_ENDPOINT` value. It's `project.2018` for `ovh-{eu,ca}` and `project` when using `ovh-us`.
   * `pricing_mode` - (Required) Pricing model identifier
   * `catalog_name` - Catalog name
   * `configuration` - (Optional) Representation of a configuration item for personalizing product


### PR DESCRIPTION
# Description

This PR fixes public cloud project creation for OVH US. It also improves cloud project documentation so that creation in the US is easier for end user.

Because of some differences in Agora, the result is different between OVH EU/CA on one side & OVH US on the other. There's been some internal discussions about changing that (I can provide more details in PM) and they haven't landed on a result and are not expected to in any near future.

This PR works around the issue by making extra call to find out serviceName if the initial serviceName determination attempt failed.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Improvement (improve existing resource(s) or datasource(s))
- [x] Documentation update

# How Has This Been Tested?

I manually tested it by successfully creating & importing a cloud project on OVH-US.

**Test Configuration**:
* Terraform version: `terraform version`: Terraform v1.4.2
* Existing HCL configuration you used: 
``` bash
export OVH_ENDPOINT=ovh-us
```
```hcl
data "ovh_order_cart" "aaa_cart" {
  ovh_subsidiary = "us"
  description    = "us public cloud project cart"
}

data "ovh_order_cart_product_plan" "cloud" {
  cart_id        = data.ovh_order_cart.aaa_cart.id
  price_capacity = "renew"
  product        = "cloud"
  plan_code      = "project" # naming is different in the us.
}

resource "ovh_cloud_project" "cloud_project" {
  ovh_subsidiary = data.ovh_order_cart.aaa_cart.ovh_subsidiary
  description    = "us cloud project"
  payment_mean   = "ovh-account"

  plan {
    duration     = data.ovh_order_cart_product_plan.cloud.selected_price.0.duration
    plan_code    = data.ovh_order_cart_product_plan.cloud.plan_code
    pricing_mode = data.ovh_order_cart_product_plan.cloud.selected_price.0.pricing_mode
  }
}
```
And also `terraform import ovh_cloud_project.cloud_project <project_id>


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or issues
- [ ] I have added acceptance tests that prove my fix is effective or that my feature works
- [ ] New and existing acceptance tests pass locally with my changes
- [ ] I ran successfully `go mod vendor` if I added or modify `go.mod` file
