### PR TITLE
Datasource cloud public project vrack

### DIFF
--- a/ovh/data_cloud_project_vrack.go
+++ b/ovh/data_cloud_project_vrack.go
@@ -42,7 +42,7 @@ func dataSourceCloudProjectVrackRead(ctx context.Context, d *schema.ResourceData
 
 	log.Printf("[DEBUG] Will read public cloud vRack for project: %s", serviceName)
 
-	res := &CloudProjectVerackResponse{}
+	res := &CloudProjectVrackResponse{}
 	endpoint := fmt.Sprintf(
 		"/cloud/project/%s/vrack",
 		url.PathEscape(serviceName),

--- a/ovh/data_cloud_project_vrack.go
+++ b/ovh/data_cloud_project_vrack.go
@@ -1,0 +1,63 @@
+package ovh
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"net/url"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/ovh/terraform-provider-ovh/ovh/helpers"
+)
+
+func dataSourceCloudProjectVrack() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceCloudProjectVrackRead,
+		Schema: map[string]*schema.Schema{
+			"service_name": {
+				Type:        schema.TypeString,
+				Required:    true,
+				DefaultFunc: schema.EnvDefaultFunc("OVH_CLOUD_PROJECT_SERVICE", nil),
+			},
+			"id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"description": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func dataSourceCloudProjectVrackRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	config := meta.(*Config)
+	serviceName := d.Get("service_name").(string)
+
+	log.Printf("[DEBUG] Will read public cloud vRack for project: %s", serviceName)
+
+	res := &CloudProjectVerackResponse{}
+	endpoint := fmt.Sprintf(
+		"/cloud/project/%s/vrack",
+		url.PathEscape(serviceName),
+	)
+	if err := config.OVHClient.Get(endpoint, res); err != nil {
+		return diag.FromErr(helpers.CheckDeleted(d, err, endpoint))
+	}
+
+	for k, v := range res.ToMap(d) {
+		if k != "id" {
+			d.Set(k, v)
+		} else {
+			d.SetId(fmt.Sprint(v))
+		}
+	}
+
+	return nil
+}

--- a/ovh/data_cloud_project_vrack_test.go
+++ b/ovh/data_cloud_project_vrack_test.go
@@ -1,0 +1,28 @@
+package ovh
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccCloudProjectVrackDataSource_basic(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheckCloud(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCloudProjectVrackDatasourceConfig,
+				Check:  resource.TestCheckResourceAttrSet("data.ovh_cloud_project_vrack.vrack", "id"),
+			},
+		},
+	})
+}
+
+var testAccCloudProjectVrackDatasourceConfig = fmt.Sprintf(`
+data "ovh_cloud_project_vrack" "vrack" {
+  service_name = "%s"
+}
+`, os.Getenv("OVH_CLOUD_PROJECT_SERVICE_TEST"))

--- a/ovh/provider.go
+++ b/ovh/provider.go
@@ -94,6 +94,7 @@ func Provider() *schema.Provider {
 			"ovh_cloud_project_user_s3_credentials":                   dataCloudProjectUserS3Credentials(),
 			"ovh_cloud_project_user_s3_policy":                        dataCloudProjectUserS3Policy(),
 			"ovh_cloud_project_users":                                 datasourceCloudProjectUsers(),
+			"ovh_cloud_project_vrack":                                 dataSourceCloudProjectVrack(),
 			"ovh_dbaas_logs_cluster":                                  dataSourceDbaasLogsCluster(),
 			"ovh_dbaas_logs_input_engine":                             dataSourceDbaasLogsInputEngine(),
 			"ovh_dbaas_logs_output_graylog_stream":                    dataSourceDbaasLogsOutputGraylogStream(),

--- a/ovh/types_cloud_project_vrack.go
+++ b/ovh/types_cloud_project_vrack.go
@@ -1,0 +1,19 @@
+package ovh
+
+import (
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+type CloudProjectVrackResponse struct {
+	Id          string `json:"id"`
+	Name        string `json:"name"`
+	Description string `json:"description"`
+}
+
+func (v *CloudProjectVrackResponse) ToMap(d *schema.ResourceData) map[string]interface{} {
+	obj := make(map[string]interface{})
+	obj["id"] = v.Id
+	obj["name"] = v.Name
+	obj["description"] = v.Description
+	return obj
+}

--- a/website/docs/d/cloud_project_vrack.html.markdown
+++ b/website/docs/d/cloud_project_vrack.html.markdown
@@ -1,0 +1,34 @@
+---
+subcategory : "Public Cloud Network"
+---
+
+# ovh_cloud_project_vrack (Data Source)
+
+Use this data source to get the linked vrack on your public cloud project.
+
+## Example Usage
+
+```hcl
+data "ovh_cloud_project_vrack" "vrack" {
+  service_name = "XXXXXX"
+}
+
+output "vrack" {
+  value = data.ovh_cloud_project_vrack.vrack
+}
+```
+
+## Argument Reference
+
+
+* `service_name` - The id of the public cloud project. If omitted,
+    the `OVH_CLOUD_PROJECT_SERVICE` environment variable is used. 
+
+
+## Attributes Reference
+
+The following attributes are exported
+* `id` - The id of the vrack
+* `name` - The name of the vrack
+* `decription` - The description of the vrack
+* `service_name` - The id of the public cloud project


### PR DESCRIPTION
# Description

To prepare test for this issue https://github.com/ovh/terraform-provider-ovh/issues/402, i need data to get vrack for a public cloud project

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] Documentation update

# How Has This Been Tested?

- [x] Test: 
```hcl
 % make testacc TESTARGS="-run TestAccCloudProjectVrackDataSource_basic"                                                    
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -run TestAccCloudProjectVrackDataSource_basic -timeout 600m -p 10
?       github.com/ovh/terraform-provider-ovh   [no test files]
?       github.com/ovh/terraform-provider-ovh/ovh/helpers       [no test files]
=== RUN   TestAccCloudProjectVrackDataSource_basic
--- PASS: TestAccCloudProjectVrackDataSource_basic (1.64s)
PASS
ok      github.com/ovh/terraform-provider-ovh/ovh       1.649s
testing: warning: no tests to run
PASS
ok      github.com/ovh/terraform-provider-ovh/ovh/helpers/hashcode      0.002s [no tests to run]
```

**Test Configuration**:
* Terraform version: `terraform version`: Terraform v1.5.7
* Existing HCL configuration you used: 
```hcl
data "ovh_cloud_project_vrack" "vrack"{
  service_name = "xxxxxxxxxxxxxxxxxxx"
}

output "vrack"{
   value       = data.ovh_cloud_project_vrack.vrack
}
```

output : 
```
Apply complete! Resources: 0 added, 0 changed, 0 destroyed.

Outputs:

vrack = {
  "description" = ""
  "id" = "yyyyyyyyy"
  "name" = ""
  "service_name" = "xxxxxxxxxxxxxxxxxxx"
}
```

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or issues
- [x] I have added acceptance tests that prove my fix is effective or that my feature works
- [x] New and existing acceptance tests pass locally with my changes