### PR TITLE
Add support for getting and updating boot script

### DIFF
--- a/ovh/data_dedicated_server.go
+++ b/ovh/data_dedicated_server.go
@@ -27,6 +27,11 @@ func dataSourceDedicatedServer() *schema.Resource {
 				Computed:    true,
 				Description: "",
 			},
+			"boot_script": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "",
+			},
 			"commercial_range": {
 				Type:        schema.TypeString,
 				Computed:    true,
@@ -202,6 +207,7 @@ func dataSourceDedicatedServerRead(d *schema.ResourceData, meta interface{}) err
 	d.SetId(ds.Name)
 	d.Set("urn", ds.URN)
 	d.Set("boot_id", ds.BootId)
+	d.Set("boot_script", ds.BootScript)
 	d.Set("commercial_range", ds.CommercialRange)
 	d.Set("datacenter", ds.Datacenter)
 	d.Set("ip", ds.Ip)

--- a/ovh/data_dedicated_server_test.go
+++ b/ovh/data_dedicated_server_test.go
@@ -27,6 +27,8 @@ func TestAccDedicatedServerDataSource_basic(t *testing.T) {
 						"data.ovh_dedicated_server.server", "vnis.#"),
 					resource.TestCheckResourceAttr(
 						"data.ovh_dedicated_server.server", "vnis.0.server_name", dedicated_server),
+					resource.TestCheckResourceAttr(
+						"data.ovh_dedicated_server.server", "boot_script", ""),
 					resource.TestCheckResourceAttrSet(
 						"data.ovh_dedicated_server.server", "urn"),
 				),

--- a/ovh/resource_dedicated_server_update.go
+++ b/ovh/resource_dedicated_server_update.go
@@ -21,11 +21,15 @@ func resourceDedicatedServerUpdate() *schema.Resource {
 				Description: "The internal name of your dedicated server.",
 				Required:    true,
 			},
-
 			"boot_id": {
 				Type:        schema.TypeInt,
 				Description: "The boot id of your dedicated server.",
 				Computed:    true,
+				Optional:    true,
+			},
+			"boot_script": {
+				Type:        schema.TypeString,
+				Description: "The boot script of your dedicated server.",
 				Optional:    true,
 			},
 			"monitoring": {
@@ -93,6 +97,7 @@ func resourceDedicatedServerUpdateRead(d *schema.ResourceData, meta interface{})
 	}
 
 	d.Set("boot_id", ds.BootId)
+	d.Set("boot_script", ds.BootScript)
 	d.Set("monitoring", ds.Monitoring)
 	d.Set("state", ds.State)
 

--- a/ovh/resource_dedicated_server_update_test.go
+++ b/ovh/resource_dedicated_server_update_test.go
@@ -24,6 +24,8 @@ func TestAccDedicatedServerUpdate_basic(t *testing.T) {
 						"ovh_dedicated_server_update.server", "monitoring", "true"),
 					resource.TestCheckResourceAttr(
 						"ovh_dedicated_server_update.server", "state", "ok"),
+					resource.TestCheckResourceAttr(
+						"ovh_dedicated_server_update.server", "boot_script", ""),
 				),
 			},
 			{
@@ -34,6 +36,8 @@ func TestAccDedicatedServerUpdate_basic(t *testing.T) {
 						"ovh_dedicated_server_update.server", "monitoring", "false"),
 					resource.TestCheckResourceAttr(
 						"ovh_dedicated_server_update.server", "state", "ok"),
+					resource.TestCheckResourceAttr(
+						"ovh_dedicated_server_update.server", "boot_script", ""),
 				),
 			},
 		},

--- a/ovh/types_dedicated_server.go
+++ b/ovh/types_dedicated_server.go
@@ -11,6 +11,7 @@ import (
 type DedicatedServer struct {
 	Name               string `json:"name"`
 	BootId             int    `json:"bootId"`
+	BootScript         string `json:"bootScript"`
 	CommercialRange    string `json:"commercialRange"`
 	Datacenter         string `json:"datacenter"`
 	Ip                 string `json:"ip"`
@@ -40,12 +41,14 @@ func (ds DedicatedServer) String() string {
 
 type DedicatedServerUpdateOpts struct {
 	BootId     *int64  `json:"bootId,omitempty"`
+	BootScript *string `json:"bootScript,omitempty"`
 	Monitoring *bool   `json:"monitoring,omitempty"`
 	State      *string `json:"state,omitempty"`
 }
 
 func (opts *DedicatedServerUpdateOpts) FromResource(d *schema.ResourceData) *DedicatedServerUpdateOpts {
 	opts.BootId = helpers.GetNilInt64PointerFromData(d, "boot_id")
+	opts.BootScript = helpers.GetNilStringPointerFromData(d, "boot_script")
 	opts.Monitoring = helpers.GetNilBoolPointerFromData(d, "monitoring")
 	opts.State = helpers.GetNilStringPointerFromData(d, "state")
 	return opts

--- a/website/docs/d/dedicated_server.html.markdown
+++ b/website/docs/d/dedicated_server.html.markdown
@@ -24,6 +24,7 @@ data "ovh_dedicated_server" "server" {
 In addition, the following attributes are exported:
 
 * `boot_id` - boot id of the server
+* `boot_script` - boot script of the server
 * `urn` - URN of the dedicated server instance
 * `commercial_range` - dedicated server commercial range
 * `datacenter` - dedicated datacenter localisation (bhs1,bhs2,...)

--- a/website/docs/r/dedicated_server_update.html.markdown
+++ b/website/docs/r/dedicated_server_update.html.markdown
@@ -34,6 +34,7 @@ The following arguments are supported:
 
 * `service_name` - (Required) The service_name of your dedicated server.
 * `boot_id` - boot id of the server
+* `boot_script` - boot script of the server
 * `monitoring` - Icmp monitoring state
 * `state` - error, hacked, hackedBlocked, ok
 


### PR DESCRIPTION
# Description
This PR adds for getting and setting the boot script

Fixes #546 (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (improve existing resource(s) or datasource(s))
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

```hcl
data "ovh_dedicated_server_boots" "rescue" {
  service_name = "nsxxxxxxx.ip-xx-xx-xx.eu"
  boot_type    = "rescue"
  kernel       = "rescue64-pro"
}

resource "ovh_dedicated_server_update" "server" {
  service_name = "nsxxxxxxx.ip-xx-xx-xx.eu"
  boot_script  = "TEST SCRIPT"
  monitoring   = true
  state        = "ok"
}
```

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or issues
- [x] New and existing acceptance tests pass locally with my changes
- [x] I ran succesfully `go mod vendor` if I added or modify `go.mod` file
