### PR TITLE
ovh_dbaas_logs_cluster: add lookup for default clusterId on Read resource

### DIFF
--- a/ovh/resource_dbaas_logs_cluster.go
+++ b/ovh/resource_dbaas_logs_cluster.go
@@ -273,6 +273,14 @@ func resourceDbaasLogsClusterRead(d *schema.ResourceData, meta interface{}) erro
 
 	serviceName := d.Get("service_name").(string)
 	clusterId := d.Get("cluster_id").(string)
+	if clusterId == "" {
+		var err error
+		clusterId, err = dbaasGetClusterID(config, serviceName)
+		if err != nil {
+			return fmt.Errorf("error retrieving clusterId for %s:\n\t %q", serviceName, err)
+		}
+	}
+	d.Set("cluster_id", clusterId)
 
 	log.Printf("[DEBUG] Will read dbaas logs cluster %s/%s", serviceName, clusterId)
 


### PR DESCRIPTION
# Description

This PR fixes an error when the state does not contain the `clusterId` and therefore avoid such error:

```
 Error: Error calling GET /dbaas/logs/ldp-xxxx/cluster/: "json: cannot unmarshal array into Go value of type map[string]interface {}"
with ovh_dbaas_logs_cluster.foo
on main.tf line 110, in resource "ovh_dbaas_logs_cluster" "fooo": 
```

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (improve existing resource(s) or datasource(s))
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or issues
- [ ] I have added acceptance tests that prove my fix is effective or that my feature works
- [ ] New and existing acceptance tests pass locally with my changes
- [ ] I ran succesfully `go mod vendor` if I added or modify `go.mod` file
