### PR TITLE
fix: multi-provider doesn't allow Required/Optional to have different value

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -63,3 +63,5 @@ require (
 )
 
 go 1.20
+
+retract v0.36.0 // OVH_ENDPOINT environment variable prevent a correct usage of the terraform provider

--- a/ovh/provider_new.go
+++ b/ovh/provider_new.go
@@ -37,7 +37,8 @@ func (p *OvhProvider) Schema(_ context.Context, _ provider.SchemaRequest, resp *
 	resp.Schema = schema.Schema{
 		Attributes: map[string]schema.Attribute{
 			"endpoint": schema.StringAttribute{
-				Optional:    true,
+				Required:    os.Getenv("OVH_ENDPOINT") == "",
+				Optional:    os.Getenv("OVH_ENDPOINT") != "",
 				Description: descriptions["endpoint"],
 			},
 			"application_key": schema.StringAttribute{


### PR DESCRIPTION
While migrating to new terraform-sdk, regression has been introduced.

`terraform-plugin-sdk/v2` is changing value of Required/Optional schema variable when a DefaultFunc is provided, while the `terraform-plugin-framework` hasn't the same behavior, and crying about the schema difference.

Fixes #528.
