### PR TITLE
fix: TestAccCloudProjectVrackDataSource_basic: Attach a vRack before test and detach it afterwards

### DIFF
--- a/ovh/data_cloud_project_vrack_test.go
+++ b/ovh/data_cloud_project_vrack_test.go
@@ -22,7 +22,13 @@ func TestAccCloudProjectVrackDataSource_basic(t *testing.T) {
 }
 
 var testAccCloudProjectVrackDatasourceConfig = fmt.Sprintf(`
+resource "ovh_vrack_cloudproject" "attach" {
+	service_name = "%s"
+	project_id   = "%s"
+}
+
 data "ovh_cloud_project_vrack" "vrack" {
   service_name = "%s"
+  depends_on = [ovh_vrack_cloudproject.attach]
 }
-`, os.Getenv("OVH_CLOUD_PROJECT_SERVICE_TEST"))
+`, os.Getenv("OVH_VRACK_SERVICE_TEST"), os.Getenv("OVH_CLOUD_PROJECT_SERVICE_TEST"), os.Getenv("OVH_CLOUD_PROJECT_SERVICE_TEST"))


### PR DESCRIPTION
# Description

Acceptance test `TestAccCloudProjectVrackDataSource_basic` was failing because it expects a vRack to be attached to the cloud project, which is not always the case.
This PR ensures that a vRack is attached before running, and detaches it afterwards.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (improve existing resource(s) or datasource(s))
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

# How Has This Been Tested?

- [ ] Test A: `make testacc TESTARGS="-run TestAccCloudProjectVrackDataSource_basic"`

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or issues
- [ ] I have added acceptance tests that prove my fix is effective or that my feature works
- [x] New and existing acceptance tests pass locally with my changes
- [x] I ran succesfully `go mod vendor` if I added or modify `go.mod` file
