### PR TITLE
[Doc] Update Terraform State storage doc to replace by a link to the official documentation

### DIFF
--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -98,51 +98,7 @@ The following arguments are supported:
 
 ## Terraform State storage in an OVHcloud Object Storage (S3 compatibility)
 
-In order to store your Terraform states on an Object Storage, and generally if you want to interact with the Object Storage, you need to have the rights to manage an Object Storage.
-
-You should already have a [High Performance Object Storage container and a user](https://help.ovhcloud.com/csm/en-public-cloud-compute-terraform-high-perf-object-storage-backend-state?id=kb_article_view&sysparm_article=KB0051345).
-
-You should also be able to interact with the `aws` CLI and list the OVHcloud High Performance Object Storage containers that the user is linked to:
-```
-$ aws s3 ls
-2022-07-11 16:20:48 my-container
-2022-07-11 16:55:20 terraform-state-hp
-```
-
-Before Terraform 1.6.0:
-
-```
-terraform {
-    backend "s3" {
-      bucket = "terraform-state-hp"
-      key    = "terraform.tfstate"
-      region = "gra"
-      #or sbg or any activated high performance storage region
-      endpoint = "s3.gra.perf.cloud.ovh.net"
-      skip_credentials_validation = true
-      skip_region_validation = true
-    }
-}
-```
-
-Terraform 1.6.0 and later:
-
-```
-terraform {
-    backend "s3" {
-      bucket = "terraform-state-hp"
-      key    = "terraform.tfstate"
-      region = "gra"
-      # sbg or any activated high performance storage region
-      endpoints = {
-        s3 = "https://s3.gra.perf.cloud.ovh.net/"
-      }
-      skip_credentials_validation = true
-      skip_region_validation      = true
-      skip_requesting_account_id  = true
-    }
-}
-```
+In order to store your Terraform states on a High Performance (S3) OVHcloud Object Storage, please follow the [guide](https://help.ovhcloud.com/csm/en-public-cloud-compute-terraform-high-perf-object-storage-backend-state?id=kb_article_view&sysparm_article=KB0051345).
 
 ## Testing and Development
 


### PR DESCRIPTION
# Description
Update the documentation  to explain to the user to use an OVHcloud object storage to store its terraform state.

## Type of change

Please delete options that are not relevant.

- [x] Documentation update

# How Has This Been Tested?

```
$ terraform version
Terraform v1.6.4
on darwin_amd64
+ provider registry.terraform.io/hashicorp/local v2.4.0
+ provider registry.terraform.io/ovh/ovh v0.35.0
```

`backend.tf`:

```
terraform {
    backend "s3" {
      bucket = "terraform-state-hp"
      key    = "terraform.tfstate"
      region = "gra"
      #or sbg or any activated high performance storage region
      endpoints = {
        s3 = "https://s3.gra.perf.cloud.ovh.net"
      }
      skip_credentials_validation = true
      skip_region_validation = true
      skip_requesting_account_id = true
    }
}
```

```
$ terraform init

Initializing the backend...

Initializing provider plugins...
- Reusing previous version of ovh/ovh from the dependency lock file
- Reusing previous version of hashicorp/local from the dependency lock file
- Using previously-installed ovh/ovh v0.35.0
- Using previously-installed hashicorp/local v2.4.0

Terraform has been successfully initialized!

You may now begin working with Terraform. Try running "terraform plan" to see
any changes that are required for your infrastructure. All Terraform commands
should now work.

If you ever set or change modules or backend configuration for Terraform,
rerun this command to reinitialize your working directory. If you forget, other
commands will detect it and remind you to do so if necessary.
```

# Checklist:

- [x] I have made corresponding changes to the documentation
