### PR TITLE
Update in ssh key doc 

### DIFF
--- a/website/docs/r/me_ssh_key.html.markdown
+++ b/website/docs/r/me_ssh_key.html.markdown
@@ -6,6 +6,8 @@ subcategory : "Account Management"
 
 Creates an SSH Key.
 
+-> __NOTE__ An SSH key in OVH provider cannot be currently used with Public Cloud instances through terraform. We advise  to use [openstack provider](https://registry.terraform.io/providers/terraform-provider-openstack/openstack/latest) to manage Public Cloud instances. Hence, if you need to associate an SSH key to a Public Cloud instance, you need to use [openstack_compute_keypair_v2](https://registry.terraform.io/providers/terraform-provider-openstack/openstack/latest/docs/resources/compute_keypair_v2)
+
 ## Example Usage
 
 ```hcl


### PR DESCRIPTION


# Description
Highlight the fact that the ovh ssh keys are currently not useable with Openstack resources

## Type of change

- [X ] Documentation update

# How Has This Been Tested?
N/A
