### PR TITLE
fix: Stop computing URNs in the provider and rely on the API responses

### DIFF
--- a/ovh/data_dedicated_ceph.go
+++ b/ovh/data_dedicated_ceph.go
@@ -88,7 +88,7 @@ func dataSourceDedicatedCephRead(d *schema.ResourceData, meta interface{}) error
 	}
 	log.Printf("[DEBUG] CEPH is %v", ceph.CephMonitors)
 	d.SetId(ceph.ServiceName)
-	d.Set("urn", helpers.ServiceURN(config.Plate, "dedicatedCeph", ceph.ServiceName))
+	d.Set("urn", ceph.URN)
 	d.Set("service_name", ceph.ServiceName)
 	d.Set("ceph_mons", ceph.CephMonitors)
 	d.Set("ceph_version", ceph.CephVersion)

--- a/ovh/data_dedicated_ceph_test.go
+++ b/ovh/data_dedicated_ceph_test.go
@@ -22,6 +22,8 @@ func TestAccDedicatedCephDatasource(t *testing.T) {
 						"data.ovh_dedicated_ceph.ceph", "service_name", dedicated_ceph),
 					resource.TestCheckResourceAttr(
 						"data.ovh_dedicated_ceph.ceph", "status", "INSTALLED"),
+					resource.TestCheckResourceAttrSet(
+						"data.ovh_dedicated_ceph.ceph", "urn"),
 				),
 			},
 		},

--- a/ovh/data_dedicated_nasha.go
+++ b/ovh/data_dedicated_nasha.go
@@ -6,7 +6,6 @@ import (
 	"net/url"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
-	"github.com/ovh/terraform-provider-ovh/ovh/helpers"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
@@ -92,7 +91,7 @@ func dataSourceDedicatedNashaRead(c context.Context, d *schema.ResourceData, met
 	}
 
 	d.SetId(ds.ServiceName)
-	d.Set("urn", helpers.ServiceURN(config.Plate, "nasHA", ds.ServiceName))
+	d.Set("urn", ds.URN)
 	d.Set("service_name", ds.ServiceName)
 	d.Set("monitored", ds.Monitored)
 	d.Set("zpool_size", ds.ZpoolSize)

--- a/ovh/data_dedicated_nasha_test.go
+++ b/ovh/data_dedicated_nasha_test.go
@@ -27,6 +27,7 @@ func TestAccDedicatedNashaData(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("data.ovh_dedicated_nasha.testacc", "disk_type", "ssd"),
 					resource.TestCheckResourceAttr("data.ovh_dedicated_nasha.testacc", "service_name", serviceName),
+					resource.TestCheckResourceAttrSet("data.ovh_dedicated_nasha.testacc", "urn"),
 				),
 			},
 		},

--- a/ovh/data_dedicated_server.go
+++ b/ovh/data_dedicated_server.go
@@ -6,7 +6,6 @@ import (
 	"net/url"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/ovh/terraform-provider-ovh/ovh/helpers"
 )
 
 func dataSourceDedicatedServer() *schema.Resource {
@@ -201,7 +200,7 @@ func dataSourceDedicatedServerRead(d *schema.ResourceData, meta interface{}) err
 	}
 
 	d.SetId(ds.Name)
-	d.Set("urn", helpers.ServiceURN(config.Plate, "dedicatedServer", ds.Name))
+	d.Set("urn", ds.URN)
 	d.Set("boot_id", ds.BootId)
 	d.Set("commercial_range", ds.CommercialRange)
 	d.Set("datacenter", ds.Datacenter)

--- a/ovh/data_dedicated_server_test.go
+++ b/ovh/data_dedicated_server_test.go
@@ -27,6 +27,8 @@ func TestAccDedicatedServerDataSource_basic(t *testing.T) {
 						"data.ovh_dedicated_server.server", "vnis.#"),
 					resource.TestCheckResourceAttr(
 						"data.ovh_dedicated_server.server", "vnis.0.server_name", dedicated_server),
+					resource.TestCheckResourceAttrSet(
+						"data.ovh_dedicated_server.server", "urn"),
 				),
 			},
 		},

--- a/ovh/data_domain_zone.go
+++ b/ovh/data_domain_zone.go
@@ -2,9 +2,9 @@ package ovh
 
 import (
 	"fmt"
+	"net/url"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/ovh/terraform-provider-ovh/ovh/helpers"
 )
 
 func dataSourceDomainZone() *schema.Resource {
@@ -48,7 +48,7 @@ func dataSourceDomainZoneRead(d *schema.ResourceData, meta interface{}) error {
 	zoneName := d.Get("name").(string)
 
 	dz := &DomainZone{}
-	err := config.OVHClient.Get(fmt.Sprintf("/domain/zone/%s", zoneName), &dz)
+	err := config.OVHClient.Get(fmt.Sprintf("/domain/zone/%s", url.PathEscape(zoneName)), &dz)
 
 	if err != nil {
 		return fmt.Errorf("Error calling /domain/zone/%s:\n\t %q", zoneName, err)
@@ -59,8 +59,7 @@ func dataSourceDomainZoneRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("dnssec_supported", dz.DnssecSupported)
 	d.Set("last_update", dz.LastUpdate)
 	d.Set("name_servers", dz.NameServers)
-
-	d.Set("urn", helpers.ServiceURN(config.Plate, "dnsZone", zoneName))
+	d.Set("urn", dz.URN)
 
 	return nil
 }

--- a/ovh/data_domain_zone_test.go
+++ b/ovh/data_domain_zone_test.go
@@ -24,6 +24,8 @@ func TestAccDomainZoneDataSource_basic(t *testing.T) {
 					testAccCheckDomainZoneHasNameServers("data.ovh_domain_zone.rootzone", t),
 					resource.TestCheckResourceAttr(
 						"data.ovh_domain_zone.rootzone", "id", zoneName),
+					resource.TestCheckResourceAttrSet(
+						"data.ovh_domain_zone.rootzone", "urn"),
 				),
 			},
 		},

--- a/ovh/data_hosting_privatedatabase.go
+++ b/ovh/data_hosting_privatedatabase.go
@@ -5,7 +5,6 @@ import (
 	"net/url"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/ovh/terraform-provider-ovh/ovh/helpers"
 )
 
 func dataSourceHostingPrivateDatabase() *schema.Resource {
@@ -143,7 +142,6 @@ func dataSourceHostingPrivateDatabaseRead(d *schema.ResourceData, meta interface
 		}
 	}
 	d.SetId(ds.ServiceName)
-	d.Set("urn", helpers.ServiceURN(config.Plate, "webCloudDatabases", ds.ServiceName))
 
 	return nil
 }

--- a/ovh/data_hosting_privatedatabase_test.go
+++ b/ovh/data_hosting_privatedatabase_test.go
@@ -90,6 +90,10 @@ func TestAccDataSourceHostingPrivateDatabase_basic(t *testing.T) {
 						"data.ovh_hosting_privatedatabase.database",
 						"version_number",
 					),
+					resource.TestCheckResourceAttrSet(
+						"data.ovh_hosting_privatedatabase.database",
+						"urn",
+					),
 				),
 			},
 		},

--- a/ovh/data_iploadbalancing.go
+++ b/ovh/data_iploadbalancing.go
@@ -3,6 +3,7 @@ package ovh
 import (
 	"fmt"
 	"log"
+	"net/url"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/ovh/terraform-provider-ovh/ovh/helpers"
@@ -164,7 +165,7 @@ func dataSourceIpLoadbalancingRead(d *schema.ResourceData, meta interface{}) err
 
 	for _, serviceName := range response {
 		iplb := &IpLoadbalancing{}
-		err := config.OVHClient.Get(fmt.Sprintf("/ipLoadbalancing/%s", serviceName), &iplb)
+		err := config.OVHClient.Get(fmt.Sprintf("/ipLoadbalancing/%s", url.PathEscape(serviceName)), &iplb)
 
 		if err != nil {
 			return fmt.Errorf("Error calling /ipLoadbalancing/%s:\n\t %q", serviceName, err)
@@ -244,8 +245,8 @@ func dataSourceIpLoadbalancingAttributes(config *Config, d *schema.ResourceData,
 	}
 
 	d.SetId(iplb.ServiceName)
-	d.Set("urn", helpers.ServiceURN(config.Plate, "loadbalancer", iplb.ServiceName))
 
+	d.Set("urn", iplb.URN)
 	d.Set("ipv6", iplb.IPv6)
 	d.Set("ipv4", iplb.IPv4)
 	d.Set("zone", iplb.Zone)

--- a/ovh/data_iploadbalancing_test.go
+++ b/ovh/data_iploadbalancing_test.go
@@ -23,6 +23,8 @@ func TestAccIpLoadbalancingDataSource_basic(t *testing.T) {
 						"data.ovh_iploadbalancing.iplb", "service_name", serviceName),
 					resource.TestCheckResourceAttr(
 						"data.ovh_iploadbalancing.iplb", "id", serviceName),
+					resource.TestCheckResourceAttrSet(
+						"data.ovh_iploadbalancing.iplb", "urn"),
 				),
 			},
 		},
@@ -48,6 +50,8 @@ func TestAccIpLoadbalancingDataSource_statevrack(t *testing.T) {
 						"data.ovh_iploadbalancing.iplb", "state", "ok"),
 					resource.TestCheckResourceAttr(
 						"data.ovh_iploadbalancing.iplb", "vrack_eligibility", "true"),
+					resource.TestCheckResourceAttrSet(
+						"data.ovh_iploadbalancing.iplb", "urn"),
 				),
 			},
 		},

--- a/ovh/data_vps.go
+++ b/ovh/data_vps.go
@@ -5,7 +5,6 @@ import (
 	"net/url"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/ovh/terraform-provider-ovh/ovh/helpers"
 )
 
 func dataSourceVPS() *schema.Resource {
@@ -113,8 +112,7 @@ func dataSourceVPSRead(d *schema.ResourceData, meta interface{}) error {
 
 	d.SetId(vps.Name)
 
-	d.Set("urn", helpers.ServiceURN(config.Plate, helpers.VPSkind, serviceName))
-
+	d.Set("urn", vps.URN)
 	d.Set("name", vps.Name)
 	d.Set("zone", vps.Zone)
 	d.Set("state", vps.State)
@@ -135,7 +133,7 @@ func dataSourceVPSRead(d *schema.ResourceData, meta interface{}) error {
 
 	ips := []string{}
 	err = config.OVHClient.Get(
-		fmt.Sprintf("/vps/%s/ips", d.Id()),
+		fmt.Sprintf("/vps/%s/ips", url.PathEscape(d.Id())),
 		&ips,
 	)
 	if err != nil {
@@ -146,7 +144,7 @@ func dataSourceVPSRead(d *schema.ResourceData, meta interface{}) error {
 
 	vpsDatacenter := VPSDatacenter{}
 	err = config.OVHClient.Get(
-		fmt.Sprintf("/vps/%s/datacenter", d.Id()),
+		fmt.Sprintf("/vps/%s/datacenter", url.PathEscape(d.Id())),
 		&vpsDatacenter,
 	)
 	if err != nil {

--- a/ovh/data_vps_test.go
+++ b/ovh/data_vps_test.go
@@ -23,6 +23,8 @@ func TestAccVPSDataSource_basic(t *testing.T) {
 						"data.ovh_vps.server", "name", vps),
 					resource.TestCheckResourceAttr(
 						"data.ovh_vps.server", "service_name", vps),
+					resource.TestCheckResourceAttrSet(
+						"data.ovh_vps.server", "urn"),
 				),
 			},
 		},

--- a/ovh/resource_cloud_project.go
+++ b/ovh/resource_cloud_project.go
@@ -106,7 +106,7 @@ func resourceCloudProjectUpdate(d *schema.ResourceData, meta interface{}) error 
 
 	log.Printf("[DEBUG] Will update cloudProject: %s", serviceName)
 	opts := (&CloudProjectUpdateOpts{}).FromResource(d)
-	endpoint := fmt.Sprintf("/cloud/project/%s", serviceName)
+	endpoint := fmt.Sprintf("/cloud/project/%s", url.PathEscape(serviceName))
 	if err := config.OVHClient.Put(endpoint, opts, nil); err != nil {
 		return fmt.Errorf("calling Put %s: %q", endpoint, err)
 	}
@@ -142,12 +142,10 @@ func resourceCloudProjectRead(d *schema.ResourceData, meta interface{}) error {
 
 	log.Printf("[DEBUG] Will read cloudProject: %s", serviceName)
 	r := &CloudProject{}
-	endpoint := fmt.Sprintf("/cloud/project/%s", serviceName)
+	endpoint := fmt.Sprintf("/cloud/project/%s", url.PathEscape(serviceName))
 	if err := config.OVHClient.Get(endpoint, &r); err != nil {
 		return helpers.CheckDeleted(d, err, endpoint)
 	}
-
-	d.Set("urn", helpers.ServiceURN(config.Plate, "publicCloudProject", serviceName))
 
 	// set resource attributes
 	for k, v := range r.ToMap() {

--- a/ovh/resource_cloud_project_test.go
+++ b/ovh/resource_cloud_project_test.go
@@ -143,6 +143,8 @@ func TestAccResourceCloudProject_basic(t *testing.T) {
 						"ovh_cloud_project.cloud", "project_id"),
 					resource.TestCheckResourceAttrSet(
 						"ovh_cloud_project.cloud", "project_name"),
+					resource.TestCheckResourceAttrSet(
+						"ovh_cloud_project.cloud", "urn"),
 				),
 			},
 		},

--- a/ovh/resource_domain_zone.go
+++ b/ovh/resource_domain_zone.go
@@ -88,7 +88,7 @@ func resourceDomainZoneRead(d *schema.ResourceData, meta interface{}) error {
 
 	log.Printf("[DEBUG] Will read domainZone: %s", zoneName)
 	r := &DomainZone{}
-	endpoint := fmt.Sprintf("/domain/zone/%s", zoneName)
+	endpoint := fmt.Sprintf("/domain/zone/%s", url.PathEscape(zoneName))
 	if err := config.OVHClient.Get(endpoint, &r); err != nil {
 		return helpers.CheckDeleted(d, err, endpoint)
 	}
@@ -97,8 +97,6 @@ func resourceDomainZoneRead(d *schema.ResourceData, meta interface{}) error {
 	for k, v := range r.ToMap() {
 		d.Set(k, v)
 	}
-
-	d.Set("urn", helpers.ServiceURN(config.Plate, "dnsZone", r.Name))
 
 	return nil
 }

--- a/ovh/resource_domain_zone_test.go
+++ b/ovh/resource_domain_zone_test.go
@@ -141,6 +141,8 @@ func TestAccResourceDomainZone_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(
 						"ovh_domain_zone.zone", "name", name),
+					resource.TestCheckResourceAttrSet(
+						"ovh_domain_zone.zone", "urn"),
 				),
 			},
 		},

--- a/ovh/resource_hosting_privatedatabase.go
+++ b/ovh/resource_hosting_privatedatabase.go
@@ -194,7 +194,6 @@ func resourceHostingPrivateDatabaseRead(d *schema.ResourceData, meta interface{}
 	for k, v := range ds.ToMap() {
 		d.Set(k, v)
 	}
-	d.Set("urn", helpers.ServiceURN(config.Plate, "webCloudDatabases", ds.ServiceName))
 
 	return nil
 }

--- a/ovh/resource_hosting_privatedatabase_test.go
+++ b/ovh/resource_hosting_privatedatabase_test.go
@@ -154,6 +154,8 @@ func TestAccHostingPrivateDatabase_basic(t *testing.T) {
 						"ovh_hosting_privatedatabase.database", "datacenter", dc),
 					resource.TestCheckResourceAttr(
 						"ovh_hosting_privatedatabase.database", "version", engine),
+					resource.TestCheckResourceAttrSet(
+						"ovh_hosting_privatedatabase.database", "urn"),
 				),
 			},
 		},

--- a/ovh/resource_iploadbalancing.go
+++ b/ovh/resource_iploadbalancing.go
@@ -172,7 +172,7 @@ func resourceIpLoadbalancingUpdate(d *schema.ResourceData, meta interface{}) err
 
 	log.Printf("[DEBUG] Will update ipLoadbalancing: %s", serviceName)
 	opts := (&IpLoadbalancingUpdateOpts{}).FromResource(d)
-	endpoint := fmt.Sprintf("/ipLoadbalancing/%s", serviceName)
+	endpoint := fmt.Sprintf("/ipLoadbalancing/%s", url.PathEscape(serviceName))
 	if err := config.OVHClient.Put(endpoint, opts, nil); err != nil {
 		return fmt.Errorf("calling Put %s: %q", endpoint, err)
 	}
@@ -197,7 +197,7 @@ func resourceIpLoadbalancingRead(d *schema.ResourceData, meta interface{}) error
 	log.Printf("[DEBUG] Will read ipLoadbalancing: %s", serviceName)
 
 	r := &IpLoadbalancing{}
-	endpoint := fmt.Sprintf("/ipLoadbalancing/%s", serviceName)
+	endpoint := fmt.Sprintf("/ipLoadbalancing/%s", url.PathEscape(serviceName))
 	if err := config.OVHClient.Get(endpoint, &r); err != nil {
 		return helpers.CheckDeleted(d, err, endpoint)
 	}
@@ -206,7 +206,6 @@ func resourceIpLoadbalancingRead(d *schema.ResourceData, meta interface{}) error
 	for k, v := range r.ToMap() {
 		d.Set(k, v)
 	}
-	d.Set("urn", helpers.ServiceURN(config.Plate, "loadbalancer", r.ServiceName))
 
 	return nil
 }

--- a/ovh/resource_iploadbalancing_test.go
+++ b/ovh/resource_iploadbalancing_test.go
@@ -176,6 +176,8 @@ func TestAccResourceIpLoadbalancing_basic(t *testing.T) {
 						"ovh_iploadbalancing.iplb-lb1", "ipv4"),
 					resource.TestCheckResourceAttr(
 						"ovh_iploadbalancing.iplb-lb1", "display_name", desc),
+					resource.TestCheckResourceAttrSet(
+						"ovh_iploadbalancing.iplb-lb1", "urn"),
 				),
 			},
 		},
@@ -200,6 +202,8 @@ func TestAccResourceIpLoadbalancing_internal(t *testing.T) {
 						"ovh_iploadbalancing.iplb-internal", "ipv4"),
 					resource.TestCheckResourceAttr(
 						"ovh_iploadbalancing.iplb-internal", "display_name", desc),
+					resource.TestCheckResourceAttrSet(
+						"ovh_iploadbalancing.iplb-internal", "urn"),
 				),
 			},
 		},

--- a/ovh/resource_vrack.go
+++ b/ovh/resource_vrack.go
@@ -3,6 +3,7 @@ package ovh
 import (
 	"fmt"
 	"log"
+	"net/url"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/ovh/terraform-provider-ovh/ovh/helpers"
@@ -78,7 +79,7 @@ func resourceVrackUpdate(d *schema.ResourceData, meta interface{}) error {
 
 	log.Printf("[DEBUG] Will update vrack: %s", serviceName)
 	opts := (&VrackUpdateOpts{}).FromResource(d)
-	endpoint := fmt.Sprintf("/vrack/%s", serviceName)
+	endpoint := fmt.Sprintf("/vrack/%s", url.PathEscape(serviceName))
 	if err := config.OVHClient.Put(endpoint, opts, nil); err != nil {
 		return fmt.Errorf("calling Put %s: %q", endpoint, err)
 	}
@@ -97,7 +98,7 @@ func resourceVrackRead(d *schema.ResourceData, meta interface{}) error {
 
 	log.Printf("[DEBUG] Will read vrack: %s", serviceName)
 	r := &Vrack{}
-	endpoint := fmt.Sprintf("/vrack/%s", serviceName)
+	endpoint := fmt.Sprintf("/vrack/%s", url.PathEscape(serviceName))
 	if err := config.OVHClient.Get(endpoint, &r); err != nil {
 		return helpers.CheckDeleted(d, err, endpoint)
 	}
@@ -108,7 +109,6 @@ func resourceVrackRead(d *schema.ResourceData, meta interface{}) error {
 	for k, v := range r.ToMap() {
 		d.Set(k, v)
 	}
-	d.Set("urn", helpers.ServiceURN(config.Plate, "vrack", serviceName))
 
 	return nil
 }

--- a/ovh/resource_vrack_test.go
+++ b/ovh/resource_vrack_test.go
@@ -57,6 +57,8 @@ func TestAccResourceVrack_basic(t *testing.T) {
 						"ovh_vrack.vrack", "description", desc),
 					resource.TestCheckResourceAttrSet(
 						"ovh_vrack.vrack", "service_name"),
+					resource.TestCheckResourceAttrSet(
+						"ovh_vrack.vrack", "urn"),
 				),
 			},
 		},

--- a/ovh/types_cloud_project.go
+++ b/ovh/types_cloud_project.go
@@ -6,11 +6,12 @@ import (
 )
 
 type CloudProject struct {
-	Access      string  `json:"access"`
-	Description *string `json:"description"`
-	ProjectName *string `json:"projectName"`
-	ProjectId   string  `json:"project_id"`
-	Status      string  `json:"status"`
+	Access             string  `json:"access"`
+	Description        *string `json:"description"`
+	ProjectName        *string `json:"projectName"`
+	ProjectId          string  `json:"project_id"`
+	Status             string  `json:"status"`
+	IamResourceDetails `json:"iam"`
 }
 
 func (v CloudProject) ToMap() map[string]interface{} {
@@ -19,6 +20,7 @@ func (v CloudProject) ToMap() map[string]interface{} {
 	obj["access"] = v.Access
 	obj["project_id"] = v.ProjectId
 	obj["status"] = v.Status
+	obj["urn"] = v.URN
 
 	if v.Description != nil {
 		obj["description"] = *v.Description

--- a/ovh/types_dedicated_ceph.go
+++ b/ovh/types_dedicated_ceph.go
@@ -33,15 +33,16 @@ const (
 )
 
 type DedicatedCeph struct {
-	ServiceName   string                    `json:"serviceName"`
-	CephMonitors  []string                  `json:"cephMons"`
-	CephVersion   string                    `json:"cephVersion"`
-	CrushTunables DedicatedCephCrushTunable `json:"crushTunables"`
-	Label         string                    `json:"label"`
-	Region        string                    `json:"region"`
-	Size          float32                   `json:"size"`
-	State         DedicatedCephState        `json:"state"`
-	Status        DedicatedCephStatus       `json:"status"`
+	ServiceName        string                    `json:"serviceName"`
+	CephMonitors       []string                  `json:"cephMons"`
+	CephVersion        string                    `json:"cephVersion"`
+	CrushTunables      DedicatedCephCrushTunable `json:"crushTunables"`
+	Label              string                    `json:"label"`
+	Region             string                    `json:"region"`
+	Size               float32                   `json:"size"`
+	State              DedicatedCephState        `json:"state"`
+	Status             DedicatedCephStatus       `json:"status"`
+	IamResourceDetails `json:"iam"`
 }
 
 type DedicatedCephACL struct {

--- a/ovh/types_dedicated_nasha.go
+++ b/ovh/types_dedicated_nasha.go
@@ -18,6 +18,7 @@ type DedicatedNASHA struct {
 	CanCreatePartition bool   `json:"canCreatePartition,omitempty"`
 	Ip                 string `json:"ip,omitempty"`
 	ZpoolCapacity      int    `json:"zpoolCapacity,omitempty"`
+	IamResourceDetails `json:"iam"`
 }
 
 type DedicatedNASHAPartition struct {

--- a/ovh/types_dedicated_server.go
+++ b/ovh/types_dedicated_server.go
@@ -9,22 +9,23 @@ import (
 )
 
 type DedicatedServer struct {
-	Name            string `json:"name"`
-	BootId          int    `json:"bootId"`
-	CommercialRange string `json:"commercialRange"`
-	Datacenter      string `json:"datacenter"`
-	Ip              string `json:"ip"`
-	LinkSpeed       int    `json:"linkSpeed"`
-	Monitoring      bool   `json:"monitoring"`
-	Os              string `json:"os"`
-	ProfessionalUse bool   `json:"professionalUse"`
-	Rack            string `json:"rack"`
-	RescueMail      string `json:"rescueMail"`
-	Reverse         string `json:"reverse"`
-	RootDevice      string `json:"rootDevice"`
-	ServerId        int    `json:"serverId"`
-	State           string `json:"state"`
-	SupportLevel    string `json:"supportLevel"`
+	Name               string `json:"name"`
+	BootId             int    `json:"bootId"`
+	CommercialRange    string `json:"commercialRange"`
+	Datacenter         string `json:"datacenter"`
+	Ip                 string `json:"ip"`
+	LinkSpeed          int    `json:"linkSpeed"`
+	Monitoring         bool   `json:"monitoring"`
+	Os                 string `json:"os"`
+	ProfessionalUse    bool   `json:"professionalUse"`
+	Rack               string `json:"rack"`
+	RescueMail         string `json:"rescueMail"`
+	Reverse            string `json:"reverse"`
+	RootDevice         string `json:"rootDevice"`
+	ServerId           int    `json:"serverId"`
+	State              string `json:"state"`
+	SupportLevel       string `json:"supportLevel"`
+	IamResourceDetails `json:"iam"`
 }
 
 func (ds DedicatedServer) String() string {

--- a/ovh/types_domain_zone.go
+++ b/ovh/types_domain_zone.go
@@ -1,13 +1,12 @@
 package ovh
 
-import ()
-
 type DomainZone struct {
-	DnssecSupported bool     `json:"dnssecSupported"`
-	HasDnsAnycast   bool     `json:"hasDnsAnycast"`
-	LastUpdate      string   `json:"lastUpdate"`
-	Name            string   `json:"name"`
-	NameServers     []string `json:"nameServers"`
+	DnssecSupported    bool     `json:"dnssecSupported"`
+	HasDnsAnycast      bool     `json:"hasDnsAnycast"`
+	LastUpdate         string   `json:"lastUpdate"`
+	Name               string   `json:"name"`
+	NameServers        []string `json:"nameServers"`
+	IamResourceDetails `json:"iam"`
 }
 
 func (v DomainZone) ToMap() map[string]interface{} {
@@ -17,6 +16,7 @@ func (v DomainZone) ToMap() map[string]interface{} {
 	obj["has_dns_anycast"] = v.HasDnsAnycast
 	obj["last_update"] = v.LastUpdate
 	obj["name"] = v.Name
+	obj["urn"] = v.URN
 
 	if v.NameServers != nil {
 		obj["name_servers"] = v.NameServers

--- a/ovh/types_hostingPrivatedatabase.go
+++ b/ovh/types_hostingPrivatedatabase.go
@@ -6,25 +6,26 @@ import (
 )
 
 type HostingPrivateDatabase struct {
-	ServiceName    string        `json:"serviceName"`
-	Cpu            int           `json:"cpu"`
-	Datacenter     string        `json:"datacenter"`
-	DisplayName    string        `json:"displayName"`
-	Hostname       string        `json:"hostname"`
-	HostnameFtp    string        `json:"hostnameFtp"`
-	Infrastructure string        `json:"infrastructure"`
-	Offer          string        `json:"offer"`
-	Port           int           `json:"port"`
-	PortFtp        int           `json:"portFtp"`
-	QuotaSize      *UnitAndValue `json:"quotasize"`
-	QuotaUsed      *UnitAndValue `json:"quotaUsed"`
-	Ram            *UnitAndValue `json:"ram"`
-	Server         string        `json:"server"`
-	State          string        `json:"state"`
-	Type           string        `json:"type"`
-	Version        string        `json:"version"`
-	VersionLabel   string        `json:"versionLabel"`
-	VersionNumber  float64       `json:"versionNumber"`
+	ServiceName        string        `json:"serviceName"`
+	Cpu                int           `json:"cpu"`
+	Datacenter         string        `json:"datacenter"`
+	DisplayName        string        `json:"displayName"`
+	Hostname           string        `json:"hostname"`
+	HostnameFtp        string        `json:"hostnameFtp"`
+	Infrastructure     string        `json:"infrastructure"`
+	Offer              string        `json:"offer"`
+	Port               int           `json:"port"`
+	PortFtp            int           `json:"portFtp"`
+	QuotaSize          *UnitAndValue `json:"quotasize"`
+	QuotaUsed          *UnitAndValue `json:"quotaUsed"`
+	Ram                *UnitAndValue `json:"ram"`
+	Server             string        `json:"server"`
+	State              string        `json:"state"`
+	Type               string        `json:"type"`
+	Version            string        `json:"version"`
+	VersionLabel       string        `json:"versionLabel"`
+	VersionNumber      float64       `json:"versionNumber"`
+	IamResourceDetails `json:"iam"`
 }
 
 func (v HostingPrivateDatabase) ToMap() map[string]interface{} {
@@ -47,6 +48,7 @@ func (v HostingPrivateDatabase) ToMap() map[string]interface{} {
 	obj["version"] = v.Version
 	obj["version_label"] = v.VersionLabel
 	obj["version_number"] = v.VersionNumber
+	obj["urn"] = v.URN
 
 	return obj
 }

--- a/ovh/types_iploadbalancing.go
+++ b/ovh/types_iploadbalancing.go
@@ -8,19 +8,20 @@ import (
 )
 
 type IpLoadbalancing struct {
-	DisplayName      *string                         `json:"displayName"`
-	IPv4             *string                         `json:"ipv4,omitempty"`
-	IPv6             *string                         `json:"ipv6,omitempty"`
-	IpLoadbalancing  string                          `json:"ipLoadbalancing"`
-	MetricsToken     *string                         `json:"metricsToken,omitempty"`
-	Offer            string                          `json:"offer"`
-	OrderableZones   []*IpLoadbalancingOrderableZone `json:"orderableZone"`
-	ServiceName      string                          `json:"serviceName"`
-	SslConfiguration *string                         `json:"sslConfiguration"`
-	State            string                          `json:"state"`
-	VrackEligibility bool                            `json:"vrackEligibility"`
-	VrackName        *string                         `json:"vrackName"`
-	Zone             []string                        `json:"zone"`
+	DisplayName        *string                         `json:"displayName"`
+	IPv4               *string                         `json:"ipv4,omitempty"`
+	IPv6               *string                         `json:"ipv6,omitempty"`
+	IpLoadbalancing    string                          `json:"ipLoadbalancing"`
+	MetricsToken       *string                         `json:"metricsToken,omitempty"`
+	Offer              string                          `json:"offer"`
+	OrderableZones     []*IpLoadbalancingOrderableZone `json:"orderableZone"`
+	ServiceName        string                          `json:"serviceName"`
+	SslConfiguration   *string                         `json:"sslConfiguration"`
+	State              string                          `json:"state"`
+	VrackEligibility   bool                            `json:"vrackEligibility"`
+	VrackName          *string                         `json:"vrackName"`
+	Zone               []string                        `json:"zone"`
+	IamResourceDetails `json:"iam"`
 }
 
 func (v IpLoadbalancing) ToMap() map[string]interface{} {
@@ -33,6 +34,7 @@ func (v IpLoadbalancing) ToMap() map[string]interface{} {
 	obj["state"] = v.State
 	obj["vrack_eligibility"] = v.VrackEligibility
 	obj["display_name"] = v.DisplayName
+	obj["urn"] = v.URN
 
 	if v.IPv4 != nil {
 		obj["ipv4"] = *v.IPv4

--- a/ovh/types_vps.go
+++ b/ovh/types_vps.go
@@ -14,18 +14,19 @@ type VPSModel struct {
 }
 
 type VPS struct {
-	Name           string   `json:"name"`
-	Cluster        string   `json:"cluster"`
-	Memory         int      `json:"memoryLimit"`
-	NetbootMode    string   `json:"netbootMode"`
-	Keymap         string   `json:"keymap"`
-	Zone           string   `json:"zone"`
-	State          string   `json:"state"`
-	Vcore          int      `json:"vcore"`
-	OfferType      string   `json:"offerType"`
-	SlaMonitorting bool     `json:"slaMonitoring"`
-	DisplayName    string   `json:"displayName"`
-	Model          VPSModel `json:"model"`
+	Name               string   `json:"name"`
+	Cluster            string   `json:"cluster"`
+	Memory             int      `json:"memoryLimit"`
+	NetbootMode        string   `json:"netbootMode"`
+	Keymap             string   `json:"keymap"`
+	Zone               string   `json:"zone"`
+	State              string   `json:"state"`
+	Vcore              int      `json:"vcore"`
+	OfferType          string   `json:"offerType"`
+	SlaMonitorting     bool     `json:"slaMonitoring"`
+	DisplayName        string   `json:"displayName"`
+	Model              VPSModel `json:"model"`
+	IamResourceDetails `json:"iam"`
 }
 
 type VPSDatacenter struct {

--- a/ovh/types_vrack.go
+++ b/ovh/types_vrack.go
@@ -8,8 +8,9 @@ import (
 )
 
 type Vrack struct {
-	Description *string `json:"description"`
-	Name        *string `json:"name"`
+	Description        *string `json:"description"`
+	Name               *string `json:"name"`
+	IamResourceDetails `json:"iam"`
 }
 
 func (v Vrack) ToMap() map[string]interface{} {
@@ -22,6 +23,8 @@ func (v Vrack) ToMap() map[string]interface{} {
 	if v.Name != nil {
 		obj["name"] = *v.Name
 	}
+
+	obj["urn"] = v.URN
 
 	return obj
 }


### PR DESCRIPTION
# Description

The URNs of the IAM resources are computed locally in the provider. This is not necessary anymore since a field `iam` is included in the response bodies of the API, which includes the `urn`.
Also added a few `url.PathEscape` on service ids.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (improve existing resource(s) or datasource(s))
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

# How Has This Been Tested?

Added a check in all tests that check resources that have an IAM URN.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or issues
- [ ] I have added acceptance tests that prove my fix is effective or that my feature works
- [x] New and existing acceptance tests pass locally with my changes
- [x] I ran succesfully `go mod vendor` if I added or modify `go.mod` file
