### PR TITLE
fix: vrack: remove deprecation warning for non-deprecated resource

### DIFF
--- a/ovh/resource_vrack_dedicated_server.go
+++ b/ovh/resource_vrack_dedicated_server.go
@@ -32,7 +32,6 @@ func resourceVrackDedicatedServer() *schema.Resource {
 				ForceNew: true,
 			},
 		},
-		DeprecationMessage: "Use ovh_vrack_dedicated_server_interface instead.",
 	}
 }
 

--- a/website/docs/r/vrack_dedicated_server.html.markdown
+++ b/website/docs/r/vrack_dedicated_server.html.markdown
@@ -4,10 +4,10 @@ subcategory : "vRack"
 
 # ovh_vrack_dedicated_server
 
-~> **NOTE:** The resource `ovh_vrack_dedicated_server` is DEPRECATED and will be removed in a future version.
-Use the resource [`ovh_vrack_dedicated_server_interface`](vrack_dedicated_server_interface.html.markdown) instead.
+Attach a legacy dedicated server to a vRack.
 
-Attach a dedicated server to a VRack.
+~> **NOTE:** The resource `ovh_vrack_dedicated_server` is intended to be used for legacy dedicated servers.<br />
+Dedicated servers that have configurable network interfaces MUST use the resource [`ovh_vrack_dedicated_server_interface`](vrack_dedicated_server_interface.html.markdown) instead.
 
 ## Example Usage
 
@@ -23,7 +23,7 @@ resource "ovh_vrack_dedicated_server" "vds" {
 The following arguments are supported:
 
 * `service_name` - (Required) The service name of the vrack. If omitted,
-    the `OVH_VRACK_SERVICE` environment variable is used. 
+    the `OVH_VRACK_SERVICE` environment variable is used.
 
 * `server_id` - (Required) The id of the dedicated server. 
 

--- a/website/docs/r/vrack_dedicated_server_interface.html.markdown
+++ b/website/docs/r/vrack_dedicated_server_interface.html.markdown
@@ -4,7 +4,10 @@ subcategory : "vRack"
 
 # ovh_vrack_dedicated_server_interface
 
-Attach a Dedicated Server Network Interface to a VRack.
+Attach a Dedicated Server Network Interface to a vRack.
+
+~> **NOTE:** The resource `ovh_vrack_dedicated_server_interface` is intended to be used for dedicated servers that have configurable network interfaces.<br />
+Legacy Dedicated servers that do not have configurable network interfaces MUST use the resource [`ovh_vrack_dedicated_server`](vrack_dedicated_server.html.markdown) instead.
 
 ## Example Usage
 
@@ -24,7 +27,7 @@ resource "ovh_vrack_dedicated_server_interface" "vdsi" {
 The following arguments are supported:
 
 * `service_name` - (Required) The id of the vrack. If omitted,
-    the `OVH_VRACK_SERVICE` environment variable is used. 
+    the `OVH_VRACK_SERVICE` environment variable is used.
 
 * `interface_id` - (Required) The id of dedicated server network interface.
 


### PR DESCRIPTION
`ovh_vrack_dedicated_server` is not deprecated, still in use for legacy dedicated servers that do not have network interfaces.
