### PR TITLE
fix(s3): fix s3 credentials secret retrieval

### DIFF
--- a/ovh/data_cloud_project_user_s3_credential.go
+++ b/ovh/data_cloud_project_user_s3_credential.go
@@ -52,14 +52,14 @@ func dataCloudProjectUserS3CredentialRead(d *schema.ResourceData, meta interface
 	log.Printf("[DEBUG] Will read public cloud secret access key for access key %s user %s on project: %s", accessKey, userID, serviceName)
 
 	endpoint := fmt.Sprintf(
-		"/cloud/project/%s/user/%s/s3Credentials/%s",
+		"/cloud/project/%s/user/%s/s3Credentials/%s/secret",
 		url.PathEscape(serviceName),
 		url.PathEscape(userID),
 		url.PathEscape(accessKey),
 	)
 
-	s3Credential := &CloudProjectUserS3Credential{}
-	if err := config.OVHClient.Get(endpoint, &s3Credential); err != nil {
+	s3Credential := &CloudProjectUserS3Secret{}
+	if err := config.OVHClient.Post(endpoint, nil, &s3Credential); err != nil {
 		return helpers.CheckDeleted(d, err, endpoint)
 	}
 

--- a/ovh/resource_cloud_project_user_s3_credential_test.go
+++ b/ovh/resource_cloud_project_user_s3_credential_test.go
@@ -33,6 +33,12 @@ func TestAccCloudProjectUserS3Credential_basic(t *testing.T) {
 				Config: config,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet(
+						"ovh_cloud_project_user_s3_credential.s3_cred", "service_name"),
+					resource.TestCheckResourceAttrSet(
+						"ovh_cloud_project_user_s3_credential.s3_cred", "user_id"),
+					resource.TestCheckResourceAttrSet(
+						"ovh_cloud_project_user_s3_credential.s3_cred", "internal_user_id"),
+					resource.TestCheckResourceAttrSet(
 						"ovh_cloud_project_user_s3_credential.s3_cred", "access_key_id"),
 					resource.TestCheckResourceAttrSet(
 						"ovh_cloud_project_user_s3_credential.s3_cred", "secret_access_key"),

--- a/ovh/types_cloud.go
+++ b/ovh/types_cloud.go
@@ -151,9 +151,17 @@ type CloudProjectUserOpenstackRC struct {
 
 type CloudProjectUserS3Credential struct {
 	Access      string `json:"access"`
-	Secret      string `json:"secret"`
 	ServiceName string `json:"tenantId"`
 	UserId      string `json:"userId"`
+}
+
+type CloudProjectUserS3Secret struct {
+	Secret string `json:"secret"`
+}
+
+type CloudProjectUserS3CredentialSecret struct {
+	CloudProjectUserS3Credential
+	CloudProjectUserS3Secret
 }
 
 func (u *CloudProjectUserS3Credential) String() string {
@@ -163,9 +171,30 @@ func (u *CloudProjectUserS3Credential) String() string {
 func (u CloudProjectUserS3Credential) ToMap() map[string]interface{} {
 	obj := make(map[string]interface{})
 	obj["access_key_id"] = u.Access
-	obj["secret_access_key"] = u.Secret
 	obj["service_name"] = u.ServiceName
 	obj["internal_user_id"] = u.UserId
+	return obj
+}
+
+func (u *CloudProjectUserS3Secret) String() string {
+	return "CloudProjectUserS3Secret[Secret: ***]"
+}
+
+func (u CloudProjectUserS3Secret) ToMap() map[string]interface{} {
+	obj := make(map[string]interface{})
+	obj["secret_access_key"] = u.Secret
+	return obj
+}
+
+func (u *CloudProjectUserS3CredentialSecret) String() string {
+	return fmt.Sprintf("CloudProjectUserS3CredentialSecret[ServiceName:%s, UserId: %s, Access: %s, Secret: ***]", u.ServiceName, u.UserId, u.Access)
+}
+
+func (u CloudProjectUserS3CredentialSecret) ToMap() map[string]interface{} {
+	obj := u.CloudProjectUserS3Credential.ToMap()
+	for k, v := range u.CloudProjectUserS3Secret.ToMap() {
+		obj[k] = v
+	}
 	return obj
 }
 


### PR DESCRIPTION
# Description

Fix the security update that removes S3 secret key from GET calls in OVH API.

Fixes #490

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

It has been tested to retrieve a user and check that the secret is properly returned.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or issues
- [x] I have added acceptance tests that prove my fix is effective or that my feature works
- [x] New and existing acceptance tests pass locally with my changes
- [x] I ran succesfully `go mod vendor` if I added or modify `go.mod` file
