### PR TITLE
Add a variable for the Managed Kubernetes Service upgrade test

### DIFF
--- a/ovh/provider_test.go
+++ b/ovh/provider_test.go
@@ -234,6 +234,7 @@ func testAccPreCheckKubernetes(t *testing.T) {
 	testAccPreCheckCloud(t)
 	checkEnvOrSkip(t, "OVH_CLOUD_PROJECT_KUBE_REGION_TEST")
 	checkEnvOrSkip(t, "OVH_CLOUD_PROJECT_KUBE_VERSION_TEST")
+	checkEnvOrSkip(t, "OVH_CLOUD_PROJECT_KUBE_PREV_VERSION_TEST")
 }
 
 // Checks that the environment variables needed for the /vrack/{service}/cloudProject acceptance tests

--- a/ovh/resource_cloud_project_kube_test.go
+++ b/ovh/resource_cloud_project_kube_test.go
@@ -1166,8 +1166,8 @@ func TestAccCloudProjectKubeUpdateVersion_basic(t *testing.T) {
 	name := acctest.RandomWithPrefix(test_prefix)
 	updatedName := acctest.RandomWithPrefix(test_prefix)
 
-	version1 := "1.24"
-	version2 := "1.25"
+	version1 := os.Getenv("OVH_CLOUD_PROJECT_KUBE_VERSION_TEST")
+	version2 := os.Getenv("OVH_CLOUD_PROJECT_KUBE_PREV_VERSION_TEST")
 
 	config := fmt.Sprintf(
 		testAccCloudProjectKubeConfig,

--- a/ovh/resource_cloud_project_kube_test.go
+++ b/ovh/resource_cloud_project_kube_test.go
@@ -1166,8 +1166,8 @@ func TestAccCloudProjectKubeUpdateVersion_basic(t *testing.T) {
 	name := acctest.RandomWithPrefix(test_prefix)
 	updatedName := acctest.RandomWithPrefix(test_prefix)
 
-	version1 := os.Getenv("OVH_CLOUD_PROJECT_KUBE_VERSION_TEST")
-	version2 := os.Getenv("OVH_CLOUD_PROJECT_KUBE_PREV_VERSION_TEST")
+	version1 := os.Getenv("OVH_CLOUD_PROJECT_KUBE_PREV_VERSION_TEST")
+	version2 := os.Getenv("OVH_CLOUD_PROJECT_KUBE_VERSION_TEST")
 
 	config := fmt.Sprintf(
 		testAccCloudProjectKubeConfig,

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -145,6 +145,7 @@ variables must also be set:
 * `OVH_CLOUD_PROJECT_KUBE_REGION_TEST` - The region of your public cloud kubernetes project.
 
 * `OVH_CLOUD_PROJECT_KUBE_VERSION_TEST` - The version of your public cloud kubernetes project.
+* `OVH_CLOUD_PROJECT_KUBE_PREV_VERSION_TEST` - The previous version of your public cloud kubernetes project. This is used to test upgrade. 
 
 * `OVH_DEDICATED_SERVER` - The name of the dedicated server to test dedicated_server_networking resource.
 


### PR DESCRIPTION
# Description

The `TestAccCloudProjectKubeUpdateVersion_basic` was using deprecated kubernetes version that was hardcoded. 
This PR adds a variable (`OVH_CLOUD_PROJECT_KUBE_PREV_VERSION_TEST`) to specify the previous version (compared to `OVH_CLOUD_PROJECT_KUBE_VERSION_TEST`)

## Type of change

Please delete options that are not relevant.

- [ x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ x] `make testacc TESTARGS="-run TestAccCloudProjectKubeUpdateVersion_basic"`


