### PR TITLE
add import documentation for zone

### DIFF
--- a/website/docs/r/ovh_domain_zone.html.markdown
+++ b/website/docs/r/ovh_domain_zone.html.markdown
@@ -89,3 +89,9 @@ Id is set to the order Id. In addition, the following attributes are exported:
     * `order_detail_id` - order detail id
     * `domain` - expiration date
     * `quantity` - quantity
+
+## Import
+Zone can be imported using the `order_id` that can be retrieved in the [order page](https://www.ovh.com/manager/#/dedicated/billing/orders/orders) at the creation time of the zone. 
+```bash
+$ terraform import ovh_domain_zone.zone order_id
+```


### PR DESCRIPTION
# Description
Add documentation on how to import domain_zone resource
Fixes #481 

## Type of change

- [X ] Documentation update

# How Has This Been Tested?

**Test Configuration**:
* Terraform version: `terraform version`: Terraform v1.6.2
* Existing HCL configuration you used: 
```hcl
data "ovh_me" "myaccount" {}

data "ovh_order_cart" "mycart" {
  ovh_subsidiary = data.ovh_me.myaccount.ovh_subsidiary
}

data "ovh_order_cart_product_plan" "zone" {
  cart_id        = data.ovh_order_cart.mycart.id
  price_capacity = "renew"
  product        = "dns"
  plan_code      = "zone"
}

resource "ovh_domain_zone" "main" {
  ovh_subsidiary = data.ovh_order_cart.mycart.ovh_subsidiary

  plan {
    duration     = data.ovh_order_cart_product_plan.zone.selected_price.0.duration
    plan_code    = data.ovh_order_cart_product_plan.zone.plan_code
    pricing_mode = data.ovh_order_cart_product_plan.zone.selected_price.0.pricing_mode
  }
}
```
* `terraform import ovh_domain_zone.main XXXXXX`
# Checklist:
N/A