### PR TITLE
increase create default timeout of resource_cloud_project_databe to 4…

### DIFF
--- a/ovh/resource_cloud_project_database.go
+++ b/ovh/resource_cloud_project_database.go
@@ -25,7 +25,7 @@ func resourceCloudProjectDatabase() *schema.Resource {
 		},
 
 		Timeouts: &schema.ResourceTimeout{
-			Create: schema.DefaultTimeout(20 * time.Minute),
+			Create: schema.DefaultTimeout(40 * time.Minute),
 			Update: schema.DefaultTimeout(40 * time.Minute),
 			Delete: schema.DefaultTimeout(20 * time.Minute),
 		},


### PR DESCRIPTION
# Description

Set up Default timeout to create resource_cloud_project_database to 40 minutes because some database can take more to 20 minutes (current timeout) to spawn some time. Customer can owerwrite this default timeout but with 40 minute customer will not need to most of the time.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Improvement (improve existing resource(s) or datasource(s))

