### PR TITLE
remove some unused dedicated server options

### DIFF
--- a/ovh/data_me_installation_template.go
+++ b/ovh/data_me_installation_template.go
@@ -29,12 +29,6 @@ func dataSourceMeInstallationTemplate() *schema.Resource {
 				Computed: true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
-						"change_log": {
-							Type:        schema.TypeString,
-							Computed:    true,
-							Deprecated:  "field is not used anymore",
-							Description: "Template change log details",
-						},
 						"custom_hostname": {
 							Type:        schema.TypeString,
 							Computed:    true,

--- a/ovh/data_me_installation_template.go
+++ b/ovh/data_me_installation_template.go
@@ -234,11 +234,6 @@ func dataSourceMeInstallationTemplate() *schema.Resource {
 				Computed:    true,
 				Description: "This distribution supports installation using the distribution's native kernel instead of the recommended OVH kernel",
 			},
-			"supports_rtm": {
-				Type:        schema.TypeBool,
-				Computed:    true,
-				Description: "This distribution supports RTM software",
-			},
 			"supports_sql_server": {
 				Type:        schema.TypeBool,
 				Computed:    true,

--- a/ovh/data_me_installation_template.go
+++ b/ovh/data_me_installation_template.go
@@ -60,11 +60,6 @@ func dataSourceMeInstallationTemplate() *schema.Resource {
 							Computed:    true,
 							Description: "Name of the ssh key that should be installed. Password login will be disabled",
 						},
-						"use_distribution_kernel": {
-							Type:        schema.TypeBool,
-							Computed:    true,
-							Description: "Use the distribution's native kernel instead of the recommended OVH Kernel",
-						},
 					},
 				},
 			},
@@ -228,11 +223,6 @@ func dataSourceMeInstallationTemplate() *schema.Resource {
 				Type:        schema.TypeBool,
 				Computed:    true,
 				Description: "This distribution supports Logical Volumes (Linux LVM)",
-			},
-			"supports_distribution_kernel": {
-				Type:        schema.TypeBool,
-				Computed:    true,
-				Description: "This distribution supports installation using the distribution's native kernel instead of the recommended OVH kernel",
 			},
 			"supports_sql_server": {
 				Type:        schema.TypeBool,

--- a/ovh/import_me_installation_template_test.go
+++ b/ovh/import_me_installation_template_test.go
@@ -25,7 +25,6 @@ func TestAccMeInstallationTemplate_importBasic(t *testing.T) {
 				ImportStateVerify: true,
 				ImportStateVerifyIgnore: []string{
 					"remove_default_partition_schemes",
-					"customization.0.change_log",
 					"customization.0.rating",
 				},
 			},

--- a/ovh/resource_dedicated_server_install_task.go
+++ b/ovh/resource_dedicated_server_install_task.go
@@ -75,12 +75,6 @@ func resourceDedicatedServerInstallTask() *schema.Resource {
 							ForceNew:    true,
 							Description: "",
 						},
-						"install_rtm": {
-							Type:        schema.TypeBool,
-							Optional:    true,
-							ForceNew:    true,
-							Description: "",
-						},
 						"install_sql_server": {
 							Type:        schema.TypeBool,
 							Optional:    true,

--- a/ovh/resource_dedicated_server_install_task.go
+++ b/ovh/resource_dedicated_server_install_task.go
@@ -129,12 +129,6 @@ func resourceDedicatedServerInstallTask() *schema.Resource {
 							ForceNew:    true,
 							Description: "",
 						},
-						"use_distrib_kernel": {
-							Type:        schema.TypeBool,
-							Optional:    true,
-							ForceNew:    true,
-							Description: "Use the distribution's native kernel instead of the recommended OVH Kernel",
-						},
 					},
 				},
 			},

--- a/ovh/resource_dedicated_server_install_task.go
+++ b/ovh/resource_dedicated_server_install_task.go
@@ -105,12 +105,6 @@ func resourceDedicatedServerInstallTask() *schema.Resource {
 							ForceNew:    true,
 							Description: "indicate the string returned by your postinstall customisation script on successful execution. Advice: your script should return a unique validation string in case of succes. A good example is 'loh1Xee7eo OK OK OK UGh8Ang1Gu'",
 						},
-						"reset_hw_raid": {
-							Type:        schema.TypeBool,
-							Optional:    true,
-							ForceNew:    true,
-							Description: "",
-						},
 						"soft_raid_devices": {
 							Type:        schema.TypeInt,
 							Optional:    true,

--- a/ovh/resource_dedicated_server_install_task.go
+++ b/ovh/resource_dedicated_server_install_task.go
@@ -57,12 +57,6 @@ func resourceDedicatedServerInstallTask() *schema.Resource {
 				MaxItems: 1,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
-						"change_log": {
-							Type:        schema.TypeString,
-							Optional:    true,
-							Deprecated:  "field is not used anymore",
-							Description: "Template change log details",
-						},
 						"custom_hostname": {
 							Type:        schema.TypeString,
 							Optional:    true,

--- a/ovh/resource_me_installation_template.go
+++ b/ovh/resource_me_installation_template.go
@@ -171,11 +171,6 @@ func resourceMeInstallationTemplate() *schema.Resource {
 				Computed:    true,
 				Description: "This distribution supports installation using the distribution's native kernel instead of the recommended OVH kernel",
 			},
-			"supports_rtm": {
-				Type:        schema.TypeBool,
-				Computed:    true,
-				Description: "This distribution supports RTM software",
-			},
 			"supports_sql_server": {
 				Type:        schema.TypeBool,
 				Computed:    true,

--- a/ovh/resource_me_installation_template.go
+++ b/ovh/resource_me_installation_template.go
@@ -91,11 +91,6 @@ func resourceMeInstallationTemplate() *schema.Resource {
 							Optional:    true,
 							Description: "Name of the ssh key that should be installed. Password login will be disabled",
 						},
-						"use_distribution_kernel": {
-							Type:        schema.TypeBool,
-							Optional:    true,
-							Description: "Use the distribution's native kernel instead of the recommended OVH Kernel",
-						},
 					},
 				},
 			},
@@ -165,11 +160,6 @@ func resourceMeInstallationTemplate() *schema.Resource {
 				Type:        schema.TypeBool,
 				Computed:    true,
 				Description: "This distribution supports Logical Volumes (Linux LVM)",
-			},
-			"supports_distribution_kernel": {
-				Type:        schema.TypeBool,
-				Computed:    true,
-				Description: "This distribution supports installation using the distribution's native kernel instead of the recommended OVH kernel",
 			},
 			"supports_sql_server": {
 				Type:        schema.TypeBool,

--- a/ovh/resource_me_installation_template.go
+++ b/ovh/resource_me_installation_template.go
@@ -60,12 +60,6 @@ func resourceMeInstallationTemplate() *schema.Resource {
 				MaxItems: 1,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
-						"change_log": {
-							Type:        schema.TypeString,
-							Deprecated:  "field is not used anymore",
-							Optional:    true,
-							Description: "Template change log details",
-						},
 						"custom_hostname": {
 							Type:        schema.TypeString,
 							Optional:    true,

--- a/ovh/types_dedicated_server.go
+++ b/ovh/types_dedicated_server.go
@@ -133,7 +133,6 @@ type DedicatedServerInstallTaskDetails struct {
 	NoRaid                       *bool   `json:"noRaid,omitempty"`
 	PostInstallationScriptLink   *string `json:"postInstallationScriptLink,omitempty"`
 	PostInstallationScriptReturn *string `json:"postInstallationScriptReturn,omitempty"`
-	ResetHwRaid                  *bool   `json:"resetHwRaid,omitempty"`
 	SoftRaidDevices              *int64  `json:"softRaidDevices,omitempty"`
 	SshKeyName                   *string `json:"sshKeyName,omitempty"`
 	UseSpla                      *bool   `json:"useSpla,omitempty"`
@@ -147,7 +146,6 @@ func (opts *DedicatedServerInstallTaskDetails) FromResource(d *schema.ResourceDa
 	opts.NoRaid = helpers.GetNilBoolPointerFromData(d, fmt.Sprintf("%s.no_raid", parent))
 	opts.PostInstallationScriptLink = helpers.GetNilStringPointerFromData(d, fmt.Sprintf("%s.post_installation_script_link", parent))
 	opts.PostInstallationScriptReturn = helpers.GetNilStringPointerFromData(d, fmt.Sprintf("%s.post_installation_script_return", parent))
-	opts.ResetHwRaid = helpers.GetNilBoolPointerFromData(d, fmt.Sprintf("%s.reset_hw_raid", parent))
 	opts.SoftRaidDevices = helpers.GetNilInt64PointerFromData(d, fmt.Sprintf("%s.soft_raid_devices", parent))
 	opts.SshKeyName = helpers.GetNilStringPointerFromData(d, fmt.Sprintf("%s.ssh_key_name", parent))
 	opts.UseSpla = helpers.GetNilBoolPointerFromData(d, fmt.Sprintf("%s.use_spla", parent))

--- a/ovh/types_dedicated_server.go
+++ b/ovh/types_dedicated_server.go
@@ -128,7 +128,6 @@ func (opts *DedicatedServerInstallTaskCreateOpts) FromResource(d *schema.Resourc
 type DedicatedServerInstallTaskDetails struct {
 	CustomHostname               *string `json:"customHostname,omitempty"`
 	DiskGroupId                  *int64  `json:"diskGroupId,omitempty"`
-	InstallRTM                   *bool   `json:"installRTM,omitempty"`
 	InstallSqlServer             *bool   `json:"installSqlServer,omitempty"`
 	Language                     *string `json:"language,omitempty"`
 	NoRaid                       *bool   `json:"noRaid,omitempty"`
@@ -144,7 +143,6 @@ type DedicatedServerInstallTaskDetails struct {
 func (opts *DedicatedServerInstallTaskDetails) FromResource(d *schema.ResourceData, parent string) *DedicatedServerInstallTaskDetails {
 	opts.CustomHostname = helpers.GetNilStringPointerFromData(d, fmt.Sprintf("%s.custom_hostname", parent))
 	opts.DiskGroupId = helpers.GetNilInt64PointerFromData(d, fmt.Sprintf("%s.disk_group_id", parent))
-	opts.InstallRTM = helpers.GetNilBoolPointerFromData(d, fmt.Sprintf("%s.install_rtm", parent))
 	opts.InstallSqlServer = helpers.GetNilBoolPointerFromData(d, fmt.Sprintf("%s.install_sql_server", parent))
 	opts.Language = helpers.GetNilStringPointerFromData(d, fmt.Sprintf("%s.language", parent))
 	opts.NoRaid = helpers.GetNilBoolPointerFromData(d, fmt.Sprintf("%s.no_raid", parent))

--- a/ovh/types_dedicated_server.go
+++ b/ovh/types_dedicated_server.go
@@ -136,7 +136,6 @@ type DedicatedServerInstallTaskDetails struct {
 	ResetHwRaid                  *bool   `json:"resetHwRaid,omitempty"`
 	SoftRaidDevices              *int64  `json:"softRaidDevices,omitempty"`
 	SshKeyName                   *string `json:"sshKeyName,omitempty"`
-	UseDistribKernel             *bool   `json:"useDistribKernel,omitempty"`
 	UseSpla                      *bool   `json:"useSpla,omitempty"`
 }
 
@@ -151,7 +150,6 @@ func (opts *DedicatedServerInstallTaskDetails) FromResource(d *schema.ResourceDa
 	opts.ResetHwRaid = helpers.GetNilBoolPointerFromData(d, fmt.Sprintf("%s.reset_hw_raid", parent))
 	opts.SoftRaidDevices = helpers.GetNilInt64PointerFromData(d, fmt.Sprintf("%s.soft_raid_devices", parent))
 	opts.SshKeyName = helpers.GetNilStringPointerFromData(d, fmt.Sprintf("%s.ssh_key_name", parent))
-	opts.UseDistribKernel = helpers.GetNilBoolPointerFromData(d, fmt.Sprintf("%s.use_distrib_kernel", parent))
 	opts.UseSpla = helpers.GetNilBoolPointerFromData(d, fmt.Sprintf("%s.use_spla", parent))
 
 	return opts

--- a/ovh/types_installation_template.go
+++ b/ovh/types_installation_template.go
@@ -24,7 +24,6 @@ type InstallationTemplate struct {
 	LastModification           *string                            `json:"last_modification"`
 	LvmReady                   *bool                              `json:"lvmReady,omitempty"`
 	SupportsDistributionKernel *bool                              `json:"supportsDistributionKernel,omitempty"`
-	SupportsRTM                bool                               `json:"supportsRTM"`
 	SupportsSqlServer          *bool                              `json:"supportsSqlServer,omitempty"`
 	TemplateName               string                             `json:"templateName"`
 }
@@ -74,8 +73,6 @@ func (v InstallationTemplate) ToMap() map[string]interface{} {
 	if v.SupportsDistributionKernel != nil {
 		obj["supports_distribution_kernel"] = *v.SupportsDistributionKernel
 	}
-
-	obj["supports_rtm"] = v.SupportsRTM
 
 	if v.SupportsSqlServer != nil {
 		obj["supports_sql_server"] = *v.SupportsSqlServer

--- a/ovh/types_installation_template.go
+++ b/ovh/types_installation_template.go
@@ -9,23 +9,22 @@ import (
 )
 
 type InstallationTemplate struct {
-	AvailableLanguages         []string                           `json:"available_languages"`
-	Beta                       *bool                              `json:"beta,omitempty"`
-	BitFormat                  int                                `json:"bitFormat"`
-	Category                   string                             `json:"category"`
-	Customization              *InstallationTemplateCustomization `json:"customization,omitempty"`
-	DefaultLanguage            string                             `json:"defaultLanguage"`
-	Deprecated                 *bool                              `json:"deprecated,omitempty"`
-	Description                string                             `json:"description"`
-	Distribution               string                             `json:"distribution"`
-	Family                     string                             `json:"family"`
-	Filesystems                []string                           `json:"filesystems"`
-	HardRaidConfiguration      *bool                              `json:"hardRaidConfigurtion,omitempty"`
-	LastModification           *string                            `json:"last_modification"`
-	LvmReady                   *bool                              `json:"lvmReady,omitempty"`
-	SupportsDistributionKernel *bool                              `json:"supportsDistributionKernel,omitempty"`
-	SupportsSqlServer          *bool                              `json:"supportsSqlServer,omitempty"`
-	TemplateName               string                             `json:"templateName"`
+	AvailableLanguages    []string                           `json:"available_languages"`
+	Beta                  *bool                              `json:"beta,omitempty"`
+	BitFormat             int                                `json:"bitFormat"`
+	Category              string                             `json:"category"`
+	Customization         *InstallationTemplateCustomization `json:"customization,omitempty"`
+	DefaultLanguage       string                             `json:"defaultLanguage"`
+	Deprecated            *bool                              `json:"deprecated,omitempty"`
+	Description           string                             `json:"description"`
+	Distribution          string                             `json:"distribution"`
+	Family                string                             `json:"family"`
+	Filesystems           []string                           `json:"filesystems"`
+	HardRaidConfiguration *bool                              `json:"hardRaidConfigurtion,omitempty"`
+	LastModification      *string                            `json:"last_modification"`
+	LvmReady              *bool                              `json:"lvmReady,omitempty"`
+	SupportsSqlServer     *bool                              `json:"supportsSqlServer,omitempty"`
+	TemplateName          string                             `json:"templateName"`
 }
 
 func (v InstallationTemplate) ToMap() map[string]interface{} {
@@ -68,10 +67,6 @@ func (v InstallationTemplate) ToMap() map[string]interface{} {
 
 	if v.LvmReady != nil {
 		obj["lvm_ready"] = *v.LvmReady
-	}
-
-	if v.SupportsDistributionKernel != nil {
-		obj["supports_distribution_kernel"] = *v.SupportsDistributionKernel
 	}
 
 	if v.SupportsSqlServer != nil {
@@ -119,7 +114,6 @@ type InstallationTemplateCustomization struct {
 	PostInstallationScriptLink   *string `json:"postInstallationScriptLink,omitempty"`
 	PostInstallationScriptReturn *string `json:"postInstallationScriptReturn,omitempty"`
 	SshKeyName                   *string `json:"sshKeyName,omitempty"`
-	UseDistributionKernel        *bool   `json:"useDistributionKernel,omitempty"`
 }
 
 func (v InstallationTemplateCustomization) ToMap() map[string]interface{} {
@@ -146,11 +140,6 @@ func (v InstallationTemplateCustomization) ToMap() map[string]interface{} {
 		custom_attr_set = true
 	}
 
-	if v.UseDistributionKernel != nil {
-		obj["use_distribution_kernel"] = *v.UseDistributionKernel
-		custom_attr_set = true
-	}
-
 	// dont return an object if nothing is set
 	if custom_attr_set {
 		return obj
@@ -164,8 +153,6 @@ func (opts *InstallationTemplateCustomization) FromResource(d *schema.ResourceDa
 	opts.PostInstallationScriptLink = helpers.GetNilStringPointerFromData(d, fmt.Sprintf("%s.post_installation_script_link", parent))
 	opts.PostInstallationScriptReturn = helpers.GetNilStringPointerFromData(d, fmt.Sprintf("%s.post_installation_script_return", parent))
 	opts.SshKeyName = helpers.GetNilStringPointerFromData(d, fmt.Sprintf("%s.ssh_key_name", parent))
-	opts.UseDistributionKernel = helpers.GetNilBoolPointerFromData(d, fmt.Sprintf("%s.use_distribution_kernel", parent))
-
 	return opts
 }
 

--- a/website/docs/d/me_installation_template.html.markdown
+++ b/website/docs/d/me_installation_template.html.markdown
@@ -27,7 +27,6 @@ The following attributes are exported:
 * `bit_format`: This template bit format (32 or 64).
 * `category`: Category of this template (informative only). (basic, customer, hosting, other, readyToUse, virtualisation).
 * `customization`: 
-  * `change_log`: (DEPRECATED) Template change log details.
   * `custom_hostname`: Set up the server using the provided hostname instead of the default hostname.
   * `post_installation_script_link`: Indicate the URL where your postinstall customisation script is located.
   * `post_installation_script_return`: indicate the string returned by your postinstall customisation script on successful execution. Advice: your script should return a unique validation string in case of succes. A good example is 'loh1Xee7eo OK OK OK UGh8Ang1Gu'.

--- a/website/docs/d/me_installation_template.html.markdown
+++ b/website/docs/d/me_installation_template.html.markdown
@@ -33,7 +33,6 @@ The following attributes are exported:
   * `post_installation_script_return`: indicate the string returned by your postinstall customisation script on successful execution. Advice: your script should return a unique validation string in case of succes. A good example is 'loh1Xee7eo OK OK OK UGh8Ang1Gu'.
   * `rating`: (DEPRECATED) Rating.
   * `ssh_key_name`: Name of the ssh key that should be installed. Password login will be disabled.
-  * `use_distribution_kernel`: Use the distribution's native kernel instead of the recommended OVHcloud Kernel.
 * `default_language`: The default language of this template.
 * `deprecated`: is this distribution deprecated.
 * `description`: information about this template.
@@ -58,5 +57,4 @@ The following attributes are exported:
      * `order`: step or order. specifies the creation order of the partition on the disk
      * `type`: partition type.
      * `volume_name`: The volume name needed for proxmox distribution
-* `supports_distribution_kernel`: This distribution supports installation using the distribution's native kernel instead of the recommended OVHcloud kernel.
 * `supports_sql_server`: This distribution supports the microsoft SQL server.

--- a/website/docs/d/me_installation_template.html.markdown
+++ b/website/docs/d/me_installation_template.html.markdown
@@ -59,5 +59,4 @@ The following attributes are exported:
      * `type`: partition type.
      * `volume_name`: The volume name needed for proxmox distribution
 * `supports_distribution_kernel`: This distribution supports installation using the distribution's native kernel instead of the recommended OVHcloud kernel.
-* `supports_rtm`: This distribution supports RTM software.
 * `supports_sql_server`: This distribution supports the microsoft SQL server.

--- a/website/docs/r/dedicated_server_install_task.html.markdown
+++ b/website/docs/r/dedicated_server_install_task.html.markdown
@@ -65,7 +65,6 @@ The `details` block supports:
 * `no_raid` - set to true to disable RAID.
 * `post_installation_script_link` - Indicate the URL where your postinstall customisation script is located.
 * `post_installation_script_return` - Indicate the string returned by your postinstall customisation script on successful execution. Advice: your script should return a unique validation string in case of succes. A good example is 'loh1Xee7eo OK OK OK UGh8Ang1Gu'.
-* `reset_hw_raid` - set to true to make a hardware raid reset.
 * `soft_raid_devices` - soft raid devices.
 * `ssh_key_name` - Name of the ssh key that should be installed. Password login will be disabled.
 * `use_spla` - set to true to use SPLA.

--- a/website/docs/r/dedicated_server_install_task.html.markdown
+++ b/website/docs/r/dedicated_server_install_task.html.markdown
@@ -60,7 +60,6 @@ The `details` block supports:
 * `change_log` - Template change log details.
 * `custom_hostname` - Set up the server using the provided hostname instead of the default hostname.
 * `disk_group_id` - Disk group id.
-* `install_rtm` - set to true to install RTM.
 * `install_sql_server` - set to true to install sql server (Windows template only).
 * `language` - language.
 * `no_raid` - set to true to disable RAID.

--- a/website/docs/r/dedicated_server_install_task.html.markdown
+++ b/website/docs/r/dedicated_server_install_task.html.markdown
@@ -69,7 +69,6 @@ The `details` block supports:
 * `soft_raid_devices` - soft raid devices.
 * `ssh_key_name` - Name of the ssh key that should be installed. Password login will be disabled.
 * `use_spla` - set to true to use SPLA.
-* `use_distrib_kernel` - Use the distribution's native kernel instead of the recommended OVHcloud Kernel.
 
 ## Attributes Reference
 

--- a/website/docs/r/dedicated_server_install_task.html.markdown
+++ b/website/docs/r/dedicated_server_install_task.html.markdown
@@ -57,7 +57,6 @@ The following arguments are supported:
 
 The `details` block supports:
 
-* `change_log` - Template change log details.
 * `custom_hostname` - Set up the server using the provided hostname instead of the default hostname.
 * `disk_group_id` - Disk group id.
 * `install_sql_server` - set to true to install sql server (Windows template only).

--- a/website/docs/r/me_installation_template.html.markdown
+++ b/website/docs/r/me_installation_template.html.markdown
@@ -41,7 +41,6 @@ resource "ovh_me_installation_template" "mytemplate" {
 * `last_modification`: Date of last modification of the base image.
 * `remove_default_partition_schemes`: (Required) Remove default partition schemes at creation.
 * `supports_distribution_kernel`: This distribution supports installation using the distribution's native kernel instead of the recommended OVHcloud kernel.
-* `supports_rtm`: This distribution supports RTM software.
 * `supports_sql_server`: This distribution supports the microsoft SQL server.
 * `template_name`: (Required)  This template name.
 

--- a/website/docs/r/me_installation_template.html.markdown
+++ b/website/docs/r/me_installation_template.html.markdown
@@ -30,7 +30,6 @@ resource "ovh_me_installation_template" "mytemplate" {
   * `post_installation_script_return`: indicate the string returned by your postinstall customisation script on successful execution. Advice: your script should return a unique validation string in case of succes. A good example is 'loh1Xee7eo OK OK OK UGh8Ang1Gu'.
   * `rating`: (DEPRECATED) Rating.
   * `ssh_key_name`: Name of the ssh key that should be installed. Password login will be disabled.
-  * `use_distribution_kernel`: Use the distribution's native kernel instead of the recommended OV
 * `default_language`: (Required)  The default language of this template.
 * `deprecated`: is this distribution deprecated.
 * `description`: information about this template.
@@ -40,7 +39,6 @@ resource "ovh_me_installation_template" "mytemplate" {
 * `hard_raid_configuration`: This distribution supports hardware raid configuration through the OVHcloud API.
 * `last_modification`: Date of last modification of the base image.
 * `remove_default_partition_schemes`: (Required) Remove default partition schemes at creation.
-* `supports_distribution_kernel`: This distribution supports installation using the distribution's native kernel instead of the recommended OVHcloud kernel.
 * `supports_sql_server`: This distribution supports the microsoft SQL server.
 * `template_name`: (Required)  This template name.
 

--- a/website/docs/r/me_installation_template.html.markdown
+++ b/website/docs/r/me_installation_template.html.markdown
@@ -24,7 +24,6 @@ resource "ovh_me_installation_template" "mytemplate" {
 * `bit_format`: This template bit format (32 or 64).
 * `category`: Category of this template (informative only). (basic, customer, hosting, other, readyToUse, virtualisation).
 * `customization`:
-  * `change_log`: (DEPRECATED) Template change log details. 
   * `custom_hostname`: Set up the server using the provided hostname instead of the default hostname.
   * `post_installation_script_link`: Indicate the URL where your postinstall customisation script is located.
   * `post_installation_script_return`: indicate the string returned by your postinstall customisation script on successful execution. Advice: your script should return a unique validation string in case of succes. A good example is 'loh1Xee7eo OK OK OK UGh8Ang1Gu'.


### PR DESCRIPTION
# Description

update of the dedicated server section (remove deprecated option mainly)
-remove install/support RTM option
-remove support/use distribution_kernel option
-remove reset_hwraid option
-remove change_log option

## Type of change

Please delete options that are not relevant.

- [ ] Improvement (improve existing resource(s) or datasource(s))
- [ ] Documentation update

# How Has This Been Tested?

- [ ] Test A: `make testacc TESTARGS="-run TestAccMeInstallationTemplateResource_customization"`
- [ ] Test B: `make testacc TESTARGS="-run TestAccDedicatedServerInstall_basic"`

**Test Configuration**:
* Terraform version: `terraform version`: Terraform 1.6.6
* Existing HCL configuration you used: 
```hcl
resource "" "" {
 xx = "yy"
 zz = "aa"
}
```

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings or issues
- [ ] I have added acceptance tests that prove my fix is effective or that my feature works
- [ ] New and existing acceptance tests pass locally with my changes
- [ ] I ran succesfully `go mod vendor` if I added or modify `go.mod` file
