### PR TITLE
fix failing acceptance tests

### DIFF
--- a/.cds/terraform-provider-ovh.yml
+++ b/.cds/terraform-provider-ovh.yml
@@ -301,17 +301,6 @@ workflow:
     pipeline: terraform-provider-ovh-testacc
     when:
     - success
-  Tests_CloudProjectKubeVRack:
-    application: terraform-provider-ovh
-    depends_on:
-    - terraform-provider-ovh-pre-sweepers
-    environment: acctests
-    one_at_a_time: true
-    parameters:
-      testargs: -run CloudProjectKubeVRack
-    pipeline: terraform-provider-ovh-testacc
-    when:
-    - success
   Tests_CloudProjectKube_basic:
     application: terraform-provider-ovh
     depends_on:
@@ -540,8 +529,7 @@ workflow:
     environment: acctests
     one_at_a_time: true
     parameters:
-      # Skip TestAccDataSourceOrderCartCloudOptionsPlan_basic as it references a vRack service, already tested in pipeline Tests_Vrack
-      testargs: -run TestAccDataSourceOrderCart -skip TestAccDataSourceOrderCartCloudOptionsPlan_basic
+      testargs: -run TestAccDataSourceOrderCart
     pipeline: terraform-provider-ovh-testacc
     when:
     - success
@@ -619,7 +607,7 @@ workflow:
     one_at_a_time: true
     parameters:
       # Include specific test TestAccCloudProjectNetwork as it uses a vRack service
-      testargs: -run 'Vrack|TestAccCloudProjectNetwork|TestAccDataSourceOrderCartCloudOptionsPlan_basic'
+      testargs: -run 'Vrack|TestAccCloudProjectNetwork|TestAccCloudProjectKubeVRack'
     pipeline: terraform-provider-ovh-testacc
     when:
     - success
@@ -667,7 +655,6 @@ workflow:
     - Tests_CloudProjectKubeDataSource
     - Tests_CloudProjectKubeCustomization
     - Tests_CloudProjectKube_kube_proxy
-    - Tests_CloudProjectKubeVRack
     - Tests_CloudProjectKubeEmptyVersion
     - Tests_CloudProjectKubeUpdate
     - Tests_CloudProjectKube_basic

--- a/ovh/data_order_cart_product_options_plan_test.go
+++ b/ovh/data_order_cart_product_options_plan_test.go
@@ -37,7 +37,7 @@ func TestAccDataSourceOrderCartCloudOptionsPlan_basic(t *testing.T) {
 		t,
 		"cloud",
 		"project",
-		"vrack",
+		"certification.hds",
 	)
 }
 


### PR DESCRIPTION
# Description

This PR fixes:
- Acceptance test `TestAccDataSourceOrderCartCloudOptionsPlan_basic` that used an invalid `optionCode` value
- The workflow that runs the acceptance tests. Until now, several tests using the same `vRack` service ran in parallel, which made the tests fail

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (improve existing resource(s) or datasource(s))
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] All acceptance tests run using the CDS workflow

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or issues
- [ ] I have added acceptance tests that prove my fix is effective or that my feature works
- [x] New and existing acceptance tests pass locally with my changes
- [ ] I ran succesfully `go mod vendor` if I added or modify `go.mod` file
