### PR TITLE
fix(ovh_domain_zone_record): attribute fieldtype doesn't exist in PUT request body

### DIFF
--- a/ovh/resource_domain_zone_record.go
+++ b/ovh/resource_domain_zone_record.go
@@ -19,7 +19,7 @@ type OvhDomainZoneRecord struct {
 	Zone      string `json:"zone,omitempty"`
 	Target    string `json:"target"`
 	Ttl       int    `json:"ttl,omitempty"`
-	FieldType string `json:"fieldType"`
+	FieldType string `json:"fieldType,omitempty"`
 	SubDomain string `json:"subDomain,omitempty"`
 }
 
@@ -195,9 +195,6 @@ func resourceOvhDomainZoneRecordUpdate(d *schema.ResourceData, meta interface{})
 
 	if attr, ok := d.GetOk("subdomain"); ok {
 		record.SubDomain = attr.(string)
-	}
-	if attr, ok := d.GetOk("fieldtype"); ok {
-		record.FieldType = attr.(string)
 	}
 	if attr, ok := d.GetOk("target"); ok {
 		record.Target = attr.(string)


### PR DESCRIPTION
# Description

When updating a resource of type `ovh_domain_zone_record`, an attribute `fieldtype` was set in the request body of the API call `PUT /domain/zone/{zoneName}/record/{id}`. This field is not declared in the API specifications so the updates end up in 400 HTTP error.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (improve existing resource(s) or datasource(s))
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Acceptance tests: `make testacc TESTARGS="-parallel=1 -run=TestAccDomainZoneRecord"`

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or issues
- [x] I have added acceptance tests that prove my fix is effective or that my feature works
- [x] New and existing acceptance tests pass locally with my changes
- [x] I ran succesfully `go mod vendor` if I added or modify `go.mod` file
