### PR TITLE
CustomDiff Computed on password if password_resest change

### DIFF
--- a/ovh/resource_cloud_project_database_m3db_user.go
+++ b/ovh/resource_cloud_project_database_m3db_user.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/ovh/terraform-provider-ovh/ovh/helpers"
 )
@@ -77,6 +78,13 @@ func resourceCloudProjectDatabaseM3dbUser() *schema.Resource {
 				Computed:    true,
 			},
 		},
+
+		CustomizeDiff: customdiff.ComputedIf(
+			"password",
+			func(ctx context.Context, d *schema.ResourceDiff, meta interface{}) bool {
+				return d.HasChange("password_reset")
+			},
+		),
 	}
 }
 

--- a/ovh/resource_cloud_project_database_mongodb_user.go
+++ b/ovh/resource_cloud_project_database_mongodb_user.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/ovh/go-ovh/ovh"
@@ -96,6 +97,13 @@ func resourceCloudProjectDatabaseMongodbUser() *schema.Resource {
 				Computed:    true,
 			},
 		},
+
+		CustomizeDiff: customdiff.ComputedIf(
+			"password",
+			func(ctx context.Context, d *schema.ResourceDiff, meta interface{}) bool {
+				return d.HasChange("password_reset")
+			},
+		),
 	}
 }
 

--- a/ovh/resource_cloud_project_database_opensearch_user.go
+++ b/ovh/resource_cloud_project_database_opensearch_user.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/ovh/terraform-provider-ovh/ovh/helpers"
 )
@@ -91,6 +92,13 @@ func resourceCloudProjectDatabaseOpensearchUser() *schema.Resource {
 				Computed:    true,
 			},
 		},
+
+		CustomizeDiff: customdiff.ComputedIf(
+			"password",
+			func(ctx context.Context, d *schema.ResourceDiff, meta interface{}) bool {
+				return d.HasChange("password_reset")
+			},
+		),
 	}
 }
 

--- a/ovh/resource_cloud_project_database_postgresql_user.go
+++ b/ovh/resource_cloud_project_database_postgresql_user.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/ovh/terraform-provider-ovh/ovh/helpers"
 )
@@ -79,6 +80,13 @@ func resourceCloudProjectDatabasePostgresqlUser() *schema.Resource {
 				Computed:    true,
 			},
 		},
+
+		CustomizeDiff: customdiff.ComputedIf(
+			"password",
+			func(ctx context.Context, d *schema.ResourceDiff, meta interface{}) bool {
+				return d.HasChange("password_reset")
+			},
+		),
 	}
 }
 

--- a/ovh/resource_cloud_project_database_redis_user.go
+++ b/ovh/resource_cloud_project_database_redis_user.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/ovh/terraform-provider-ovh/ovh/helpers"
 )
@@ -100,6 +101,13 @@ func resourceCloudProjectDatabaseRedisUser() *schema.Resource {
 				Computed:    true,
 			},
 		},
+
+		CustomizeDiff: customdiff.ComputedIf(
+			"password",
+			func(ctx context.Context, d *schema.ResourceDiff, meta interface{}) bool {
+				return d.HasChange("password_reset")
+			},
+		),
 	}
 }
 

--- a/ovh/resource_cloud_project_database_user.go
+++ b/ovh/resource_cloud_project_database_user.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/ovh/terraform-provider-ovh/ovh/helpers"
 )
@@ -80,6 +81,13 @@ func resourceCloudProjectDatabaseUser() *schema.Resource {
 				Computed:    true,
 			},
 		},
+
+		CustomizeDiff: customdiff.ComputedIf(
+			"password",
+			func(ctx context.Context, d *schema.ResourceDiff, meta interface{}) bool {
+				return d.HasChange("password_reset")
+			},
+		),
 	}
 }
 

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff/compose.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff/compose.go
@@ -1,0 +1,76 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package customdiff
+
+import (
+	"context"
+	"errors"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+// All returns a CustomizeDiffFunc that runs all of the given
+// CustomizeDiffFuncs and returns all of the errors produced.
+//
+// If one function produces an error, functions after it are still run.
+// If this is not desirable, use function Sequence instead.
+//
+// If multiple functions returns errors, the result is a multierror.
+//
+// For example:
+//
+//	&schema.Resource{
+//	    // ...
+//	    CustomizeDiff: customdiff.All(
+//	        customdiff.ValidateChange("size", func (ctx context.Context, old, new, meta interface{}) error {
+//	            // If we are increasing "size" then the new value must be
+//	            // a multiple of the old value.
+//	            if new.(int) <= old.(int) {
+//	                return nil
+//	            }
+//	            if (new.(int) % old.(int)) != 0 {
+//	                return fmt.Errorf("new size value must be an integer multiple of old value %d", old.(int))
+//	            }
+//	            return nil
+//	        }),
+//	        customdiff.ForceNewIfChange("size", func (ctx context.Context, old, new, meta interface{}) bool {
+//	            // "size" can only increase in-place, so we must create a new resource
+//	            // if it is decreased.
+//	            return new.(int) < old.(int)
+//	        }),
+//	        customdiff.ComputedIf("version_id", func (ctx context.Context, d *schema.ResourceDiff, meta interface{}) bool {
+//	            // Any change to "content" causes a new "version_id" to be allocated.
+//	            return d.HasChange("content")
+//	        }),
+//	    ),
+//	}
+func All(funcs ...schema.CustomizeDiffFunc) schema.CustomizeDiffFunc {
+	return func(ctx context.Context, d *schema.ResourceDiff, meta interface{}) error {
+		var errs []error
+		for _, f := range funcs {
+			thisErr := f(ctx, d, meta)
+			if thisErr != nil {
+				errs = append(errs, thisErr)
+			}
+		}
+		return errors.Join(errs...)
+	}
+}
+
+// Sequence returns a CustomizeDiffFunc that runs all of the given
+// CustomizeDiffFuncs in sequence, stopping at the first one that returns
+// an error and returning that error.
+//
+// If all functions succeed, the combined function also succeeds.
+func Sequence(funcs ...schema.CustomizeDiffFunc) schema.CustomizeDiffFunc {
+	return func(ctx context.Context, d *schema.ResourceDiff, meta interface{}) error {
+		for _, f := range funcs {
+			err := f(ctx, d, meta)
+			if err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+}

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff/computed.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff/computed.go
@@ -1,0 +1,36 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package customdiff
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/internal/logging"
+)
+
+// ComputedIf returns a CustomizeDiffFunc that sets the given key's new value
+// as computed if the given condition function returns true.
+//
+// This function is best effort and will generate a warning log on any errors.
+func ComputedIf(key string, f ResourceConditionFunc) schema.CustomizeDiffFunc {
+	return func(ctx context.Context, d *schema.ResourceDiff, meta interface{}) error {
+		if f(ctx, d, meta) {
+			// To prevent backwards compatibility issues, this logic only
+			// generates a warning log instead of returning the error to
+			// the provider and ultimately the practitioner. Providers may
+			// not be aware of all situations in which the key may not be
+			// present in the data, such as during resource creation, so any
+			// further changes here should take that into account by
+			// documenting how to prevent the error.
+			if err := d.SetNewComputed(key); err != nil {
+				logging.HelperSchemaWarn(ctx, "unable to set attribute value to unknown", map[string]interface{}{
+					logging.KeyAttributePath: key,
+					logging.KeyError:         err,
+				})
+			}
+		}
+		return nil
+	}
+}

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff/condition.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff/condition.go
@@ -1,0 +1,65 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package customdiff
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+// ResourceConditionFunc is a function type that makes a boolean decision based
+// on an entire resource diff.
+type ResourceConditionFunc func(ctx context.Context, d *schema.ResourceDiff, meta interface{}) bool
+
+// ValueChangeConditionFunc is a function type that makes a boolean decision
+// by comparing two values.
+type ValueChangeConditionFunc func(ctx context.Context, oldValue, newValue, meta interface{}) bool
+
+// ValueConditionFunc is a function type that makes a boolean decision based
+// on a given value.
+type ValueConditionFunc func(ctx context.Context, value, meta interface{}) bool
+
+// If returns a CustomizeDiffFunc that calls the given condition
+// function and then calls the given CustomizeDiffFunc only if the condition
+// function returns true.
+//
+// This can be used to include conditional customizations when composing
+// customizations using All and Sequence, but should generally be used only in
+// simple scenarios. Prefer directly writing a CustomizeDiffFunc containing
+// a conditional branch if the given CustomizeDiffFunc is already a
+// locally-defined function, since this avoids obscuring the control flow.
+func If(cond ResourceConditionFunc, f schema.CustomizeDiffFunc) schema.CustomizeDiffFunc {
+	return func(ctx context.Context, d *schema.ResourceDiff, meta interface{}) error {
+		if cond(ctx, d, meta) {
+			return f(ctx, d, meta)
+		}
+		return nil
+	}
+}
+
+// IfValueChange returns a CustomizeDiffFunc that calls the given condition
+// function with the old and new values of the given key and then calls the
+// given CustomizeDiffFunc only if the condition function returns true.
+func IfValueChange(key string, cond ValueChangeConditionFunc, f schema.CustomizeDiffFunc) schema.CustomizeDiffFunc {
+	return func(ctx context.Context, d *schema.ResourceDiff, meta interface{}) error {
+		oldValue, newValue := d.GetChange(key)
+		if cond(ctx, oldValue, newValue, meta) {
+			return f(ctx, d, meta)
+		}
+		return nil
+	}
+}
+
+// IfValue returns a CustomizeDiffFunc that calls the given condition
+// function with the new values of the given key and then calls the
+// given CustomizeDiffFunc only if the condition function returns true.
+func IfValue(key string, cond ValueConditionFunc, f schema.CustomizeDiffFunc) schema.CustomizeDiffFunc {
+	return func(ctx context.Context, d *schema.ResourceDiff, meta interface{}) error {
+		if cond(ctx, d.Get(key), meta) {
+			return f(ctx, d, meta)
+		}
+		return nil
+	}
+}

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff/doc.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff/doc.go
@@ -1,0 +1,14 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+// Package customdiff provides a set of reusable and composable functions
+// to enable more "declarative" use of the CustomizeDiff mechanism available
+// for resources in package helper/schema.
+//
+// The intent of these helpers is to make the intent of a set of diff
+// customizations easier to see, rather than lost in a sea of Go function
+// boilerplate. They should _not_ be used in situations where they _obscure_
+// intent, e.g. by over-using the composition functions where a single
+// function containing normal Go control flow statements would be more
+// straightforward.
+package customdiff

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff/force_new.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff/force_new.go
@@ -1,0 +1,74 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package customdiff
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/internal/logging"
+)
+
+// ForceNewIf returns a CustomizeDiffFunc that flags the given key as
+// requiring a new resource if the given condition function returns true.
+//
+// The return value of the condition function is ignored if the old and new
+// values of the field compare equal, since no attribute diff is generated in
+// that case.
+//
+// This function is best effort and will generate a warning log on any errors.
+func ForceNewIf(key string, f ResourceConditionFunc) schema.CustomizeDiffFunc {
+	return func(ctx context.Context, d *schema.ResourceDiff, meta interface{}) error {
+		if f(ctx, d, meta) {
+			// To prevent backwards compatibility issues, this logic only
+			// generates a warning log instead of returning the error to
+			// the provider and ultimately the practitioner. Providers may
+			// not be aware of all situations in which the key may not be
+			// present in the data, such as during resource creation, so any
+			// further changes here should take that into account by
+			// documenting how to prevent the error.
+			if err := d.ForceNew(key); err != nil {
+				logging.HelperSchemaWarn(ctx, "unable to require attribute replacement", map[string]interface{}{
+					logging.KeyAttributePath: key,
+					logging.KeyError:         err,
+				})
+			}
+		}
+		return nil
+	}
+}
+
+// ForceNewIfChange returns a CustomizeDiffFunc that flags the given key as
+// requiring a new resource if the given condition function returns true.
+//
+// The return value of the condition function is ignored if the old and new
+// values compare equal, since no attribute diff is generated in that case.
+//
+// This function is similar to ForceNewIf but provides the condition function
+// only the old and new values of the given key, which leads to more compact
+// and explicit code in the common case where the decision can be made with
+// only the specific field value.
+//
+// This function is best effort and will generate a warning log on any errors.
+func ForceNewIfChange(key string, f ValueChangeConditionFunc) schema.CustomizeDiffFunc {
+	return func(ctx context.Context, d *schema.ResourceDiff, meta interface{}) error {
+		oldValue, newValue := d.GetChange(key)
+		if f(ctx, oldValue, newValue, meta) {
+			// To prevent backwards compatibility issues, this logic only
+			// generates a warning log instead of returning the error to
+			// the provider and ultimately the practitioner. Providers may
+			// not be aware of all situations in which the key may not be
+			// present in the data, such as during resource creation, so any
+			// further changes here should take that into account by
+			// documenting how to prevent the error.
+			if err := d.ForceNew(key); err != nil {
+				logging.HelperSchemaWarn(ctx, "unable to require attribute replacement", map[string]interface{}{
+					logging.KeyAttributePath: key,
+					logging.KeyError:         err,
+				})
+			}
+		}
+		return nil
+	}
+}

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff/validate.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff/validate.go
@@ -1,0 +1,43 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package customdiff
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+// ValueChangeValidationFunc is a function type that validates the difference
+// (or lack thereof) between two values, returning an error if the change
+// is invalid.
+type ValueChangeValidationFunc func(ctx context.Context, oldValue, newValue, meta interface{}) error
+
+// ValueValidationFunc is a function type that validates a particular value,
+// returning an error if the value is invalid.
+type ValueValidationFunc func(ctx context.Context, value, meta interface{}) error
+
+// ValidateChange returns a CustomizeDiffFunc that applies the given validation
+// function to the change for the given key, returning any error produced.
+func ValidateChange(key string, f ValueChangeValidationFunc) schema.CustomizeDiffFunc {
+	return func(ctx context.Context, d *schema.ResourceDiff, meta interface{}) error {
+		oldValue, newValue := d.GetChange(key)
+		return f(ctx, oldValue, newValue, meta)
+	}
+}
+
+// ValidateValue returns a CustomizeDiffFunc that applies the given validation
+// function to value of the given key, returning any error produced.
+//
+// This should generally not be used since it is functionally equivalent to
+// a validation function applied directly to the schema attribute in question,
+// but is provided for situations where composing multiple CustomizeDiffFuncs
+// together makes intent clearer than spreading that validation across the
+// schema.
+func ValidateValue(key string, f ValueValidationFunc) schema.CustomizeDiffFunc {
+	return func(ctx context.Context, d *schema.ResourceDiff, meta interface{}) error {
+		val := d.Get(key)
+		return f(ctx, val, meta)
+	}
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -195,6 +195,7 @@ github.com/hashicorp/terraform-plugin-mux/tf6muxserver
 # github.com/hashicorp/terraform-plugin-sdk/v2 v2.31.0
 ## explicit; go 1.20
 github.com/hashicorp/terraform-plugin-sdk/v2/diag
+github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff
 github.com/hashicorp/terraform-plugin-sdk/v2/helper/logging
 github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema
 github.com/hashicorp/terraform-plugin-sdk/v2/internal/addrs


### PR DESCRIPTION
# Description

Add a CustomizeDiff ComputedIf for password in all database user resource to ling the password attribute with the password_resest attribute.
With this, if password_resest change, the field password will be show as recomputed in the Plan.
So any other resource that use this password field will know that they must update something.

Fixes #559 

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

**Test Configuration**:
* Existing HCL configuration you used: 
```hcl
resource "ovh_cloud_project_database_postgresql_user" "user" {
  service_name     = "xxxxx"
  cluster_id            = "xxxxx"
  name                   = "testname"
  password_reset  = "reset1"
}

output "user_password" {
  value     = ovh_cloud_project_database_postgresql_user.user.password
  sensitive = true
}
```
Then update `password_reset`, I can see plan show update on `password_reset` and `password`.
Also `user_password` output is now automatically
