### PR TITLE
fix #405 by stating that `BANK_ACCOUNT` is not anymore supported 

### DIFF
--- a/website/docs/r/cloud_project.html.markdown
+++ b/website/docs/r/cloud_project.html.markdown
@@ -10,7 +10,10 @@ Orders a public cloud project.
 
 -> __NOTE__ To order a product through Terraform, your account needs to have a default payment method defined. This can be done in the [OVHcloud Control Panel](https://www.ovh.com/manager/#/dedicated/billing/payment/method) or via API with the [/me/payment/method](https://api.ovh.com/console/#/me/payment/method~GET) endpoint.
 
+~> __WARNING__ `BANK_ACCOUNT` is not supported anymore, please update your default payment method to `SEPA_DIRECT_DEBIT`
+
 ## Example Usage
+
 
 ```hcl
 data "ovh_me" "myaccount" {}

--- a/website/docs/r/hosting_privatedatabase.html.markdown
+++ b/website/docs/r/hosting_privatedatabase.html.markdown
@@ -10,6 +10,8 @@ Creates an OVHcloud managed private cloud database.
 
 -> __NOTE__ To order a product through Terraform, your account needs to have a default payment method defined. This can be done in the [OVHcloud Control Panel](https://www.ovh.com/manager/#/dedicated/billing/payment/method) or via API with the [/me/payment/method](https://api.ovh.com/console/#/me/payment/method~GET) endpoint.
 
+~> __WARNING__ `BANK_ACCOUNT` is not supported anymore, please update your default payment method to `SEPA_DIRECT_DEBIT`
+
 ## Example Usage
 
 ```hcl

--- a/website/docs/r/ip_service.html.markdown
+++ b/website/docs/r/ip_service.html.markdown
@@ -14,6 +14,8 @@ Use with caution.
 
 -> __NOTE__ To order a product through Terraform, your account needs to have a default payment method defined. This can be done in the [OVHcloud Control Panel](https://www.ovh.com/manager/#/dedicated/billing/payment/method) or via API with the [/me/payment/method](https://api.ovh.com/console/#/me/payment/method~GET) endpoint.
 
+~> __WARNING__ `BANK_ACCOUNT` is not supported anymore, please update your default payment method to `SEPA_DIRECT_DEBIT`
+
 
 ## Example Usage
 

--- a/website/docs/r/iploadbalancing.html.markdown
+++ b/website/docs/r/iploadbalancing.html.markdown
@@ -13,6 +13,7 @@ Use with caution.
 
 -> __NOTE__ To order a product through Terraform, your account needs to have a default payment method defined. This can be done in the [OVHcloud Control Panel](https://www.ovh.com/manager/#/dedicated/billing/payment/method) or via API with the [/me/payment/method](https://api.ovh.com/console/#/me/payment/method~GET) endpoint.
 
+~> __WARNING__ `BANK_ACCOUNT` is not supported anymore, please update your default payment method to `SEPA_DIRECT_DEBIT`
 
 ## Example Usage
 

--- a/website/docs/r/ovh_domain_zone.html.markdown
+++ b/website/docs/r/ovh_domain_zone.html.markdown
@@ -10,6 +10,9 @@ Creates a domain zone.
 
 -> __NOTE__ To order a product through Terraform, your account needs to have a default payment method defined. This can be done in the [OVHcloud Control Panel](https://www.ovh.com/manager/#/dedicated/billing/payment/method) or via API with the [/me/payment/method](https://api.ovh.com/console/#/me/payment/method~GET) endpoint.
 
+~> __WARNING__ `BANK_ACCOUNT` is not supported anymore, please update your default payment method to `SEPA_DIRECT_DEBIT`
+
+
 ## Example Usage
 
 ```hcl

--- a/website/docs/r/vrack.html.markdown
+++ b/website/docs/r/vrack.html.markdown
@@ -10,7 +10,10 @@ Orders a vrack.
 
 -> __NOTE__ To order a product through Terraform, your account needs to have a default payment method defined. This can be done in the [OVHcloud Control Panel](https://www.ovh.com/manager/#/dedicated/billing/payment/method) or via API with the [/me/payment/method](https://api.ovh.com/console/#/me/payment/method~GET) endpoint.
 
--> __WARNING__ Currently, the OVHcloud API doesn't support Vrack termination. You have to open a support ticket to ask for vrack termination. Otherwise, you may hit vrack quota issues.
+~> __WARNING__ Currently, the OVHcloud API doesn't support Vrack termination. You have to open a support ticket to ask for vrack termination. Otherwise, you may hit vrack quota issues.
+
+~> __WARNING__ `BANK_ACCOUNT` is not supported anymore, please update your default payment_method to `SEPA_DIRECT_DEBIT`
+
 
 ## Example Usage
 


### PR DESCRIPTION
# Description
Fix documentation by stating that `BANK_ACCOUNT` payment method  is not supported anymore and shall be replaced by `SEPA_DIRECT_DEBIT`
