### PR TITLE
fix: Use a separate cloud project ID for test TestAccCloudProjectVrackDataSource_basic

### DIFF
--- a/ovh/data_cloud_project_vrack_test.go
+++ b/ovh/data_cloud_project_vrack_test.go
@@ -10,7 +10,7 @@ import (
 
 func TestAccCloudProjectVrackDataSource_basic(t *testing.T) {
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheckCloud(t) },
+		PreCheck:  func() { testAccPreCheckCloudWithVrack(t) },
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
@@ -25,4 +25,4 @@ var testAccCloudProjectVrackDatasourceConfig = fmt.Sprintf(`
 data "ovh_cloud_project_vrack" "vrack" {
   service_name = "%s"
 }
-`, os.Getenv("OVH_CLOUD_PROJECT_SERVICE_TEST"))
+`, os.Getenv("OVH_CLOUD_PROJECT_WITH_VRACK_SERVICE_TEST"))

--- a/ovh/provider_test.go
+++ b/ovh/provider_test.go
@@ -187,6 +187,13 @@ func testAccPreCheckCloud(t *testing.T) {
 	checkEnvOrSkip(t, "OVH_CLOUD_PROJECT_SERVICE_TEST")
 }
 
+// Checks that the environment variables needed for the /cloud acceptance tests
+// are set.
+func testAccPreCheckCloudWithVrack(t *testing.T) {
+	testAccPreCheckCredentials(t)
+	checkEnvOrSkip(t, "OVH_CLOUD_PROJECT_WITH_VRACK_SERVICE_TEST")
+}
+
 // Checks that the environment variables needed for the /cloud/{cloudId}/containerregistry acceptance tests
 // are set.
 func testAccPreCheckContainerRegistry(t *testing.T) {


### PR DESCRIPTION
# Description

Test TestAccCloudProjectVrackDataSource_basic requires a cloud project that already has a vRack associated to it. This is not compatible with other tests that manually attach a vRack to the common cloud project used for tests, so we will use another project for this one.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (improve existing resource(s) or datasource(s))
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

# How Has This Been Tested?

- [ ] `make testacc TESTARGS="-run TestAccCloudProjectVrackDataSource_basic"`

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings or issues
- [ ] I have added acceptance tests that prove my fix is effective or that my feature works
- [ ] New and existing acceptance tests pass locally with my changes
- [ ] I ran succesfully `go mod vendor` if I added or modify `go.mod` file
