### PR TITLE
add acceptance test for a template name not found + fix the #497 issue

### DIFF
--- a/ovh/data_me_installation_template.go
+++ b/ovh/data_me_installation_template.go
@@ -254,6 +254,9 @@ func dataSourceMeInstallationTemplateRead(d *schema.ResourceData, meta interface
 	if err != nil {
 		return err
 	}
+	if template == nil {
+		return fmt.Errorf("Your query returned no results. Please change your search criteria")
+	}
 
 	// set attributes
 	for k, v := range template.ToMap() {

--- a/ovh/data_me_installation_template_test.go
+++ b/ovh/data_me_installation_template_test.go
@@ -2,6 +2,7 @@ package ovh
 
 import (
 	"fmt"
+	"regexp"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
@@ -45,10 +46,19 @@ func TestAccMeInstallationTemplateDataSource_basic(t *testing.T) {
 					),
 				),
 			},
+			{
+				Config:      testAccMeInstallationTemplateDatasourceConfig_404,
+				ExpectError: regexp.MustCompile("Your query returned no results. Please change your search criteria"),
+			},
 		},
 	})
 }
 
+const testAccMeInstallationTemplateDatasourceConfig_404 = `
+data "ovh_me_installation_template" "template" {
+	template_name = "42"
+  }
+`
 const testAccMeInstallationTemplateDatasourceConfig_Basic = `
 resource "ovh_me_installation_template" "template" {
   base_template_name = "centos7_64"


### PR DESCRIPTION
# Description
Fixes #497  : when a template was not found the data source launched a panic. 

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [X ] Test A: `make testacc TESTARGS="-run TestAccMeInstallationTemplateDataSource_basic"`
