### PR TITLE
fix: cloud_project_failover_ip_attach: attaching to a new instance_id need to recreate the attach link

### DIFF
--- a/ovh/resource_cloud_project_failover_ip_attach.go
+++ b/ovh/resource_cloud_project_failover_ip_attach.go
@@ -2,10 +2,11 @@ package ovh
 
 import (
 	"fmt"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/ovh/terraform-provider-ovh/ovh/helpers"
 	"log"
 	"net/url"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/ovh/terraform-provider-ovh/ovh/helpers"
 )
 
 func resourceCloudProjectFailoverIpAttach() *schema.Resource {
@@ -85,6 +86,7 @@ func resourceCloudProjectFailoverIpAttachSchema() map[string]*schema.Schema {
 			Type:        schema.TypeString,
 			Description: "Instance where ip is routed to",
 			Computed:    true,
+			ForceNew:    true,
 			Optional:    true,
 		},
 		"status": {


### PR DESCRIPTION
# Description

Fix issue with cloud_project_failover_ip_attach when updating `routed_to` on a resource
Fixes #xx (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (improve existing resource(s) or datasource(s))
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
