### PR TITLE
"service_name" could not be both required and have a default function

### DIFF
--- a/ovh/resource_cloud_project_database.go
+++ b/ovh/resource_cloud_project_database.go
@@ -34,7 +34,6 @@ func resourceCloudProjectDatabase() *schema.Resource {
 			"service_name": {
 				Type:        schema.TypeString,
 				ForceNew:    true,
-				Required:    true,
 				DefaultFunc: schema.EnvDefaultFunc("OVH_CLOUD_PROJECT_SERVICE", nil),
 			},
 			"description": {


### PR DESCRIPTION
# Description

In some resources such as managed databases, a `service_name`  argument is both required AND have default function. Those are not  compatible, and could lead to a shrodinger situation where a end user provide its value via an env var (`OVH_CLOUD_PROJECT_SERVICE`), and see its resource tagged as invalid.

My proposition is to remove the `required` flag.

Note that this pr only applies to `ovh_cloud_project_database` , but the same should be applied to all relevants situations.

Also, see: https://github.com/hashicorp/terraform-plugin-docs/issues/42 (thx @hyvs )

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings or issues
- [ ] I have added acceptance tests that prove my fix is effective or that my feature works
- [ ] New and existing acceptance tests pass locally with my changes
- [ ] I ran succesfully `go mod vendor` if I added or modify `go.mod` file
