### PR TITLE
fix(TestAccDbaasLogsCluster): Set cluster_id property when creating a resource of type ovh_dbaas_logs_cluster

### DIFF
--- a/ovh/resource_dbaas_logs_cluster_test.go
+++ b/ovh/resource_dbaas_logs_cluster_test.go
@@ -30,13 +30,16 @@ func testSweepDbaasLogsCluster(region string) error {
 
 func TestAccDbaasLogsCluster(t *testing.T) {
 	serviceName := os.Getenv("OVH_DBAAS_LOGS_SERVICE_TEST")
+	clusterId := os.Getenv("OVH_DBAAS_LOGS_CLUSTER_ID")
+
 	config := fmt.Sprintf(
 		testAccDbaasLogsClusterConfig,
 		serviceName,
+		clusterId,
 	)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheckDbaasLogs(t) },
+		PreCheck:  func() { testAccPreCheckDbaasLogsCluster(t) },
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
@@ -66,6 +69,7 @@ func TestAccDbaasLogsCluster(t *testing.T) {
 const testAccDbaasLogsClusterConfig = `
 resource "ovh_dbaas_logs_cluster" "ldp" {
 	service_name = "%s"
+	cluster_id = "%s"
 
 	archive_allowed_networks       = ["10.0.0.0/16"]
 	direct_input_allowed_networks  = ["10.0.0.0/16"]


### PR DESCRIPTION
# Description

Fixes test `TestAccDbaasLogsCluster`: define the field `cluster_id` on the cluster resource

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (improve existing resource(s) or datasource(s))
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

# How Has This Been Tested?

- [x] `make testacc TESTARGS="-parallel=1 -run 'TestAccDbaasLogsCluster'"`

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or issues
- [ ] I have added acceptance tests that prove my fix is effective or that my feature works
- [x] New and existing acceptance tests pass locally with my changes
- [x] I ran succesfully `go mod vendor` if I added or modify `go.mod` file
