### PR TITLE
Improve the order documentation 

### DIFF
--- a/ovh/resource_cloud_project_test.go
+++ b/ovh/resource_cloud_project_test.go
@@ -14,9 +14,10 @@ import (
 )
 
 const testAccCloudProjectBasic = `
+data "ovh_me" "myaccount" {}
+
 data "ovh_order_cart" "mycart" {
- ovh_subsidiary = "fr"
- description    = "%s"
+ ovh_subsidiary = data.ovh_me.myaccount.ovh_subsidiary
 }
 
 data "ovh_order_cart_product_plan" "cloud" {
@@ -126,7 +127,6 @@ func TestAccResourceCloudProject_basic(t *testing.T) {
 	desc := acctest.RandomWithPrefix(test_prefix)
 	config := fmt.Sprintf(
 		testAccCloudProjectBasic,
-		desc,
 		desc,
 	)
 	resource.Test(t, resource.TestCase{

--- a/website/docs/d/order_cart.html.markdown
+++ b/website/docs/d/order_cart.html.markdown
@@ -9,9 +9,10 @@ Use this data source to create a temporary order cart to retrieve information or
 ## Example Usage
 
 ```hcl
+data "ovh_me" "myaccount" {}
+
 data "ovh_order_cart" "mycart" {
- ovh_subsidiary = "fr"
- description    = "my cart"
+ ovh_subsidiary = data.ovh_me.myaccount.ovh_subsidiary
 }
 ```
 

--- a/website/docs/d/order_cart_product.html.markdown
+++ b/website/docs/d/order_cart_product.html.markdown
@@ -9,9 +9,10 @@ Use this data source to retrieve information of order cart product products.
 ## Example Usage
 
 ```hcl
+data "ovh_me" "myaccount" {}
+
 data "ovh_order_cart" "mycart" {
-  ovh_subsidiary = "fr"
-  description    = "my cart"
+  ovh_subsidiary = data.ovh_me.myaccount.ovh_subsidiary
 }
 
 data "ovh_order_cart_product" "plans" {

--- a/website/docs/d/order_cart_product_options.html.markdown
+++ b/website/docs/d/order_cart_product_options.html.markdown
@@ -9,9 +9,10 @@ Use this data source to retrieve information of order cart product options.
 ## Example Usage
 
 ```hcl
+data "ovh_me" "myaccount" {}
+
 data "ovh_order_cart" "mycart" {
-  ovh_subsidiary = "fr"
-  description    = "my cart"
+  ovh_subsidiary = data.ovh_me.myaccount.ovh_subsidiary
 }
 
 data "ovh_order_cart_product_options" "options" {

--- a/website/docs/d/order_cart_product_options_plan.html.markdown
+++ b/website/docs/d/order_cart_product_options_plan.html.markdown
@@ -9,9 +9,10 @@ Use this data source to retrieve information of order cart product options plan.
 ## Example Usage
 
 ```hcl
+data "ovh_me" "myaccount" {}
+
 data "ovh_order_cart" "mycart" {
-  ovh_subsidiary = "fr"
-  description    = "my cart"
+  ovh_subsidiary = data.ovh_me.myaccount.ovh_subsidiary
 }
 
 data "ovh_order_cart_product_options_plan" "plan" {

--- a/website/docs/d/order_cart_product_plan.html.markdown
+++ b/website/docs/d/order_cart_product_plan.html.markdown
@@ -9,9 +9,10 @@ Use this data source to retrieve information of order cart product plan.
 ## Example Usage
 
 ```hcl
+data "ovh_me" "myaccount" {}
+
 data "ovh_order_cart" "mycart" {
-  ovh_subsidiary = "fr"
-  description    = "my cart"
+  ovh_subsidiary = data.ovh_me.myaccount.ovh_subsidiary
 }
 
 data "ovh_order_cart_product_plan" "plan" {

--- a/website/docs/r/cloud_project.html.markdown
+++ b/website/docs/r/cloud_project.html.markdown
@@ -13,9 +13,10 @@ Orders a public cloud project.
 ## Example Usage
 
 ```hcl
+data "ovh_me" "myaccount" {}
+
 data "ovh_order_cart" "mycart" {
-  ovh_subsidiary = "fr"
-  description    = "my cloud order cart"
+  ovh_subsidiary = data.ovh_me.myaccount.ovh_subsidiary
 }
 
 data "ovh_order_cart_product_plan" "cloud" {

--- a/website/docs/r/hosting_privatedatabase.html.markdown
+++ b/website/docs/r/hosting_privatedatabase.html.markdown
@@ -13,9 +13,10 @@ Creates an OVHcloud managed private cloud database.
 ## Example Usage
 
 ```hcl
+data "ovh_me" "myaccount" {}
+
 data "ovh_order_cart" "mycart" {
-  ovh_subsidiary = "fr"
-  description    = "my privatedatabase order cart"
+  ovh_subsidiary = data.ovh_me.myaccount.ovh_subsidiary
 }
 
 data "ovh_order_cart_product_plan" "database" {

--- a/website/docs/r/ip_service.html.markdown
+++ b/website/docs/r/ip_service.html.markdown
@@ -18,9 +18,10 @@ Use with caution.
 ## Example Usage
 
 ```hcl
+data "ovh_me" "myaccount" {}
+
 data "ovh_order_cart" "mycart" {
   ovh_subsidiary = "fr"
-  description    = "order ip block"
 }
 
 data "ovh_order_cart_product_plan" "ipblock" {

--- a/website/docs/r/iploadbalancing.html.markdown
+++ b/website/docs/r/iploadbalancing.html.markdown
@@ -17,9 +17,10 @@ Use with caution.
 ## Example Usage
 
 ```hcl
+data "ovh_me" "myaccount" {}
+
 data "ovh_order_cart" "mycart" {
- ovh_subsidiary = "fr"
- description    = "mycart"
+ ovh_subsidiary = data.ovh_me.myaccount.ovh_subsidiary
 }
 
 data "ovh_order_cart_product_plan" "iplb" {

--- a/website/docs/r/ovh_domain_zone.html.markdown
+++ b/website/docs/r/ovh_domain_zone.html.markdown
@@ -13,8 +13,10 @@ Creates a domain zone.
 ## Example Usage
 
 ```hcl
+data "ovh_me" "myaccount" {}
+
 data "ovh_order_cart" "mycart" {
-  ovh_subsidiary = "fr"
+  ovh_subsidiary = data.ovh_me.myaccount.ovh_subsidiary
 }
 
 data "ovh_order_cart_product_plan" "zone" {

--- a/website/docs/r/vrack.html.markdown
+++ b/website/docs/r/vrack.html.markdown
@@ -15,9 +15,10 @@ Orders a vrack.
 ## Example Usage
 
 ```hcl
+data "ovh_me" "myaccount" {}
+
 data "ovh_order_cart" "mycart" {
-  ovh_subsidiary = "fr"
-  description    = "my vrack order cart"
+  ovh_subsidiary = data.ovh_me.myaccount.ovh_subsidiary
 }
 
 data "ovh_order_cart_product_plan" "vrack" {

--- a/website/docs/r/vrack_ip.html.markdown
+++ b/website/docs/r/vrack_ip.html.markdown
@@ -10,8 +10,10 @@ Attach an IP block to a VRack.
 ## Example Usage
 
 ```hcl
+data "ovh_me" "myaccount" {}
+
 data "ovh_order_cart" "mycart" {
-  ovh_subsidiary = "fr"
+  ovh_subsidiary = data.ovh_me.myaccount.ovh_subsidiary
   description    = "my cart"
 }
 

--- a/website/docs/r/vrack_ip.html.markdown
+++ b/website/docs/r/vrack_ip.html.markdown
@@ -14,7 +14,6 @@ data "ovh_me" "myaccount" {}
 
 data "ovh_order_cart" "mycart" {
   ovh_subsidiary = data.ovh_me.myaccount.ovh_subsidiary
-  description    = "my cart"
 }
 
 data "ovh_order_cart_product_plan" "vrack" {


### PR DESCRIPTION
# Description
Update the order documentation and sample to use [ovh_me](https://registry.terraform.io/providers/ovh/ovh/latest/docs/data-sources/me) datasource  and its subsidiary attribute instead of hardcoding the "fr"
Also remove the description attribute when it was used to be leaner ;-) 


Fixes #xx (issue)

## Type of change
- [X ] Documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [X] Test A: `OVH_TESTACC_ORDER_CLOUD_PROJECT=1 make testacc TESTARGS="-run TestAccResourceCloudProject_basic"`
