### PR TITLE
feat(ip) - add ovh_ip_move resource to move an IP to a provided service name or park it if no service name given

### DIFF
--- a/.cds/terraform-provider-ovh.yml
+++ b/.cds/terraform-provider-ovh.yml
@@ -599,6 +599,17 @@ workflow:
     pipeline: terraform-provider-ovh-testacc
     when:
     - success
+  Tests_TestAccIpMove_basic:
+    application: terraform-provider-ovh
+    depends_on:
+    - terraform-provider-ovh-pre-sweepers
+    environment: acctests
+    one_at_a_time: true
+    parameters:
+      testargs: -run TestAccIpMove_basic
+    pipeline: terraform-provider-ovh-testacc
+    when:
+    - success
   Tests_TestAccVPS:
     application: terraform-provider-ovh
     depends_on:
@@ -690,6 +701,7 @@ workflow:
     - Tests_TestAccResourceCloudProjectFailoverIpAttachTestAccResourceCloudProject_basic
     - Tests_TestAccCloudProjectWorkflowBackup
     - Tests_TestAccResourceIpService_basic
+    - Tests_TestAccIpMove_basic
     environment: acctests
     one_at_a_time: true
     pipeline: terraform-provider-ovh-post-sweepers

--- a/README.md
+++ b/README.md
@@ -137,7 +137,6 @@ In order for all the tests to pass you can run:
 export OVH_IP_TEST="..."
 export OVH_IP_BLOCK_TEST="..."
 export OVH_IP_REVERSE_TEST="..."
-export OVH_IP_MOVE_TEST="..."
 export OVH_IP_MOVE_SERVICE_NAME_TEST="..."
 export OVH_IPLB_SERVICE_TEST="..."
 export OVH_CLOUD_PROJECT_SERVICE_TEST="..."

--- a/README.md
+++ b/README.md
@@ -137,6 +137,8 @@ In order for all the tests to pass you can run:
 export OVH_IP_TEST="..."
 export OVH_IP_BLOCK_TEST="..."
 export OVH_IP_REVERSE_TEST="..."
+export OVH_IP_MOVE_TEST="..."
+export OVH_IP_MOVE_SERVICE_NAME_TEST="..."
 export OVH_IPLB_SERVICE_TEST="..."
 export OVH_CLOUD_PROJECT_SERVICE_TEST="..."
 export OVH_CLOUD_PROJECT_FAILOVER_IP_TEST="..."

--- a/ovh/helpers/helpers.go
+++ b/ovh/helpers/helpers.go
@@ -428,3 +428,17 @@ func ValidateHostingPrivateDatabaseUserGrant(value string) error {
 		"rw",
 	})
 }
+
+func ServiceNameFromIpBlock(ip string) (*string, error) {
+	parsedIp := net.ParseIP(ip)
+	if parsedIp == nil {
+		var err error
+		parsedIp, _, err = net.ParseCIDR(ip)
+		if err != nil {
+			return nil, fmt.Errorf("ip %s is not valid IP nor a valid CIDR", ip)
+		}
+	}
+	serviceName := fmt.Sprintf("ip-%s", parsedIp)
+
+	return &serviceName, nil
+}

--- a/ovh/provider.go
+++ b/ovh/provider.go
@@ -200,6 +200,7 @@ func Provider() *schema.Provider {
 			"ovh_iam_resource_group":                                         resourceIamResourceGroup(),
 			"ovh_ip_reverse":                                                 resourceIpReverse(),
 			"ovh_ip_service":                                                 resourceIpService(),
+			"ovh_ip_move":                                                    resourceIpServiceMove(),
 			"ovh_iploadbalancing":                                            resourceIpLoadbalancing(),
 			"ovh_iploadbalancing_http_farm":                                  resourceIpLoadbalancingHttpFarm(),
 			"ovh_iploadbalancing_http_farm_server":                           resourceIpLoadbalancingHttpFarmServer(),

--- a/ovh/provider_test.go
+++ b/ovh/provider_test.go
@@ -116,7 +116,6 @@ func testAccPreCheckIp(t *testing.T) {
 // are set.
 func testAccPreCheckIpMove(t *testing.T) {
 	testAccPreCheckCredentials(t)
-	checkEnvOrSkip(t, "OVH_IP_MOVE_TEST")
 	checkEnvOrSkip(t, "OVH_IP_MOVE_SERVICE_NAME_TEST")
 }
 

--- a/ovh/provider_test.go
+++ b/ovh/provider_test.go
@@ -112,6 +112,14 @@ func testAccPreCheckIp(t *testing.T) {
 	checkEnvOrSkip(t, "OVH_IP_REVERSE_TEST")
 }
 
+// Checks that the environment variables needed for the /ip/move acceptance tests
+// are set.
+func testAccPreCheckIpMove(t *testing.T) {
+	testAccPreCheckCredentials(t)
+	checkEnvOrSkip(t, "OVH_IP_MOVE_TEST")
+	checkEnvOrSkip(t, "OVH_IP_MOVE_SERVICE_NAME_TEST")
+}
+
 // Checks that the environment variables needed to order /ip/service for acceptance tests
 // are set.
 func testAccPreCheckOrderIpService(t *testing.T) {

--- a/ovh/resource_ip_move.go
+++ b/ovh/resource_ip_move.go
@@ -1,0 +1,309 @@
+package ovh
+
+import (
+	"fmt"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/ovh/go-ovh/ovh"
+	"github.com/ovh/terraform-provider-ovh/ovh/helpers"
+	"log"
+	"net/url"
+	"reflect"
+	"strconv"
+	"time"
+)
+
+// taskExpiresAfter is the duration in seconds after which we'll consider an ongoing task to be expired and we'll allow ourselves to create a new one.
+// Usually, time taken for such a task is around 1 minute, here we tolerate 5 minutes
+const taskExpiresAfter = 300 * time.Second
+
+// WaitingTimeInSecondsBeforeRefreshState number if seconds to wait before making a new API call to refresh ip task state
+const WaitingTimeInSecondsBeforeRefreshState = 10
+
+func resourceIpServiceMove() *schema.Resource {
+	return &schema.Resource{
+		Create: resoursIpMoveCreate,
+		Update: resourceIpMoveUpdate,
+		Read:   resourceIpRead,
+		Delete: resourceIpMoveDelete,
+
+		Importer: &schema.ResourceImporter{
+			State: func(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+				return []*schema.ResourceData{d}, nil
+			},
+		},
+
+		Schema: resourceIpMoveSchema(),
+	}
+}
+
+func resourceIpMoveSchema() map[string]*schema.Schema {
+	schema := map[string]*schema.Schema{
+		"description": {
+			Type:        schema.TypeString,
+			Description: "Custom description on your ip",
+			Optional:    true,
+			Computed:    true,
+		},
+
+		//computed
+		"can_be_terminated": {
+			Type:     schema.TypeBool,
+			Computed: true,
+		},
+
+		"country": {
+			Type:     schema.TypeString,
+			Computed: true,
+		},
+
+		"ip": {
+			Type:     schema.TypeString,
+			Required: true,
+		},
+		"organisation_id": {
+			Type:     schema.TypeString,
+			Computed: true,
+		},
+		"routed_to": {
+			Type:        schema.TypeList,
+			MinItems:    1,
+			MaxItems:    1,
+			Description: "Routage information",
+			Required:    true,
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"service_name": {
+						Type:        schema.TypeString,
+						Description: "Service where ip is routed to",
+						Required:    true,
+					},
+				},
+			},
+		},
+		"service_name": {
+			Type:     schema.TypeString,
+			Computed: true,
+		},
+		"type": {
+			Type:        schema.TypeString,
+			Description: "Possible values for ip type",
+			Computed:    true,
+		},
+		"task_status": {
+			Type:        schema.TypeString,
+			Description: "Status field of the current IP task that is in charge of changing the service the IP is attached to",
+			Computed:    true,
+		},
+		"task_start_date": {
+			Type:        schema.TypeString,
+			Description: "Starting date and time field of the current IP task that is in charge of changing the service the IP is attached to",
+			Computed:    true,
+		},
+	}
+
+	return schema
+}
+
+func resoursIpMoveCreate(d *schema.ResourceData, meta interface{}) error {
+	// later on this ID will be replaced by the task if when we need to create it (see resourceIpMoveUpdate)
+	d.SetId(d.Get("ip").(string))
+	return resourceIpMoveUpdate(d, meta)
+}
+
+// resourceIpMoveUpdate will move an ip to a provided service name or detach (= park) it otherwise
+// if the resource ID is a taskId and the previous task is not done, wait for it to be finished until the previous task is considered expired
+// (see recursiveWaitTaskFinished) before trying to do the service move.
+// then do the move only if the current service is different from the one given in the inputs
+func resourceIpMoveUpdate(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+	ip := d.Get("ip").(string)
+
+	// no need to update if ip is already routed to the appropriate service
+	opts, err := (&IpMoveOpts{}).FromResource(d)
+	if err != nil {
+		return err
+	}
+
+	serviceName, err := helpers.ServiceNameFromIpBlock(ip)
+	if err != nil {
+		return err
+	}
+	err = d.Set("service_name", serviceName)
+	if err != nil {
+		return err
+	}
+
+	ipTask := &IpTask{}
+	taskId, err := strconv.ParseInt(d.Id(), 10, 64)
+	if err == nil {
+		// if previous task is not done yet we need to wait for it to be completed
+		if d.Get("task_status") != nil {
+			ipTask.Status = IpTaskStatusEnum(d.Get("task_status").(string))
+			ipTask.TaskId = taskId
+			taskStartDate, err := time.Parse("2006-01-02 15:04:05 -0700 MST", d.Get("task_start_date").(string))
+			if err != nil {
+				return err
+			}
+			ipTask.StartDate = taskStartDate
+			_, err = waitForTaskFinished(d, meta, ipTask, ip, opts)
+			if err != nil {
+				log.Printf("[WARNING] - waitForTaskFinished on previously registered task return error %s. Will continue nevertheless", err)
+			}
+		}
+	} else {
+		log.Printf("[WARNING] - resource ID %s is not an int64/not a task ID. Cannot get last task state", d.Id())
+	}
+	err = resourceIpServiceReadByServiceName(d, *serviceName, config)
+	if err != nil {
+		return err
+	}
+
+	currentlyRoutedService := GetRoutedToServiceName(d)
+	if reflect.DeepEqual(currentlyRoutedService, opts.To) {
+		log.Printf("[DEBUG] Won't do anything as ip %s (service name = %s) is already routed to service %v", ip, *serviceName, currentlyRoutedService)
+		return nil
+	} else {
+		if opts.To == nil {
+			log.Printf("[DEBUG] Will move ip %s (service name = %s) from service %s to IP parking", ip, *serviceName, *currentlyRoutedService)
+			endpoint := fmt.Sprintf("/ip/%s/park",
+				url.PathEscape(ip),
+			)
+			// retrieve the task
+			if err := config.OVHClient.Post(endpoint, nil, ipTask); err != nil {
+				return fmt.Errorf("calling Post %s: %q", endpoint, err)
+			}
+		} else {
+			log.Printf("[DEBUG] Will move ip %s (service name = %s) from service %v to service %s", ip, *serviceName, currentlyRoutedService, *opts.To)
+			endpoint := fmt.Sprintf("/ip/%s/move",
+				url.PathEscape(ip),
+			)
+			if err := config.OVHClient.Post(endpoint, opts, ipTask); err != nil {
+				return fmt.Errorf("calling Post %s: %q", endpoint, err)
+			}
+		}
+		d.SetId(fmt.Sprint(ipTask.TaskId))
+		if err = d.Set("task_start_date", ipTask.StartDate.String()); err != nil {
+			return err
+		}
+
+		_, err = waitForTaskFinished(d, meta, ipTask, ip, opts)
+		if err != nil {
+			return err
+		}
+	}
+	err = resourceIpRead(d, meta)
+	return err
+}
+
+// waitForTaskFinished queries GET /ip/:ip/task/:taskId route until task state is in a terminal success or error state or until WaitingTimeInSecondsBeforeRefreshState is reached
+// and returns :
+//   - finishedWithSuccess : true if task ended with success, false if ended with error, nil if not ended at all
+//   - err : nil if no error is encountered in the process, any met error otherwise
+//
+// in any case before returning, "task_status" field of d will be updated with the last known ipTask.Status
+func waitForTaskFinished(d *schema.ResourceData, meta interface{}, ipTask *IpTask, ip string, opts *IpMoveOpts) (finishedWithSuccess *bool, err error) {
+	defer func() {
+		errSet := d.Set("task_status", ipTask.Status)
+		if errSet == nil {
+			err = errSet
+		}
+	}()
+	return recursiveWaitTaskFinished(d, meta, ipTask, ip, opts)
+}
+
+// recursiveWaitTaskFinished checks a given ipTask and return true if task status is in a state that we consider finished.
+// and calls itself again if task is not finished while task is not yet expired
+func recursiveWaitTaskFinished(d *schema.ResourceData, meta interface{}, ipTask *IpTask, ip string, opts *IpMoveOpts) (finished *bool, err error) {
+	switch ipTask.Status {
+	case IpTaskStatusDone:
+		return helpers.GetNilBoolPointer(true), nil
+	case IpTaskStatusCancelled, IpTaskStatusOvhError, IpTaskStatusCustomerError:
+		return helpers.GetNilBoolPointer(true), fmt.Errorf("could not assign IP %s to service %v as Ip task is %s", ip, opts.To, ipTask.Status)
+	}
+	timeDiff := time.Now().Sub(ipTask.StartDate)
+	if timeDiff < taskExpiresAfter {
+		log.Printf("[DEBUG] ipTask.Status is currently: %s. Waiting %d second (we allow %f more seconds for the task to complete)", ipTask.Status, WaitingTimeInSecondsBeforeRefreshState, taskExpiresAfter.Seconds()-timeDiff.Seconds())
+		time.Sleep(WaitingTimeInSecondsBeforeRefreshState * time.Second)
+		err = resourceIpTaskRead(d, ipTask, meta)
+		return recursiveWaitTaskFinished(d, meta, ipTask, ip, opts)
+	}
+	log.Printf("[WARNING] - waitForTaskFinished max number of retries reached without the task having reached a terminal state")
+	return nil, nil
+}
+
+func resourceIpTaskRead(d *schema.ResourceData, ipTask *IpTask, meta interface{}) error {
+	config := meta.(*Config)
+
+	endpoint := fmt.Sprintf("/ip/%s/task/%d",
+		url.PathEscape(d.Get("ip").(string)),
+		ipTask.TaskId,
+	)
+	if err := config.OVHClient.Get(endpoint, ipTask); err != nil {
+		return fmt.Errorf("calling Get %s: %q", endpoint, err)
+	}
+	return nil
+}
+
+func resourceIpRead(d *schema.ResourceData, meta interface{}) error {
+	ip := d.Get("ip").(string)
+	serviceName, err := helpers.ServiceNameFromIpBlock(ip)
+	if err != nil {
+		return err
+	}
+	err = d.Set("service_name", serviceName)
+	if err != nil {
+		return err
+	}
+	config := meta.(*Config)
+	return resourceIpServiceReadByServiceName(d, *serviceName, config)
+}
+
+// resourceIpMoveDelete is an empty implementation as move do not actually create API objects but rather updates the underlying ip spec (by modifying its routed_to service)
+func resourceIpMoveDelete(d *schema.ResourceData, meta interface{}) error {
+	return nil
+}
+
+func resourceIpServiceReadByServiceName(d *schema.ResourceData, serviceName string, config *Config) error {
+	r := &IpService{}
+	endpoint := fmt.Sprintf("/ip/service/%s",
+		url.PathEscape(serviceName),
+	)
+	var err error
+	// This retry logic is there to handle a known API bug
+	// which happens while an ipblock is attached/detached from
+	// a Vrack
+	err = resource.Retry(5*time.Minute, func() *resource.RetryError {
+		if err := config.OVHClient.Get(endpoint, &r); err != nil {
+			if errOvh, ok := err.(*ovh.APIError); ok {
+				if errOvh.Code == 400 {
+					log.Printf("[DEBUG] known API bug when attaching/detaching vrack")
+					return resource.RetryableError(err)
+				}
+				return resource.NonRetryableError(err)
+			}
+
+			err = helpers.CheckDeleted(d, err, endpoint)
+			if err != nil {
+				return resource.NonRetryableError(err)
+			}
+
+			return nil
+		}
+
+		// Successful Get
+		return nil
+	})
+
+	if err != nil {
+		return err
+	}
+
+	d.Set("service_name", serviceName)
+	// set resource attributes
+	for k, v := range r.ToMap() {
+		d.Set(k, v)
+	}
+
+	return nil
+}

--- a/ovh/resource_ip_move.go
+++ b/ovh/resource_ip_move.go
@@ -3,17 +3,18 @@ package ovh
 import (
 	"errors"
 	"fmt"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
-	"github.com/ovh/go-ovh/ovh"
-	"github.com/ovh/terraform-provider-ovh/ovh/helpers"
-	"golang.org/x/exp/slices"
 	"log"
 	"net/http"
 	"net/url"
 	"reflect"
 	"strconv"
 	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/ovh/go-ovh/ovh"
+	"github.com/ovh/terraform-provider-ovh/ovh/helpers"
+	"golang.org/x/exp/slices"
 )
 
 // taskExpiresAfter is the duration in seconds after which we'll consider an ongoing task to be expired and we'll allow ourselves to create a new one.
@@ -145,7 +146,7 @@ func resourceIpMoveUpdate(d *schema.ResourceData, meta interface{}) error {
 		if d.Get("task_status") != nil {
 			ipTask.Status = IpTaskStatusEnum(d.Get("task_status").(string))
 			ipTask.TaskId = taskId
-			taskStartDate, err := time.Parse("2006-01-02 15:04:05 -0700 MST", d.Get("task_start_date").(string))
+			taskStartDate, err := time.Parse(time.RFC3339, d.Get("task_start_date").(string))
 			if err != nil {
 				return err
 			}
@@ -188,7 +189,7 @@ func resourceIpMoveUpdate(d *schema.ResourceData, meta interface{}) error {
 			}
 		}
 		d.SetId(fmt.Sprint(ipTask.TaskId))
-		if err = d.Set("task_start_date", ipTask.StartDate.String()); err != nil {
+		if err = d.Set("task_start_date", ipTask.StartDate.Format(time.RFC3339)); err != nil {
 			return err
 		}
 

--- a/ovh/resource_ip_move_test.go
+++ b/ovh/resource_ip_move_test.go
@@ -2,7 +2,7 @@ package ovh
 
 import (
 	"fmt"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"os"
 	"testing"
 )
@@ -11,12 +11,10 @@ var testAccIpMoveConfig = `
 resource "ovh_ip_move" "move" {
     ip = "%s"
     routed_to {
-		service_name = "%s"
-	}
+        service_name = "%s"
+    }
 }
 `
-
-func init() {}
 
 func TestAccIpMove_basic(t *testing.T) {
 	ip := os.Getenv("OVH_IP_MOVE_TEST")

--- a/ovh/resource_ip_move_test.go
+++ b/ovh/resource_ip_move_test.go
@@ -1,0 +1,48 @@
+package ovh
+
+import (
+	"fmt"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"os"
+	"testing"
+)
+
+var testAccIpMoveConfig = `
+resource "ovh_ip_move" "move" {
+    ip = "%s"
+    routed_to {
+		service_name = "%s"
+	}
+}
+`
+
+func init() {}
+
+func TestAccIpMove_basic(t *testing.T) {
+	ip := os.Getenv("OVH_IP_MOVE_TEST")
+	routedToServiceName := os.Getenv("OVH_IP_MOVE_SERVICE_NAME_TEST")
+
+	moveConfig := fmt.Sprintf(testAccIpMoveConfig, ip, routedToServiceName)
+	parkConfig := fmt.Sprintf(testAccIpMoveConfig, ip, "")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheckIpMove(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: moveConfig,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("ovh_ip_move.move", "ip", ip),
+					resource.TestCheckResourceAttr("ovh_ip_move.move", "routed_to.0.service_name", routedToServiceName),
+				),
+			},
+			{
+				Config: parkConfig,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("ovh_ip_move.move", "ip", ip),
+					resource.TestCheckResourceAttr("ovh_ip_move.move", "routed_to.0.service_name", ""),
+				),
+			},
+		},
+	})
+}

--- a/ovh/types_ip.go
+++ b/ovh/types_ip.go
@@ -2,11 +2,45 @@ package ovh
 
 import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"time"
 )
 
 type IpReverse struct {
 	IpReverse string `json:"ipReverse"`
 	Reverse   string `json:"reverse"`
+}
+
+type IpTaskFunctionEnum string
+
+const (
+	IpTaskFunctionEnumArinBlockReassign                 IpTaskFunctionEnum = "arinBlockReassign"
+	IpTaskFunctionEnumChangeRipeOrg                     IpTaskFunctionEnum = "changeRipeOrg"
+	IpTaskFunctionEnumCheckAndReleaseIp                 IpTaskFunctionEnum = "checkAndReleaseIp"
+	IpTaskFunctionEnumGenericMoveFloatingIp             IpTaskFunctionEnum = "genericMoveFloatingIp"
+	IpTaskFunctionEnumSupernetByoipFailoverPartitioning IpTaskFunctionEnum = "supernetByoipFailoverPartitioning"
+)
+
+type IpTaskStatusEnum string
+
+const (
+	IpTaskStatusCancelled     IpTaskStatusEnum = "cancelled"
+	IpTaskStatusCustomerError IpTaskStatusEnum = "customerError"
+	IpTaskStatusDoing         IpTaskStatusEnum = "doing"
+	IpTaskStatusDone          IpTaskStatusEnum = "done"
+	IpTaskStatusInit          IpTaskStatusEnum = "init"
+	IpTaskStatusOvhError      IpTaskStatusEnum = "ovhError"
+	IpTaskStatusTodo          IpTaskStatusEnum = "todo"
+)
+
+type IpTask struct {
+	Comment     *string            `json:"comment;omitempty"`
+	Destination *IpServiceRoutedTo `json:"routedTo;omitempty"`
+	DoneDate    *time.Time         `json:"doneDate;omitempty"`
+	Function    IpTaskFunctionEnum `json:"function"`
+	LastUpdate  *time.Time         `json:"lastUpdate;omitempty"`
+	StartDate   time.Time          `json:"startDate"`
+	Status      IpTaskStatusEnum   `json:"status"`
+	TaskId      int64              `json:"taskId"`
 }
 
 func (v IpReverse) ToMap() map[string]interface{} {

--- a/ovh/types_ip_service.go
+++ b/ovh/types_ip_service.go
@@ -60,6 +60,29 @@ func (opts *IpServiceUpdateOpts) FromResource(d *schema.ResourceData) *IpService
 	return opts
 }
 
+// see https://api.ovh.com/console/#/ip/%7Bip%7D/move~POST
+type IpMoveOpts struct {
+	NextHop *string `json:"nexthop,omitempty"`
+	To      *string `json:"to"`
+}
+
+func (opts *IpMoveOpts) FromResource(d *schema.ResourceData) (*IpMoveOpts, error) {
+	opts.To = GetRoutedToServiceName(d)
+	return opts, nil
+}
+
+func GetRoutedToServiceName(d *schema.ResourceData) *string {
+	routedTo := (d.Get("routed_to")).([]interface{})
+	if routedTo == nil || len(routedTo) == 0 || routedTo[0] == nil {
+		return nil
+	}
+	serviceName := (routedTo[0].(map[string]interface{}))["service_name"].(string)
+	if serviceName == "" {
+		return nil
+	}
+	return &serviceName
+}
+
 type IpServiceConfirmTerminationOpts struct {
 	Token string `json:"token"`
 }

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -191,6 +191,8 @@ variables must also be set:
 * `OVH_ZONE_TEST` - The domain you own to test the domain_zone resource.
 
 * `OVH_IP_TEST`, `OVH_IP_BLOCK_TEST`, `OVH_IP_REVERSE_TEST` - The values you have to set for testing ip reverse resources.
+ 
+* `OVH_IP_MOVE_TEST`, `OVH_IP_MOVE_SERVICE_NAME_TEST` - The values you have to set for testing ip move resources.
 
 * `OVH_DBAAS_LOGS_SERVICE_TEST` - The name of your Dbaas logs service.
 

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -192,7 +192,7 @@ variables must also be set:
 
 * `OVH_IP_TEST`, `OVH_IP_BLOCK_TEST`, `OVH_IP_REVERSE_TEST` - The values you have to set for testing ip reverse resources.
  
-* `OVH_IP_MOVE_TEST`, `OVH_IP_MOVE_SERVICE_NAME_TEST` - The values you have to set for testing ip move resources.
+* `OVH_IP_MOVE_SERVICE_NAME_TEST` - The value you have to set for testing ip move resources.
 
 * `OVH_DBAAS_LOGS_SERVICE_TEST` - The name of your Dbaas logs service.
 

--- a/website/docs/r/ip_move.html.markdown
+++ b/website/docs/r/ip_move.html.markdown
@@ -1,0 +1,56 @@
+---
+subcategory : "Additional IP"
+---
+
+# ovh_ip_move
+
+Moves a given IP to a different service, or inversely, parks it if empty service is given
+
+## Example Usage
+
+## Move IP `1.2.3.4` to service loadbalancer-XXXXX
+
+```hcl
+resource "ovh_ip_move" "move_ip_to_load_balancer_xxxxx" {
+  ip = "1.2.3.4"
+  routed_to {
+    service_name = "loadbalancer-XXXXX"
+  }
+}
+```
+
+## Park IP/Detach IP `1.2.3.4` from any service
+
+```hcl
+resource "ovh_ip_move" "park_ip" {
+  ip = "1.2.3.4"
+  routed_to {
+    service_name = ""
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `ip` - (Required) IP block that we want to attach to a different service
+* `routed_to` - (Required) Service to route the IP to. If null, the IP will be [parked](https://api.ovh.com/console/#/ip/%7Bip%7D/park~POST)
+  instead of [moved](https://api.ovh.com/console/#/ip/%7Bip%7D/move~POST)
+  * `service_name` - (Required) Name of the service to route the IP to. IP will be parked if this value is an empty string
+
+## Attributes Reference
+
+Attributes are mostly the same as for [ovh_ip_service](https://registry.terraform.io/providers/ovh/ovh/latest/docs/resources/ip_service#attributes-reference):
+
+* `can_be_terminated` - can be terminated
+* `country` - country
+* `description` - description attached to the IP
+* `ip` - ip block
+* `organisation_id` - IP block organisation Id
+* `routed_to` - Routage information
+  * `service_name` - Service where ip is routed to
+* `service_name`: service name in the form of `ip-<part-1>.<part-2>.<part-3>.<part-4>`
+* `type` - Possible values for ip type
+* `task_status` - Status field of the current IP task that is in charge of changing the service the IP is attached to
+* `task_start_date` - Starting date and time field of the current IP task that is in charge of changing the service the IP is attached to

--- a/website/docs/r/ip_move.html.markdown
+++ b/website/docs/r/ip_move.html.markdown
@@ -43,14 +43,14 @@ The following arguments are supported:
 
 Attributes are mostly the same as for [ovh_ip_service](https://registry.terraform.io/providers/ovh/ovh/latest/docs/resources/ip_service#attributes-reference):
 
-* `can_be_terminated` - can be terminated
-* `country` - country
-* `description` - description attached to the IP
-* `ip` - ip block
+* `can_be_terminated` - Whether IP service can be terminated
+* `country` - Country
+* `description` - Description attached to the IP
+* `ip` - IP block
 * `organisation_id` - IP block organisation Id
 * `routed_to` - Routage information
   * `service_name` - Service where ip is routed to
-* `service_name`: service name in the form of `ip-<part-1>.<part-2>.<part-3>.<part-4>`
+* `service_name`: Service name in the form of `ip-<part-1>.<part-2>.<part-3>.<part-4>`
 * `type` - Possible values for ip type
 * `task_status` - Status field of the current IP task that is in charge of changing the service the IP is attached to
 * `task_start_date` - Starting date and time field of the current IP task that is in charge of changing the service the IP is attached to


### PR DESCRIPTION
# Description

This adds a new add `ovh_ip_move` resource to move an IP to a provided service name or park it if empty service is given.

It relies on the following APIV6 routes:
- https://api.ovh.com/console/#/ip/service/%7BserviceName%7D~GET
- https://api.ovh.com/console/#/ip/%7Bip%7D/task/%7BtaskId%7D~GET
- https://api.ovh.com/console/#/ip/%7Bip%7D/move~POST
- https://api.ovh.com/console/#/ip/%7Bip%7D/park~POST

taken resource ID is the move task ID if available, or the IP itself otherwise

Moving/parking process:
- if there is an IpTask recorded in the resource state, we try to wait for it to be finished until it is considered expired
- after having waited until previous task expiration or completion, do the move only if the current service is different from the one given in the inputs

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] Documentation update

# How Has This Been Tested?

- [x] Test : 
```shell
make testacc TESTARGS="-run TestAccIpMove_basic"`
=== RUN   TestAccIpMove_basic
--- PASS: TestAccIpMove_basic (108.21s)
PASS
```

**Test Configuration**:
* Terraform version: `terraform version`: Terraform v1.2.9
* Existing HCL configuration you used: 

Attaching an IP to a service

```hcl
resource "ovh_ip_move" "move" {
    ip = "X.X.X.X/32"
    routed_to {
      service_name = "loadbalancer-YYYYYYYY"
    }
}
```

Then parking the same IP

```hcl
resource "ovh_ip_move" "move" {
    ip = "X.X.X.X/32"
    routed_to {
      service_name = ""
    }
}
```

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added acceptance tests that prove my fix is effective or that my feature works
- [x] New and existing acceptance tests pass locally with my changes

