### PR TITLE
feat(iam): add support for deny in policies

### DIFF
--- a/ovh/data_iam_policy.go
+++ b/ovh/data_iam_policy.go
@@ -51,6 +51,13 @@ func dataSourceIamPolicy() *schema.Resource {
 					Type: schema.TypeString,
 				},
 			},
+			"deny": {
+				Type:     schema.TypeSet,
+				Optional: true,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+			},
 			"owner": {
 				Type:     schema.TypeString,
 				Computed: true,

--- a/ovh/resource_iam_policy.go
+++ b/ovh/resource_iam_policy.go
@@ -52,6 +52,13 @@ func resourceIamPolicy() *schema.Resource {
 					Type: schema.TypeString,
 				},
 			},
+			"deny": {
+				Type:     schema.TypeSet,
+				Optional: true,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+			},
 			"owner": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -163,7 +170,13 @@ func prepareIamPolicyCall(d *schema.ResourceData) IamPolicy {
 
 	if except, ok := d.GetOk("except"); ok {
 		for _, e := range except.(*schema.Set).List() {
-			out.Permissions.Except = append(out.Permissions.Allow, IamAction{Action: e.(string)})
+			out.Permissions.Except = append(out.Permissions.Except, IamAction{Action: e.(string)})
+		}
+	}
+
+	if deny, ok := d.GetOk("deny"); ok {
+		for _, e := range deny.(*schema.Set).List() {
+			out.Permissions.Deny = append(out.Permissions.Deny, IamAction{Action: e.(string)})
 		}
 	}
 	return out

--- a/ovh/types_iam.go
+++ b/ovh/types_iam.go
@@ -44,13 +44,16 @@ func (p IamPolicy) ToMap() map[string]any {
 	}
 	out["resources"] = resources
 
-	// inline allow and except
-	allow, except := p.Permissions.ToLists()
+	// inline allow, except and deny
+	allow, except, deny := p.Permissions.ToLists()
 	if len(allow) != 0 {
 		out["allow"] = allow
 	}
 	if len(except) != 0 {
 		out["except"] = except
+	}
+	if len(deny) != 0 {
+		out["deny"] = deny
 	}
 
 	if p.Description != "" {
@@ -89,11 +92,13 @@ type IamResourceDetails struct {
 type IamPermissions struct {
 	Allow  []IamAction `json:"allow"`
 	Except []IamAction `json:"except"`
+	Deny   []IamAction `json:"deny"`
 }
 
-func (p IamPermissions) ToLists() ([]string, []string) {
+func (p IamPermissions) ToLists() ([]string, []string, []string) {
 	var allow []string
 	var except []string
+	var deny []string
 
 	for _, r := range p.Allow {
 		allow = append(allow, r.Action)
@@ -102,7 +107,11 @@ func (p IamPermissions) ToLists() ([]string, []string) {
 	for _, r := range p.Except {
 		except = append(except, r.Action)
 	}
-	return allow, except
+
+	for _, r := range p.Deny {
+		deny = append(deny, r.Action)
+	}
+	return allow, except, deny
 }
 
 type IamAction struct {

--- a/website/docs/d/iam_policy.html.markdown
+++ b/website/docs/d/iam_policy.html.markdown
@@ -25,7 +25,8 @@ data "ovh_iam_policy" "my_policy" {
 * `identities` - List of identities affected by the policy.
 * `resources` - List of resources affected by the policy.
 * `allow` - List of actions allowed by the policy.
-* `except` - List of actions.
+* `except` - List of actions that will be subtracted from the `allow` list.
+* `deny` - List of actions that will be denied no matter what policy exists.
 * `owner` - Owner of the policy.
 * `created_at` - Creation date of this group.
 * `updated_at` - Date of the last update of this group.

--- a/website/docs/r/iam_policy.html.markdown
+++ b/website/docs/r/iam_policy.html.markdown
@@ -21,7 +21,7 @@ resource "ovh_iam_policy" "manager" {
   description = "Users are allowed to use the OVH manager"
   identities  = [ovh_me_identity_group.my_group.urn]
   resources   = [data.ovh_me.account.urn]
-  # these are all the actions 
+  # these are all the actions
   allow = [
     "account:apiovh:me/get",
     "account:apiovh:me/supportLevel/get",
@@ -41,6 +41,7 @@ resource "ovh_iam_policy" "manager" {
 * `resources` - List of resources affected by the policy
 * `allow` - List of actions allowed on resources by identities
 * `except` - List of overrides of action that must not be allowed even if they are caught by allow. Only makes sens if allow contains wildcards.
+* `deny` - List of actions that will be denied no matter what policy exists.
 
 ## Attributes Reference
 


### PR DESCRIPTION
# Description

This PR adds support for the "deny" permissions category in policies. This is the API endpoint to create policies : https://api.ovh.com/console-preview/?section=%2Fiam&branch=v2#post-/iam/policy

## Type of change

Please delete options that are not relevant.

- [x] Improvement (improve existing resource(s) or datasource(s))

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] acceptance tests for IAM objects: `TF_ACC=1 go test -v  ./... -run 'TestAccIam.*'`

**Test Configuration**:
* Terraform version: `terraform version`: Terraform v1.6.2
* Existing HCL configuration you used: 
```hcl
resource "ovh_iam_policy" "policy2" {
	name        = "tf-test2"
	description = "tf-test2"
	identities  = ["urn:v1:eu:identity:user:<nic>/alice"]
	resources   = ["urn:v1:eu:resource:publicCloudProject:<resourceID>"]
	deny 	    = ["publicCloudProject:openstack:computeOperator"]
}
```

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or issues
- [x] I have added acceptance tests that prove my fix is effective or that my feature works
- [x] New and existing acceptance tests pass locally with my changes
- [x] I ran succesfully `go mod vendor` if I added or modify `go.mod` file
