### PR TITLE
Ip restriction in database service + Deprecate old resource 

### DIFF
--- a/ovh/data_cloud_project_database.go
+++ b/ovh/data_cloud_project_database.go
@@ -106,6 +106,25 @@ func dataSourceCloudProjectDatabase() *schema.Resource {
 				Description: "The node flavor used for this cluster",
 				Computed:    true,
 			},
+			"ip_restrictions": {
+				Type:        schema.TypeList,
+				Description: "IP Blocks authorized to access to the cluster",
+				Computed:    true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"description": {
+							Type:        schema.TypeString,
+							Description: "Description of the IP restriction",
+							Computed:    true,
+						},
+						"ip": {
+							Type:        schema.TypeString,
+							Description: "Authorized IP",
+							Computed:    true,
+						},
+					},
+				},
+			},
 			"kafka_rest_api": {
 				Type:        schema.TypeBool,
 				Description: "Defines whether the REST API is enabled on a Kafka cluster",

--- a/ovh/data_cloud_project_database.go
+++ b/ovh/data_cloud_project_database.go
@@ -107,7 +107,7 @@ func dataSourceCloudProjectDatabase() *schema.Resource {
 				Computed:    true,
 			},
 			"ip_restrictions": {
-				Type:        schema.TypeList,
+				Type:        schema.TypeSet,
 				Description: "IP Blocks authorized to access to the cluster",
 				Computed:    true,
 				Elem: &schema.Resource{
@@ -120,6 +120,11 @@ func dataSourceCloudProjectDatabase() *schema.Resource {
 						"ip": {
 							Type:        schema.TypeString,
 							Description: "Authorized IP",
+							Computed:    true,
+						},
+						"status": {
+							Type:        schema.TypeString,
+							Description: "Current status of the IP restriction",
 							Computed:    true,
 						},
 					},

--- a/ovh/data_cloud_project_database_ip_restrictions.go
+++ b/ovh/data_cloud_project_database_ip_restrictions.go
@@ -58,6 +58,8 @@ func (d *cloudProjectDatabaseIPRestrictionsDataSource) Configure(_ context.Conte
 
 func (d *cloudProjectDatabaseIPRestrictionsDataSource) Schema(_ context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {
 	resp.Schema = schema.Schema{
+		DeprecationMessage: "use ip_restriction field in cloud_project_database datasource",
+
 		Attributes: map[string]schema.Attribute{
 			"service_name": schema.StringAttribute{
 				Required:    os.Getenv("OVH_CLOUD_PROJECT_SERVICE") == "",

--- a/ovh/data_cloud_project_database_test.go
+++ b/ovh/data_cloud_project_database_test.go
@@ -19,6 +19,10 @@ resource "ovh_cloud_project_database" "db" {
 	nodes {
 		region     = "%s"
 	}
+	ip_restrictions {
+		description = "%s"
+		ip = "%s"
+	}
 	flavor = "%s"
 }
 
@@ -35,6 +39,7 @@ func TestAccCloudProjectDatabaseDataSource_basic(t *testing.T) {
 	version := os.Getenv("OVH_CLOUD_PROJECT_DATABASE_VERSION_TEST")
 	region := os.Getenv("OVH_CLOUD_PROJECT_DATABASE_REGION_TEST")
 	flavor := os.Getenv("OVH_CLOUD_PROJECT_DATABASE_FLAVOR_TEST")
+	ip := os.Getenv("OVH_CLOUD_PROJECT_DATABASE_IP_RESTRICTION_IP_TEST")
 	description := acctest.RandomWithPrefix(test_prefix)
 
 	config := fmt.Sprintf(
@@ -44,6 +49,8 @@ func TestAccCloudProjectDatabaseDataSource_basic(t *testing.T) {
 		engine,
 		version,
 		region,
+		description,
+		ip,
 		flavor,
 	)
 
@@ -82,6 +89,12 @@ func TestAccCloudProjectDatabaseDataSource_basic(t *testing.T) {
 						"data.ovh_cloud_project_database.db", "nodes.#"),
 					resource.TestCheckResourceAttr(
 						"data.ovh_cloud_project_database.db", "nodes.0.region", region),
+					resource.TestCheckResourceAttrSet(
+						"data.ovh_cloud_project_database.db", "ip_restrictions.#"),
+					resource.TestCheckResourceAttr(
+						"data.ovh_cloud_project_database.db", "ip_restrictions.0.description", description),
+					resource.TestCheckResourceAttr(
+						"data.ovh_cloud_project_database.db", "ip_restrictions.0.ip", ip),
 					resource.TestCheckResourceAttr(
 						"data.ovh_cloud_project_database.db", "plan", "essential"),
 					resource.TestCheckResourceAttrSet(

--- a/ovh/resource_cloud_project_database.go
+++ b/ovh/resource_cloud_project_database.go
@@ -54,7 +54,7 @@ func resourceCloudProjectDatabase() *schema.Resource {
 				Required:    true,
 			},
 			"ip_restrictions": {
-				Type:        schema.TypeList,
+				Type:        schema.TypeSet,
 				Description: "IP Blocks authorized to access to the cluster",
 				Optional:    true,
 				Elem: &schema.Resource{
@@ -68,6 +68,11 @@ func resourceCloudProjectDatabase() *schema.Resource {
 							Type:        schema.TypeString,
 							Description: "Authorized IP",
 							Optional:    true,
+						},
+						"status": {
+							Type:        schema.TypeString,
+							Description: "Current status of the IP restriction",
+							Computed:    true,
 						},
 					},
 				},

--- a/ovh/resource_cloud_project_database.go
+++ b/ovh/resource_cloud_project_database.go
@@ -53,6 +53,25 @@ func resourceCloudProjectDatabase() *schema.Resource {
 				Description: "The node flavor used for this cluster",
 				Required:    true,
 			},
+			"ip_restrictions": {
+				Type:        schema.TypeList,
+				Description: "IP Blocks authorized to access to the cluster",
+				Optional:    true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"description": {
+							Type:        schema.TypeString,
+							Description: "Description of the IP restriction",
+							Optional:    true,
+						},
+						"ip": {
+							Type:        schema.TypeString,
+							Description: "Authorized IP",
+							Optional:    true,
+						},
+					},
+				},
+			},
 			"kafka_rest_api": {
 				Type:        schema.TypeBool,
 				Description: "Defines whether the REST API is enabled on a Kafka cluster",

--- a/ovh/resource_cloud_project_database_ip_restriction.go
+++ b/ovh/resource_cloud_project_database_ip_restriction.go
@@ -18,6 +18,8 @@ import (
 
 func resourceCloudProjectDatabaseIpRestriction() *schema.Resource {
 	return &schema.Resource{
+		DeprecationMessage: "use ip_restriction field in cloud_project_database resource",
+
 		CreateContext: resourceCloudProjectDatabaseIpRestrictionCreate,
 		ReadContext:   resourceCloudProjectDatabaseIpRestrictionRead,
 		DeleteContext: resourceCloudProjectDatabaseIpRestrictionDelete,

--- a/ovh/resource_cloud_project_database_test.go
+++ b/ovh/resource_cloud_project_database_test.go
@@ -77,7 +77,11 @@ resource "ovh_cloud_project_database" "db" {
 	version      = "%s"
 	plan         = "essential"
 	nodes {
-		region     = "%s"
+		region = "%s"
+	}
+	ip_restrictions {
+		description = "%s"
+		ip = "%s"
 	}
 	flavor = "%s"
 }
@@ -89,6 +93,7 @@ func TestAccCloudProjectDatabase_basic(t *testing.T) {
 	version := os.Getenv("OVH_CLOUD_PROJECT_DATABASE_VERSION_TEST")
 	region := os.Getenv("OVH_CLOUD_PROJECT_DATABASE_REGION_TEST")
 	flavor := os.Getenv("OVH_CLOUD_PROJECT_DATABASE_FLAVOR_TEST")
+	ip := os.Getenv("OVH_CLOUD_PROJECT_DATABASE_IP_RESTRICTION_IP_TEST")
 	description := acctest.RandomWithPrefix(test_prefix)
 
 	config := fmt.Sprintf(
@@ -98,6 +103,8 @@ func TestAccCloudProjectDatabase_basic(t *testing.T) {
 		engine,
 		version,
 		region,
+		description,
+		ip,
 		flavor,
 	)
 
@@ -138,6 +145,12 @@ func TestAccCloudProjectDatabase_basic(t *testing.T) {
 						"ovh_cloud_project_database.db", "nodes.#"),
 					resource.TestCheckResourceAttr(
 						"ovh_cloud_project_database.db", "nodes.0.region", region),
+					resource.TestCheckResourceAttrSet(
+						"ovh_cloud_project_database.db", "ip_restrictions.#"),
+					resource.TestCheckResourceAttr(
+						"ovh_cloud_project_database.db", "ip_restrictions.0.description", description),
+					resource.TestCheckResourceAttr(
+						"ovh_cloud_project_database.db", "ip_restrictions.0.ip", ip),
 					resource.TestCheckResourceAttr(
 						"ovh_cloud_project_database.db", "plan", "essential"),
 					resource.TestCheckResourceAttr(

--- a/ovh/types_cloud_project_database.go
+++ b/ovh/types_cloud_project_database.go
@@ -32,41 +32,54 @@ type CloudProjectDatabaseBackups struct {
 	Time    string   `json:"time,omitempty"`
 }
 
-type CloudProjectDatabaseIPRestrictions struct {
-	Description string `json:"description,omitempty"`
-	IP          string `json:"ip,omitempty"`
+type CloudProjectDatabaseIPRestriction struct {
+	Description string `json:"description"`
+	IP          string `json:"ip"`
 }
 
-func (ir CloudProjectDatabaseIPRestrictions) toMap() map[string]interface{} {
+func (opts *CloudProjectDatabaseIPRestriction) FromResourceWithPath(d *schema.ResourceData, path string) *CloudProjectDatabaseIPRestriction {
+	opts.Description = d.Get(fmt.Sprintf("%s.description", path)).(string)
+	opts.IP = d.Get(fmt.Sprintf("%s.ip", path)).(string)
+
+	return opts
+}
+
+type CloudProjectDatabaseIPRestrictionResponse struct {
+	CloudProjectDatabaseIPRestriction
+	Status string `json:"status"`
+}
+
+func (ir CloudProjectDatabaseIPRestrictionResponse) toMap() map[string]interface{} {
 	obj := make(map[string]interface{})
 
 	obj["description"] = ir.Description
 	obj["ip"] = ir.IP
+	obj["status"] = ir.Status
 
 	return obj
 }
 
 type CloudProjectDatabaseResponse struct {
-	AclsEnabled           bool                                 `json:"aclsEnabled"`
-	Backups               CloudProjectDatabaseBackups          `json:"backups"`
-	CreatedAt             string                               `json:"createdAt"`
-	Description           string                               `json:"description"`
-	Endpoints             []CloudProjectDatabaseEndpoint       `json:"endpoints"`
-	Flavor                string                               `json:"flavor"`
-	Id                    string                               `json:"id"`
-	IPRestrictions        []CloudProjectDatabaseIPRestrictions `json:"ipRestrictions"`
-	MaintenanceTime       string                               `json:"maintenanceTime"`
-	NetworkId             string                               `json:"networkId"`
-	NetworkType           string                               `json:"networkType"`
-	Plan                  string                               `json:"plan"`
-	NodeNumber            int                                  `json:"nodeNumber"`
-	Region                string                               `json:"region"`
-	RestApi               bool                                 `json:"restApi"`
-	Status                string                               `json:"status"`
-	SubnetId              string                               `json:"subnetId"`
-	Version               string                               `json:"version"`
-	Disk                  CloudProjectDatabaseDisk             `json:"disk"`
-	AdvancedConfiguration map[string]string                    `json:"advancedConfiguration"`
+	AclsEnabled           bool                                        `json:"aclsEnabled"`
+	Backups               CloudProjectDatabaseBackups                 `json:"backups"`
+	CreatedAt             string                                      `json:"createdAt"`
+	Description           string                                      `json:"description"`
+	Endpoints             []CloudProjectDatabaseEndpoint              `json:"endpoints"`
+	Flavor                string                                      `json:"flavor"`
+	Id                    string                                      `json:"id"`
+	IPRestrictions        []CloudProjectDatabaseIPRestrictionResponse `json:"ipRestrictions"`
+	MaintenanceTime       string                                      `json:"maintenanceTime"`
+	NetworkId             string                                      `json:"networkId"`
+	NetworkType           string                                      `json:"networkType"`
+	Plan                  string                                      `json:"plan"`
+	NodeNumber            int                                         `json:"nodeNumber"`
+	Region                string                                      `json:"region"`
+	RestApi               bool                                        `json:"restApi"`
+	Status                string                                      `json:"status"`
+	SubnetId              string                                      `json:"subnetId"`
+	Version               string                                      `json:"version"`
+	Disk                  CloudProjectDatabaseDisk                    `json:"disk"`
+	AdvancedConfiguration map[string]string                           `json:"advancedConfiguration"`
 }
 
 func (s *CloudProjectDatabaseResponse) String() string {
@@ -171,14 +184,15 @@ func (v CloudProjectDatabaseNodes) ToMap() map[string]interface{} {
 }
 
 type CloudProjectDatabaseCreateOpts struct {
-	Description  string                           `json:"description,omitempty"`
-	NetworkId    string                           `json:"networkId,omitempty"`
-	NodesPattern CloudProjectDatabaseNodesPattern `json:"nodesPattern,omitempty"`
-	Disk         CloudProjectDatabaseDisk         `json:"disk,omitempty"`
-	Plan         string                           `json:"plan"`
-	SubnetId     string                           `json:"subnetId,omitempty"`
-	Version      string                           `json:"version"`
-	Backups      CloudProjectDatabaseBackups      `json:"backups,omitempty"`
+	Backups        CloudProjectDatabaseBackups         `json:"backups,omitempty"`
+	Description    string                              `json:"description,omitempty"`
+	Disk           CloudProjectDatabaseDisk            `json:"disk,omitempty"`
+	IPRestrictions []CloudProjectDatabaseIPRestriction `json:"ipRestrictions,omitempty"`
+	NetworkId      string                              `json:"networkId,omitempty"`
+	NodesPattern   CloudProjectDatabaseNodesPattern    `json:"nodesPattern,omitempty"`
+	Plan           string                              `json:"plan"`
+	SubnetId       string                              `json:"subnetId,omitempty"`
+	Version        string                              `json:"version"`
 }
 
 type CloudProjectDatabaseDisk struct {
@@ -205,6 +219,17 @@ func (opts *CloudProjectDatabaseCreateOpts) FromResource(d *schema.ResourceData)
 	nbOfNodes := d.Get("nodes.#").(int)
 	for i := 0; i < nbOfNodes; i++ {
 		nodes = append(nodes, *(&CloudProjectDatabaseNodes{}).FromResourceWithPath(d, fmt.Sprintf("nodes.%d", i)))
+	}
+
+	ipRests := d.Get("ip_restrictions").(*schema.Set).List()
+	opts.IPRestrictions = make([]CloudProjectDatabaseIPRestriction, len(ipRests))
+	for i, ir := range ipRests {
+		ipRestMap := ir.(map[string]interface{})
+		opts.IPRestrictions[i] = CloudProjectDatabaseIPRestriction{
+			Description: ipRestMap["description"].(string),
+			IP:          ipRestMap["ip"].(string),
+		}
+
 	}
 
 	if err := checkNodesEquality(nodes); err != nil {
@@ -235,14 +260,15 @@ func (opts *CloudProjectDatabaseCreateOpts) FromResource(d *schema.ResourceData)
 }
 
 type CloudProjectDatabaseUpdateOpts struct {
-	AclsEnabled bool                        `json:"aclsEnabled,omitempty"`
-	Description string                      `json:"description,omitempty"`
-	Flavor      string                      `json:"flavor,omitempty"`
-	Plan        string                      `json:"plan,omitempty"`
-	RestApi     bool                        `json:"restApi,omitempty"`
-	Version     string                      `json:"version,omitempty"`
-	Disk        CloudProjectDatabaseDisk    `json:"disk,omitempty"`
-	Backups     CloudProjectDatabaseBackups `json:"backups,omitempty"`
+	AclsEnabled    bool                                `json:"aclsEnabled,omitempty"`
+	Backups        CloudProjectDatabaseBackups         `json:"backups,omitempty"`
+	Description    string                              `json:"description,omitempty"`
+	Disk           CloudProjectDatabaseDisk            `json:"disk,omitempty"`
+	Flavor         string                              `json:"flavor,omitempty"`
+	IPRestrictions []CloudProjectDatabaseIPRestriction `json:"ipRestrictions,omitempty"`
+	Plan           string                              `json:"plan,omitempty"`
+	RestApi        bool                                `json:"restApi,omitempty"`
+	Version        string                              `json:"version,omitempty"`
 }
 
 func (opts *CloudProjectDatabaseUpdateOpts) FromResource(d *schema.ResourceData) (*CloudProjectDatabaseUpdateOpts, error) {
@@ -259,6 +285,17 @@ func (opts *CloudProjectDatabaseUpdateOpts) FromResource(d *schema.ResourceData)
 	opts.Flavor = d.Get("flavor").(string)
 	opts.Version = d.Get("version").(string)
 	opts.Disk = CloudProjectDatabaseDisk{Size: d.Get("disk_size").(int)}
+
+	ipRests := d.Get("ip_restrictions").(*schema.Set).List()
+	opts.IPRestrictions = make([]CloudProjectDatabaseIPRestriction, len(ipRests))
+	for i, ir := range ipRests {
+		ipRestMap := ir.(map[string]interface{})
+		opts.IPRestrictions[i] = CloudProjectDatabaseIPRestriction{
+			Description: ipRestMap["description"].(string),
+			IP:          ipRestMap["ip"].(string),
+		}
+
+	}
 
 	regions, err := helpers.StringsFromSchema(d, "backup_regions")
 	if err != nil {

--- a/ovh/types_cloud_project_database.go
+++ b/ovh/types_cloud_project_database.go
@@ -32,26 +32,41 @@ type CloudProjectDatabaseBackups struct {
 	Time    string   `json:"time,omitempty"`
 }
 
+type CloudProjectDatabaseIPRestrictions struct {
+	Description string `json:"description,omitempty"`
+	IP          string `json:"ip,omitempty"`
+}
+
+func (ir CloudProjectDatabaseIPRestrictions) toMap() map[string]interface{} {
+	obj := make(map[string]interface{})
+
+	obj["description"] = ir.Description
+	obj["ip"] = ir.IP
+
+	return obj
+}
+
 type CloudProjectDatabaseResponse struct {
-	AclsEnabled           bool                           `json:"aclsEnabled"`
-	Backups               CloudProjectDatabaseBackups    `json:"backups"`
-	CreatedAt             string                         `json:"createdAt"`
-	Description           string                         `json:"description"`
-	Endpoints             []CloudProjectDatabaseEndpoint `json:"endpoints"`
-	Flavor                string                         `json:"flavor"`
-	Id                    string                         `json:"id"`
-	MaintenanceTime       string                         `json:"maintenanceTime"`
-	NetworkId             string                         `json:"networkId"`
-	NetworkType           string                         `json:"networkType"`
-	Plan                  string                         `json:"plan"`
-	NodeNumber            int                            `json:"nodeNumber"`
-	Region                string                         `json:"region"`
-	RestApi               bool                           `json:"restApi"`
-	Status                string                         `json:"status"`
-	SubnetId              string                         `json:"subnetId"`
-	Version               string                         `json:"version"`
-	Disk                  CloudProjectDatabaseDisk       `json:"disk"`
-	AdvancedConfiguration map[string]string              `json:"advancedConfiguration"`
+	AclsEnabled           bool                                 `json:"aclsEnabled"`
+	Backups               CloudProjectDatabaseBackups          `json:"backups"`
+	CreatedAt             string                               `json:"createdAt"`
+	Description           string                               `json:"description"`
+	Endpoints             []CloudProjectDatabaseEndpoint       `json:"endpoints"`
+	Flavor                string                               `json:"flavor"`
+	Id                    string                               `json:"id"`
+	IPRestrictions        []CloudProjectDatabaseIPRestrictions `json:"ipRestrictions"`
+	MaintenanceTime       string                               `json:"maintenanceTime"`
+	NetworkId             string                               `json:"networkId"`
+	NetworkType           string                               `json:"networkType"`
+	Plan                  string                               `json:"plan"`
+	NodeNumber            int                                  `json:"nodeNumber"`
+	Region                string                               `json:"region"`
+	RestApi               bool                                 `json:"restApi"`
+	Status                string                               `json:"status"`
+	SubnetId              string                               `json:"subnetId"`
+	Version               string                               `json:"version"`
+	Disk                  CloudProjectDatabaseDisk             `json:"disk"`
+	AdvancedConfiguration map[string]string                    `json:"advancedConfiguration"`
 }
 
 func (s *CloudProjectDatabaseResponse) String() string {
@@ -65,6 +80,12 @@ func (v CloudProjectDatabaseResponse) ToMap() map[string]interface{} {
 	obj["created_at"] = v.CreatedAt
 	obj["description"] = v.Description
 	obj["id"] = v.Id
+
+	var ipRests []map[string]interface{}
+	for _, ir := range v.IPRestrictions {
+		ipRests = append(ipRests, ir.toMap())
+	}
+	obj["ip_restrictions"] = ipRests
 
 	var endpoints []map[string]interface{}
 	for _, e := range v.Endpoints {

--- a/ovh/types_cloud_project_database.go
+++ b/ovh/types_cloud_project_database.go
@@ -229,7 +229,6 @@ func (opts *CloudProjectDatabaseCreateOpts) FromResource(d *schema.ResourceData)
 			Description: ipRestMap["description"].(string),
 			IP:          ipRestMap["ip"].(string),
 		}
-
 	}
 
 	if err := checkNodesEquality(nodes); err != nil {

--- a/website/docs/d/cloud_project_database.html.markdown
+++ b/website/docs/d/cloud_project_database.html.markdown
@@ -56,6 +56,10 @@ The following attributes are exported:
   * `uri` - URI of the endpoint.
 * `engine` - See Argument Reference above.
 * `flavor` - A valid OVHcloud public cloud database flavor name in which the nodes will be started.
+* `ip_restrictions` - IP Blocks authorized to access to the cluster.
+  * `description` - Description of the IP restriction
+  * `ip` - Authorized IP
+  * `status` - Current status of the IP restriction.
 * `kafka_rest_api` - Defines whether the REST API is enabled on a kafka cluster.
 * `maintenance_time` - Time on which maintenances can start every day.
 * `network_type` - Type of network of the cluster.

--- a/website/docs/r/cloud_project_database.html.markdown
+++ b/website/docs/r/cloud_project_database.html.markdown
@@ -120,6 +120,14 @@ resource "ovh_cloud_project_database" "pgsqldb" {
     region  = "WAW"
   }
   flavor        = "db1-4"
+  ip_restrictions {
+    description = "ip 1"
+    ip = "178.97.6.0/24"
+  }
+  ip_restrictions {
+    description = "ip 2"
+    ip = "178.97.7.0/24"
+  }
 }
 
 resource "ovh_cloud_project_database" "redisdb" {
@@ -211,6 +219,10 @@ The following arguments are supported:
   Ex: "db1-7". Changing this value upgrade the nodes with the new flavor.
   You can find the list of flavor names: https://www.ovhcloud.com/fr/public-cloud/prices/
 
+* `ip_restrictions` - (Optional) IP Blocks authorized to access to the cluster.
+  * `description` - (Optional) Description of the IP restriction
+  * `ip` - (Optional) Authorized IP
+
 * `kafka_rest_api` -  (Optional) Defines whether the REST API is enabled on a kafka cluster
 
 * `nodes` - (Required, Minimum Items: 1) List of nodes object.
@@ -259,6 +271,10 @@ The following attributes are exported:
   * `uri` - URI of the endpoint.
 * `engine` - See Argument Reference above.
 * `flavor` - See Argument Reference above.
+* `ip_restrictions` - See Argument Reference above.
+  * `description` - See Argument Reference above.
+  * `ip` - See Argument Reference above.
+  * `status` - Current status of the IP restriction.
 * `kafka_rest_api` - See Argument Reference above.
 * `maintenance_time` - Time on which maintenances can start every day.
 * `network_type` - Type of network of the cluster.


### PR DESCRIPTION
# Description
Following OVH API

- Add IP restriction in Database service resource and datasource
- Depracate ip_restriction resource and datasources


## Type of change

- [ ] Improvement (improve existing resource(s) or datasource(s))
- [ ] Documentation update