### PR TITLE
fix: Use an existing boot kernel in dedicated server tests

### DIFF
--- a/ovh/resource_dedicated_server_reboot_task_test.go
+++ b/ovh/resource_dedicated_server_reboot_task_test.go
@@ -50,7 +50,7 @@ const testAccDedicatedServerRebootConfig_Basic = `
 data ovh_dedicated_server_boots "rescue" {
   service_name = "%s"
   boot_type    = "rescue"
-  kernel       = "rescue64-pro"
+  kernel       = "rescue-customer"
 }
 
 resource ovh_dedicated_server_update "server" {

--- a/ovh/resource_dedicated_server_update_test.go
+++ b/ovh/resource_dedicated_server_update_test.go
@@ -59,7 +59,7 @@ const testAccDedicatedServerUpdateConfig_Basic = `
 data ovh_dedicated_server_boots "rescue" {
   service_name = "%s"
   boot_type    = "rescue"
-  kernel       = "rescue64-pro"
+  kernel       = "rescue-customer"
 }
 
 resource ovh_dedicated_server_update "server" {


### PR DESCRIPTION
# Description

Use boot kernel `rescue-customer` in dedicated server tests as there are no results when using `rescue64-pro`.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (improve existing resource(s) or datasource(s))
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] `make testacc TESTARGS="-run DedicatedServer"`

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or issues
- [ ] I have added acceptance tests that prove my fix is effective or that my feature works
- [x] New and existing acceptance tests pass locally with my changes
- [ ] I ran succesfully `go mod vendor` if I added or modify `go.mod` file
