### PR TITLE
feat: Refactor order to be usable with terraform-plugin-framework also

### DIFF
--- a/ovh/notification_email.go
+++ b/ovh/notification_email.go
@@ -7,9 +7,7 @@ import (
 	"strings"
 )
 
-func notificationEmailSortedIds(meta interface{}) ([]int64, error) {
-	config := meta.(*Config)
-
+func notificationEmailSortedIds(config *Config) ([]int64, error) {
 	// Create Order
 	log.Printf("[DEBUG] Will read notification emails ids")
 	res := []int64{}
@@ -24,10 +22,8 @@ func notificationEmailSortedIds(meta interface{}) ([]int64, error) {
 	return res, nil
 }
 
-func getNewNotificationEmail(matches []string, oldIds []int64, meta interface{}) (*NotificationEmail, error) {
-	config := meta.(*Config)
-
-	curIds, err := notificationEmailSortedIds(meta)
+func getNewNotificationEmail(matches []string, oldIds []int64, config *Config) (*NotificationEmail, error) {
+	curIds, err := notificationEmailSortedIds(config)
 	if err != nil {
 		return nil, err
 	}

--- a/ovh/resource_cloud_project.go
+++ b/ovh/resource_cloud_project.go
@@ -71,7 +71,7 @@ func resourceCloudProjectSchema() map[string]*schema.Schema {
 }
 
 func resourceCloudProjectCreate(d *schema.ResourceData, meta interface{}) error {
-	if err := orderCreate(d, meta, "cloud"); err != nil {
+	if err := orderCreateFromResource(d, meta, "cloud"); err != nil {
 		return fmt.Errorf("Could not order cloud project: %q", err)
 	}
 
@@ -105,7 +105,7 @@ func resourceCloudProjectGetServiceName(config *Config, order *MeOrder, details 
 }
 
 func resourceCloudProjectUpdate(d *schema.ResourceData, meta interface{}) error {
-	order, details, err := orderRead(d, meta)
+	order, details, err := orderReadInResource(d, meta)
 	if err != nil {
 		return fmt.Errorf("Could not read cloud project order: %q", err)
 	}
@@ -127,7 +127,7 @@ func resourceCloudProjectUpdate(d *schema.ResourceData, meta interface{}) error 
 }
 
 func resourceCloudProjectRead(d *schema.ResourceData, meta interface{}) error {
-	order, details, err := orderRead(d, meta)
+	order, details, err := orderReadInResource(d, meta)
 	if err != nil {
 		return fmt.Errorf("Could not read cloudProject order: %q", err)
 	}
@@ -154,7 +154,7 @@ func resourceCloudProjectRead(d *schema.ResourceData, meta interface{}) error {
 }
 
 func resourceCloudProjectDelete(d *schema.ResourceData, meta interface{}) error {
-	order, details, err := orderRead(d, meta)
+	order, details, err := orderReadInResource(d, meta)
 	if err != nil {
 		return fmt.Errorf("Could not read cloudProject order: %q", err)
 	}
@@ -194,7 +194,7 @@ func resourceCloudProjectDelete(d *schema.ResourceData, meta interface{}) error 
 		return nil
 	}
 
-	if err := orderDelete(d, meta, terminate, confirmTerminate); err != nil {
+	if err := orderDeleteFromResource(d, meta, terminate, confirmTerminate); err != nil {
 		return err
 	}
 

--- a/ovh/resource_cloud_project_test.go
+++ b/ovh/resource_cloud_project_test.go
@@ -108,7 +108,7 @@ func testSweepCloudProject(region string) error {
 		}
 
 		err = resource.Retry(5*time.Minute, func() *resource.RetryError {
-			if err := orderDelete(nil, config, terminate, confirmTerminate); err != nil {
+			if err := orderDeleteFromResource(nil, config, terminate, confirmTerminate); err != nil {
 				return resource.RetryableError(err)
 			}
 

--- a/ovh/resource_domain_zone.go
+++ b/ovh/resource_domain_zone.go
@@ -70,7 +70,7 @@ func resourceDomainZoneSchema() map[string]*schema.Schema {
 }
 
 func resourceDomainZoneCreate(d *schema.ResourceData, meta interface{}) error {
-	if err := orderCreate(d, meta, "dns"); err != nil {
+	if err := orderCreateFromResource(d, meta, "dns"); err != nil {
 		return fmt.Errorf("Could not order domain zone: %q", err)
 	}
 
@@ -78,7 +78,7 @@ func resourceDomainZoneCreate(d *schema.ResourceData, meta interface{}) error {
 }
 
 func resourceDomainZoneRead(d *schema.ResourceData, meta interface{}) error {
-	_, details, err := orderRead(d, meta)
+	_, details, err := orderReadInResource(d, meta)
 	if err != nil {
 		return fmt.Errorf("Could not read domainZone order: %q", err)
 	}
@@ -102,7 +102,7 @@ func resourceDomainZoneRead(d *schema.ResourceData, meta interface{}) error {
 }
 
 func resourceDomainZoneDelete(d *schema.ResourceData, meta interface{}) error {
-	_, details, err := orderRead(d, meta)
+	_, details, err := orderReadInResource(d, meta)
 	if err != nil {
 		return fmt.Errorf("Could not read domainZone order: %q", err)
 	}
@@ -139,7 +139,7 @@ func resourceDomainZoneDelete(d *schema.ResourceData, meta interface{}) error {
 		return nil
 	}
 
-	if err := orderDelete(d, meta, terminate, confirmTerminate); err != nil {
+	if err := orderDeleteFromResource(d, meta, terminate, confirmTerminate); err != nil {
 		return err
 	}
 

--- a/ovh/resource_domain_zone_test.go
+++ b/ovh/resource_domain_zone_test.go
@@ -105,7 +105,7 @@ func testSweepDomainZone(region string) error {
 		}
 
 		err = resource.Retry(5*time.Minute, func() *resource.RetryError {
-			if err := orderDelete(nil, config, terminate, confirmTerminate); err != nil {
+			if err := orderDeleteFromResource(nil, config, terminate, confirmTerminate); err != nil {
 				return resource.RetryableError(err)
 			}
 

--- a/ovh/resource_hosting_privatedatabase.go
+++ b/ovh/resource_hosting_privatedatabase.go
@@ -141,7 +141,7 @@ func resourceHostingPrivateDatabaseSchema() map[string]*schema.Schema {
 }
 
 func resourceHostingPrivateDatabaseCreate(d *schema.ResourceData, meta interface{}) error {
-	if err := orderCreate(d, meta, "privateSQL"); err != nil {
+	if err := orderCreateFromResource(d, meta, "privateSQL"); err != nil {
 		return fmt.Errorf("could not order privateDatabase: %q", err)
 	}
 
@@ -149,7 +149,7 @@ func resourceHostingPrivateDatabaseCreate(d *schema.ResourceData, meta interface
 }
 
 func resourceHostingPrivateDatabaseUpdate(d *schema.ResourceData, meta interface{}) error {
-	_, details, err := orderRead(d, meta)
+	_, details, err := orderReadInResource(d, meta)
 	if err != nil {
 		return fmt.Errorf("could not read privateDatabase order: %q", err)
 	}
@@ -168,7 +168,7 @@ func resourceHostingPrivateDatabaseUpdate(d *schema.ResourceData, meta interface
 }
 
 func resourceHostingPrivateDatabaseRead(d *schema.ResourceData, meta interface{}) error {
-	_, details, err := orderRead(d, meta)
+	_, details, err := orderReadInResource(d, meta)
 	if err != nil {
 		return fmt.Errorf("could not read privatedatabase order: %q", err)
 	}
@@ -199,7 +199,7 @@ func resourceHostingPrivateDatabaseRead(d *schema.ResourceData, meta interface{}
 }
 
 func resourceHostingPrivateDatabaseDelete(d *schema.ResourceData, meta interface{}) error {
-	_, details, err := orderRead(d, meta)
+	_, details, err := orderReadInResource(d, meta)
 	if err != nil {
 		return fmt.Errorf("could not read privateDatabase order: %q", err)
 	}
@@ -235,7 +235,7 @@ func resourceHostingPrivateDatabaseDelete(d *schema.ResourceData, meta interface
 		return nil
 	}
 
-	if err := orderDelete(d, meta, terminate, confirmTerminate); err != nil {
+	if err := orderDeleteFromResource(d, meta, terminate, confirmTerminate); err != nil {
 		return err
 	}
 

--- a/ovh/resource_hosting_privatedatabase_test.go
+++ b/ovh/resource_hosting_privatedatabase_test.go
@@ -113,7 +113,7 @@ func testSweepHostingPrivateDatabase(region string) error {
 		}
 
 		err = resource.Retry(5*time.Minute, func() *resource.RetryError {
-			if err := orderDelete(nil, config, terminate, confirmTerminate); err != nil {
+			if err := orderDeleteFromResource(nil, config, terminate, confirmTerminate); err != nil {
 				return resource.RetryableError(err)
 			}
 

--- a/ovh/resource_ip_service.go
+++ b/ovh/resource_ip_service.go
@@ -90,7 +90,7 @@ func resourceIpServiceSchema() map[string]*schema.Schema {
 }
 
 func resourceIpServiceCreate(d *schema.ResourceData, meta interface{}) error {
-	if err := orderCreate(d, meta, "ip"); err != nil {
+	if err := orderCreateFromResource(d, meta, "ip"); err != nil {
 		return fmt.Errorf("Could not order ip: %q", err)
 	}
 
@@ -98,7 +98,7 @@ func resourceIpServiceCreate(d *schema.ResourceData, meta interface{}) error {
 }
 
 func resourceIpServiceUpdate(d *schema.ResourceData, meta interface{}) error {
-	_, details, err := orderRead(d, meta)
+	_, details, err := orderReadInResource(d, meta)
 	if err != nil {
 		return fmt.Errorf("Could not read ip order: %q", err)
 	}
@@ -120,7 +120,7 @@ func resourceIpServiceUpdate(d *schema.ResourceData, meta interface{}) error {
 }
 
 func resourceIpServiceRead(d *schema.ResourceData, meta interface{}) error {
-	_, details, err := orderRead(d, meta)
+	_, details, err := orderReadInResource(d, meta)
 	if err != nil {
 		return fmt.Errorf("Could not read ip order: %q", err)
 	}
@@ -171,7 +171,7 @@ func resourceIpServiceRead(d *schema.ResourceData, meta interface{}) error {
 }
 
 func resourceIpServiceDelete(d *schema.ResourceData, meta interface{}) error {
-	_, details, err := orderRead(d, meta)
+	_, details, err := orderReadInResource(d, meta)
 	if err != nil {
 		return fmt.Errorf("Could not read ip order: %q", err)
 	}
@@ -207,7 +207,7 @@ func resourceIpServiceDelete(d *schema.ResourceData, meta interface{}) error {
 		return nil
 	}
 
-	if err := orderDelete(d, meta, terminate, confirmTerminate); err != nil {
+	if err := orderDeleteFromResource(d, meta, terminate, confirmTerminate); err != nil {
 		return err
 	}
 

--- a/ovh/resource_ip_service_test.go
+++ b/ovh/resource_ip_service_test.go
@@ -113,7 +113,7 @@ func testSweepIp(region string) error {
 		}
 
 		err = resource.Retry(5*time.Minute, func() *resource.RetryError {
-			if err := orderDelete(nil, config, terminate, confirmTerminate); err != nil {
+			if err := orderDeleteFromResource(nil, config, terminate, confirmTerminate); err != nil {
 				return resource.RetryableError(err)
 			}
 

--- a/ovh/resource_iploadbalancing.go
+++ b/ovh/resource_iploadbalancing.go
@@ -148,7 +148,7 @@ func resourceIpLoadbalancingSchema() map[string]*schema.Schema {
 }
 
 func resourceIpLoadbalancingCreate(d *schema.ResourceData, meta interface{}) error {
-	if err := orderCreate(d, meta, "ipLoadbalancing"); err != nil {
+	if err := orderCreateFromResource(d, meta, "ipLoadbalancing"); err != nil {
 		return fmt.Errorf("Could not order ipLoadbalancing: %q", err)
 	}
 
@@ -156,7 +156,7 @@ func resourceIpLoadbalancingCreate(d *schema.ResourceData, meta interface{}) err
 }
 
 func resourceIpLoadbalancingUpdate(d *schema.ResourceData, meta interface{}) error {
-	_, details, err := orderRead(d, meta)
+	_, details, err := orderReadInResource(d, meta)
 	if err != nil {
 		return fmt.Errorf("Could not read ipLoadbalancing order: %q", err)
 	}
@@ -181,7 +181,7 @@ func resourceIpLoadbalancingUpdate(d *schema.ResourceData, meta interface{}) err
 }
 
 func resourceIpLoadbalancingRead(d *schema.ResourceData, meta interface{}) error {
-	_, details, err := orderRead(d, meta)
+	_, details, err := orderReadInResource(d, meta)
 	if err != nil {
 		return fmt.Errorf("Could not read ipLoadbalancing order: %q", err)
 	}
@@ -243,7 +243,7 @@ func resourceIpLoadbalancingDelete(d *schema.ResourceData, meta interface{}) err
 		return nil
 	}
 
-	if err := orderDelete(d, meta, terminate, confirmTerminate); err != nil {
+	if err := orderDeleteFromResource(d, meta, terminate, confirmTerminate); err != nil {
 		return err
 	}
 

--- a/ovh/resource_iploadbalancing_test.go
+++ b/ovh/resource_iploadbalancing_test.go
@@ -142,7 +142,7 @@ func testSweepIpLoadbalancing(region string) error {
 		}
 
 		err = resource.Retry(5*time.Minute, func() *resource.RetryError {
-			if err := orderDelete(nil, config, terminate, confirmTerminate); err != nil {
+			if err := orderDeleteFromResource(nil, config, terminate, confirmTerminate); err != nil {
 				return resource.RetryableError(err)
 			}
 

--- a/ovh/resource_vrack.go
+++ b/ovh/resource_vrack.go
@@ -61,7 +61,7 @@ func resourceVrackSchema() map[string]*schema.Schema {
 }
 
 func resourceVrackCreate(d *schema.ResourceData, meta interface{}) error {
-	if err := orderCreate(d, meta, "vrack"); err != nil {
+	if err := orderCreateFromResource(d, meta, "vrack"); err != nil {
 		return fmt.Errorf("Could not order vrack: %q", err)
 	}
 
@@ -69,7 +69,7 @@ func resourceVrackCreate(d *schema.ResourceData, meta interface{}) error {
 }
 
 func resourceVrackUpdate(d *schema.ResourceData, meta interface{}) error {
-	_, details, err := orderRead(d, meta)
+	_, details, err := orderReadInResource(d, meta)
 	if err != nil {
 		return fmt.Errorf("Could not read vrack order: %q", err)
 	}
@@ -88,7 +88,7 @@ func resourceVrackUpdate(d *schema.ResourceData, meta interface{}) error {
 }
 
 func resourceVrackRead(d *schema.ResourceData, meta interface{}) error {
-	_, details, err := orderRead(d, meta)
+	_, details, err := orderReadInResource(d, meta)
 	if err != nil {
 		return fmt.Errorf("Could not read vrack order: %q", err)
 	}

--- a/ovh/types_order_cart.go
+++ b/ovh/types_order_cart.go
@@ -9,6 +9,30 @@ import (
 	"github.com/ovh/terraform-provider-ovh/ovh/helpers"
 )
 
+type OrderCreateType struct {
+	OrderID string
+	*OrderCartCreateOpts
+	Plans       []*OrderCartPlanCreateOpts
+	PlanOptions []*OrderCartPlanOptionsCreateOpts
+}
+
+func (o *OrderCreateType) FromResource(d *schema.ResourceData) *OrderCreateType {
+	o.OrderCartCreateOpts = (&OrderCartCreateOpts{}).FromResource(d)
+
+	nbPlans := d.Get("plan.#").(int)
+	for i := 0; i < nbPlans; i++ {
+		o.Plans = append(o.Plans, (&OrderCartPlanCreateOpts{}).FromResourceWithPath(d, fmt.Sprintf("plan.%d", i)))
+	}
+
+	nbPlanOptions := d.Get("plan_option.#").(int)
+	for i := 0; i < nbPlanOptions; i++ {
+		o.PlanOptions = append(o.PlanOptions,
+			(&OrderCartPlanOptionsCreateOpts{}).FromResourceWithPath(d, fmt.Sprintf("plan_option.%d", i)))
+	}
+
+	return o
+}
+
 type OrderCartCreateOpts struct {
 	OvhSubsidiary string  `json:"ovhSubsidiary"`
 	Description   *string `json:"description,omitempty"`
@@ -24,11 +48,12 @@ func (opts *OrderCartCreateOpts) FromResource(d *schema.ResourceData) *OrderCart
 }
 
 type OrderCartPlanCreateOpts struct {
-	CatalogName *string `json:"catalogName,omitempty"`
-	Duration    string  `json:"duration"`
-	PlanCode    string  `json:"planCode"`
-	PricingMode string  `json:"pricingMode"`
-	Quantity    int     `json:"quantity"`
+	CatalogName   *string                           `json:"catalogName,omitempty"`
+	Duration      string                            `json:"duration"`
+	PlanCode      string                            `json:"planCode"`
+	PricingMode   string                            `json:"pricingMode"`
+	Quantity      int                               `json:"quantity"`
+	Configuration []*OrderCartItemConfigurationOpts `json:"-"`
 }
 
 func (opts *OrderCartPlanCreateOpts) FromResourceWithPath(d *schema.ResourceData, path string) *OrderCartPlanCreateOpts {
@@ -36,6 +61,13 @@ func (opts *OrderCartPlanCreateOpts) FromResourceWithPath(d *schema.ResourceData
 	opts.Duration = d.Get(fmt.Sprintf("%s.duration", path)).(string)
 	opts.PlanCode = d.Get(fmt.Sprintf("%s.plan_code", path)).(string)
 	opts.PricingMode = d.Get(fmt.Sprintf("%s.pricing_mode", path)).(string)
+
+	nbOfConfigurations := d.Get(fmt.Sprintf("%s.configuration.#", path)).(int)
+	for i := 0; i < nbOfConfigurations; i++ {
+		opts.Configuration = append(opts.Configuration,
+			(&OrderCartItemConfigurationOpts{}).FromResourceWithPath(d, fmt.Sprintf("%s.configuration.%d", path, i)))
+	}
+
 	return opts
 }
 
@@ -51,12 +83,13 @@ func (opts *OrderCartPlanCreateOpts) String() string {
 }
 
 type OrderCartPlanOptionsCreateOpts struct {
-	CatalogName *string `json:"catalogName,omitempty"`
-	Duration    string  `json:"duration"`
-	PlanCode    string  `json:"planCode"`
-	PricingMode string  `json:"pricingMode"`
-	Quantity    int     `json:"quantity"`
-	ItemId      int64   `json:"itemId"`
+	CatalogName   *string                           `json:"catalogName,omitempty"`
+	Duration      string                            `json:"duration"`
+	PlanCode      string                            `json:"planCode"`
+	PricingMode   string                            `json:"pricingMode"`
+	Quantity      int                               `json:"quantity"`
+	ItemId        int64                             `json:"itemId"`
+	Configuration []*OrderCartItemConfigurationOpts `json:"-"`
 }
 
 func (opts *OrderCartPlanOptionsCreateOpts) FromResourceWithPath(d *schema.ResourceData, path string) *OrderCartPlanOptionsCreateOpts {
@@ -64,6 +97,13 @@ func (opts *OrderCartPlanOptionsCreateOpts) FromResourceWithPath(d *schema.Resou
 	opts.Duration = d.Get(fmt.Sprintf("%s.duration", path)).(string)
 	opts.PlanCode = d.Get(fmt.Sprintf("%s.plan_code", path)).(string)
 	opts.PricingMode = d.Get(fmt.Sprintf("%s.pricing_mode", path)).(string)
+
+	nbConfigs := d.Get(fmt.Sprintf("%s.configuration.#", path)).(int)
+	for i := 0; i < nbConfigs; i++ {
+		opts.Configuration = append(opts.Configuration,
+			(&OrderCartItemConfigurationOpts{}).FromResourceWithPath(d, fmt.Sprintf("%s.configuration.%d", path, i)))
+	}
+
 	return opts
 }
 


### PR DESCRIPTION
# Description

This PR is a small refactoring of the code allowing to order new products via the provider. It makes it usable from `terraform-plugin-sdk/v2` and `terraform-plugin-framework` (will be useful for auto-generated resources that need to make orders)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (improve existing resource(s) or datasource(s))
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

# How Has This Been Tested?

- Local orders

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or issues
- [ ] I have added acceptance tests that prove my fix is effective or that my feature works
- [x] New and existing acceptance tests pass locally with my changes
- [x] I ran succesfully `go mod vendor` if I added or modify `go.mod` file
