### PR TITLE
Fix add role ai training reader

### DIFF
--- a/ovh/resource_cloud_project_user.go
+++ b/ovh/resource_cloud_project_user.go
@@ -131,6 +131,7 @@ func validateCloudProjectUserRoleFunc(v interface{}, k string) (ws []string, err
 	err := helpers.ValidateStringEnum(v.(string), []string{
 		"administrator",
 		"ai_training_operator",
+		"ai_training_read",
 		"authentication",
 		"backup_operator",
 		"compute_operator",

--- a/website/docs/r/cloud_project_user.html.markdown
+++ b/website/docs/r/cloud_project_user.html.markdown
@@ -28,6 +28,7 @@ The following arguments are supported:
 * `role_names` - A list of role names. Values can be: 
   - administrator,
   - ai_training_operator
+  - ai_training_read
   - authentication
   - backup_operator
   - compute_operator


### PR DESCRIPTION
# Description

Add role [ia_training_read](https://github.com/ovh/terraform-provider-ovh/issues/471)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
```
 ~/Templates % terraform apply -auto-approve  
[...]
Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # ovh_cloud_project_user.ai-user will be created
  + resource "ovh_cloud_project_user" "ai-user" {
      + creation_date = (known after apply)
      + id            = (known after apply)
      + openstack_rc  = (known after apply)
      + password      = (sensitive value)
      + role_names    = [
          + "ai_training_operator",
          + "ai_training_read",
          + "objectstore_operator",
        ]
[...]

Plan: 1 to add, 0 to change, 0 to destroy.
[...]
Apply complete! Resources: 1 added, 0 changed, 0 destroyed.
```