### PR TITLE
add userMetadata option for dedicated server resource

### DIFF
--- a/ovh/resource_dedicated_server_install_task.go
+++ b/ovh/resource_dedicated_server_install_task.go
@@ -8,6 +8,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/hashicorp/go-cty/cty"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/ovh/terraform-provider-ovh/ovh/helpers"
 )
@@ -116,6 +118,171 @@ func resourceDedicatedServerInstallTask() *schema.Resource {
 							Optional:    true,
 							ForceNew:    true,
 							Description: "",
+						},
+					},
+				},
+			},
+			"user_metadata": {
+				Type:     schema.TypeList,
+				Optional: true,
+				ForceNew: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"image_url": {
+							Type:        schema.TypeString,
+							Optional:    true,
+							Description: "Image URL",
+							ValidateDiagFunc: func(value interface{}, attributePath cty.Path) diag.Diagnostics {
+								if _, err := url.Parse(value.(string)); err != nil {
+									return diag.Diagnostics{
+										{
+											Severity:      diag.Error,
+											Summary:       "Image URL is invalid",
+											Detail:        fmt.Sprintf("Image URL '%v' is invalid: %v", value, err),
+											AttributePath: attributePath,
+										},
+									}
+								}
+								return diag.Diagnostics{}
+							},
+						},
+						"http_headers_0_key": {
+							Type:        schema.TypeString,
+							Optional:    true,
+							Required:    false,
+							Description: "httpHeaders0Key",
+						},
+						"http_headers_0_value": {
+							Type:        schema.TypeString,
+							Optional:    true,
+							Required:    false,
+							Description: "httpHeaders0Value",
+						},
+						"http_headers_1_key": {
+							Type:        schema.TypeString,
+							Optional:    true,
+							Required:    false,
+							Description: "httpHeaders1Key",
+						},
+						"http_headers_1_value": {
+							Type:        schema.TypeString,
+							Optional:    true,
+							Required:    false,
+							Description: "httpHeaders1Value",
+						},
+						"http_headers_2_key": {
+							Type:        schema.TypeString,
+							Optional:    true,
+							Required:    false,
+							Description: "httpHeaders2Key",
+						},
+						"http_headers_2_value": {
+							Type:        schema.TypeString,
+							Optional:    true,
+							Required:    false,
+							Description: "httpHeaders2Value",
+						},
+						"http_headers_3_key": {
+							Type:        schema.TypeString,
+							Optional:    true,
+							Required:    false,
+							Description: "httpHeaders3Key",
+						},
+						"http_headers_3_value": {
+							Type:        schema.TypeString,
+							Optional:    true,
+							Required:    false,
+							Description: "httpHeaders3Value",
+						},
+						"http_headers_4_key": {
+							Type:        schema.TypeString,
+							Optional:    true,
+							Required:    false,
+							Description: "httpHeaders4Key",
+						},
+						"http_headers_4_value": {
+							Type:        schema.TypeString,
+							Optional:    true,
+							Required:    false,
+							Description: "httpHeaders4Value",
+						},
+						"http_headers_5_key": {
+							Type:        schema.TypeString,
+							Optional:    true,
+							Required:    false,
+							Description: "httpHeaders5Key",
+						},
+						"http_headers_5_value": {
+							Type:        schema.TypeString,
+							Optional:    true,
+							Required:    false,
+							Description: "httpHeaders5Value",
+						},
+						"image_checksum": {
+							Type:        schema.TypeString,
+							Optional:    true,
+							Required:    false,
+							Description: "Image checksum",
+						},
+						"image_checksum_type": {
+							Type:        schema.TypeString,
+							Optional:    true,
+							Required:    false,
+							Description: "Checksum type",
+							ValidateDiagFunc: func(value interface{}, attributePath cty.Path) diag.Diagnostics {
+								if value != "md5" &&
+									value != "sha1" &&
+									value != "sha256" &&
+									value != "sha512" {
+									return diag.Diagnostics{
+										{
+											Severity:      diag.Error,
+											Summary:       "Checksum type is not set or is invalid",
+											Detail:        fmt.Sprintf("Checksum type is currently set as '%v'. It should be one of 'md5', 'sha1', 'sha256' or 'sha512'.", value),
+											AttributePath: attributePath,
+										},
+									}
+								}
+								return diag.Diagnostics{}
+							},
+						},
+						"config_drive_user_data": {
+							Type:        schema.TypeString,
+							Optional:    true,
+							Required:    false,
+							Description: "configDriveUserData",
+						},
+						"image_type": {
+							Type:        schema.TypeString,
+							Description: "Image type",
+							Optional:    true,
+							Required:    false,
+							ValidateDiagFunc: func(value interface{}, attributePath cty.Path) diag.Diagnostics {
+								if value != "qcow2" && value != "raw" {
+									return diag.Diagnostics{
+										{
+											Severity:      diag.Error,
+											Summary:       "Image type is not set or is invalid",
+											Detail:        fmt.Sprintf("Image type is currently set as '%v'. It should be either 'qcow2' or 'raw'.", value),
+											AttributePath: attributePath,
+										},
+									}
+								}
+								return diag.Diagnostics{}
+							},
+						},
+						"language": {
+							Type:        schema.TypeString,
+							Optional:    true,
+							Required:    false,
+							Description: "language",
+						},
+						"use_spla": {
+							Type:        schema.TypeBool,
+							Optional:    true,
+							Required:    false,
+							Description: "set to true to use your own licence",
 						},
 					},
 				},

--- a/ovh/resource_dedicated_server_install_task_test.go
+++ b/ovh/resource_dedicated_server_install_task_test.go
@@ -75,6 +75,39 @@ func TestAccDedicatedServerInstall_rebootondestroy(t *testing.T) {
 	})
 }
 
+func TestAccDedicatedServerInstall_usermetadata(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheckCredentials(t)
+			testAccPreCheckDedicatedServer(t)
+		},
+		Providers: testAccProviders,
+		ExternalProviders: map[string]resource.ExternalProvider{
+			"time": {
+				VersionConstraint: "0.10.0",
+				Source:            "hashicorp/time",
+			},
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDedicatedServerInstallConfig("usermetadata"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(
+						"ovh_dedicated_server_update.server", "state", "ok"),
+					resource.TestCheckResourceAttr(
+						"ovh_dedicated_server_update.server", "monitoring", "true"),
+					resource.TestCheckResourceAttr(
+						"ovh_dedicated_server_update.server", "state", "ok"),
+					resource.TestCheckResourceAttr(
+						"ovh_dedicated_server_install_task.server_install", "function", "reinstallServer"),
+					resource.TestCheckResourceAttr(
+						"ovh_dedicated_server_install_task.server_install", "status", "done"),
+				),
+			},
+		},
+	})
+}
+
 func testAccDedicatedServerInstallConfig(config string) string {
 	dedicated_server := os.Getenv("OVH_DEDICATED_SERVER")
 	testName := acctest.RandomWithPrefix(test_prefix)
@@ -90,6 +123,18 @@ func testAccDedicatedServerInstallConfig(config string) string {
 			testName,
 			sshKey,
 			testName,
+		)
+	}
+
+	if config == "usermetadata" {
+		return fmt.Sprintf(
+			testAccDedicatedServerInstallConfig_Usermetadata,
+			dedicated_server,
+			testName,
+			sshKey,
+			testName,
+			sshKey,
+			sshKey,
 		)
 	}
 
@@ -169,7 +214,7 @@ resource ovh_dedicated_server_update "server" {
 }
 
 resource "ovh_me_installation_template" "debian" {
-  base_template_name = "debian10_64"
+  base_template_name = "debian12_64"
   template_name      = "%s"
   default_language   = "en"
 
@@ -191,4 +236,43 @@ resource ovh_dedicated_server_install_task "server_install" {
 
   depends_on = [time_sleep.wait_for_ssh_key_sync]
 }
+`
+const testAccDedicatedServerInstallConfig_Usermetadata = `
+data ovh_dedicated_server_boots "harddisk" {
+	service_name = "%s"
+	boot_type    = "harddisk"
+}
+
+
+resource "ovh_me_ssh_key" "key" {
+	key_name = "%s"
+	key      = "%s"
+}
+
+resource ovh_dedicated_server_update "server" {
+  service_name = data.ovh_dedicated_server_boots.harddisk.service_name
+  monitoring   = true
+  state        = "ok"
+}
+
+resource "ovh_me_installation_template" "byolinux" {
+  base_template_name = "byolinux_64"
+  template_name      = "%s"
+  default_language   = "en"
+}
+
+resource ovh_dedicated_server_install_task "server_install" {
+  service_name      = data.ovh_dedicated_server_boots.harddisk.service_name
+  template_name     = ovh_me_installation_template.byolinux.template_name
+  user_metadata     {
+    image_url              = "https://github.com/ashmonger/akution_test/releases/download/0.6-fixCache/deb11k6.qcow2"
+    image_type             = "qcow2"
+    http_headers_0_key     = "Authorization"
+    http_headers_0_value   = "Basic bG9naW46cGFzc3dvcmQ="
+    image_checksum_type    = "sha512"
+    image_checksum         = "047122c9ff4d2a69512212104b06c678f5a9cdb22b75467353613ff87ccd03b57b38967e56d810e61366f9d22d6bd39ac0addf4e00a4c6445112a2416af8f225"
+    config_drive_user_data = "#cloud-config\nssh_authorized_keys:\n  - %s\n\nusers:\n  - name: aautret\n    sudo: ALL=(ALL) NOPASSWD:ALL\n    groups: users, sudo\n    shell: /bin/bash\n    lock_passwd: false\n    ssh_authorized_keys:\n      - %s\ndisable_root: false\npackages:\n  - vim\n  - tree\nfinal_message: The system is finally up, after $UPTIME seconds\n"
+  }
+}
+
 `

--- a/ovh/types_dedicated_server.go
+++ b/ovh/types_dedicated_server.go
@@ -107,10 +107,16 @@ type DedicatedServerTask struct {
 	StartDate  time.Time `json:"startDate"`
 }
 
+type UserMetadata struct {
+	Key   string `json:"key,omitempty"`
+	Value string `json:"value,omitempty"`
+}
+
 type DedicatedServerInstallTaskCreateOpts struct {
 	TemplateName        string                             `json:"templateName"`
 	PartitionSchemeName *string                            `json:"partitionSchemeName,omitempty"`
 	Details             *DedicatedServerInstallTaskDetails `json:"details"`
+	UserMetadata        *[]UserMetadata                    `json:"userMetadata"`
 }
 
 func (opts *DedicatedServerInstallTaskCreateOpts) FromResource(d *schema.ResourceData) *DedicatedServerInstallTaskCreateOpts {
@@ -118,10 +124,23 @@ func (opts *DedicatedServerInstallTaskCreateOpts) FromResource(d *schema.Resourc
 	opts.PartitionSchemeName = helpers.GetNilStringPointerFromData(d, "partition_scheme_name")
 
 	details := d.Get("details").([]interface{})
-	if details != nil && len(details) == 1 {
+	if len(details) == 1 {
 		opts.Details = (&DedicatedServerInstallTaskDetails{}).FromResource(d, "details.0")
-
 	}
+
+	var UserMetadataArray = []UserMetadata{}
+	providedUserMetadatas := d.Get("user_metadata.0")
+	if providedUserMetadatas != nil {
+		for key, value := range providedUserMetadatas.(map[string]interface{}) {
+			if value != "" {
+				UserMetadataArray = append(UserMetadataArray, UserMetadata{
+					Key:   fixKeyName(key),
+					Value: fmt.Sprintf("%v", value),
+				})
+			}
+		}
+	}
+	opts.UserMetadata = &UserMetadataArray
 	return opts
 }
 
@@ -151,4 +170,49 @@ func (opts *DedicatedServerInstallTaskDetails) FromResource(d *schema.ResourceDa
 	opts.UseSpla = helpers.GetNilBoolPointerFromData(d, fmt.Sprintf("%s.use_spla", parent))
 
 	return opts
+}
+
+func fixKeyName(key string) string {
+	switch key {
+	case "image_url":
+		return "imageURL"
+	case "http_headers_0_key":
+		return "httpHeaders0Key"
+	case "http_headers_0_value":
+		return "httpHeaders0Value"
+	case "http_headers_1_key":
+		return "httpHeaders1Key"
+	case "http_headers_1_value":
+		return "httpHeaders1Value"
+	case "http_headers_2_key":
+		return "httpHeaders2Key"
+	case "http_headers_2_value":
+		return "httpHeaders2Value"
+	case "http_headers_3_key":
+		return "httpHeaders3Key"
+	case "http_headers_3_value":
+		return "httpHeaders3Value"
+	case "http_headers_4_key":
+		return "httpHeaders4Key"
+	case "http_headers_4_value":
+		return "httpHeaders4Value"
+	case "http_headers_5_key":
+		return "httpHeaders5Key"
+	case "http_headers_5_value":
+		return "httpHeaders5Value"
+	case "image_checksum":
+		return "imageCheckSum"
+	case "image_checksum_type":
+		return "imageCheckSumType"
+	case "config_drive_user_data":
+		return "configDriveUserData"
+	case "image_type":
+		return "imageType"
+	case "language":
+		return "language"
+	case "use_spla":
+		return "useSpla"
+	default:
+		return ""
+	}
 }

--- a/website/docs/r/dedicated_server_install_task.html.markdown
+++ b/website/docs/r/dedicated_server_install_task.html.markdown
@@ -13,6 +13,7 @@ after a while.
 
 ## Example Usage
 
+Using a custom template based on an ovh template
 ```hcl
 data ovh_dedicated_server_boots "rescue" {
   service_name = "nsxxxxxxx.ip-xx-xx-xx.eu"
@@ -44,6 +45,50 @@ resource "ovh_dedicated_server_install_task" "server_install" {
   }
 }
 ```
+Using a BringYourOwnLinux (BYOL) template (with userMetadata)
+```hcl
+data "ovh_dedicated_server" "server" {
+  service_name = "nsxxxxxxx.ip-xx-xx-xx.eu"
+}
+
+resource "ovh_me_ssh_key" "key" {
+  key_name = "mykey"
+  key      = "ssh-ed25519 AAAAC3..."
+}
+
+data ovh_dedicated_server_boots "rescue" {
+  service_name = "nsxxxxxxx.ip-xx-xx-xx.eu"
+  boot_type    = "rescue"
+}
+
+resource "ovh_me_installation_template" "mytemplate" {
+  base_template_name = "byolinux_64"
+  template_name      = "mybyol_test"
+  default_language   = "en"
+  customization      {
+	  ssh_key_name = ovh_me_ssh_key.key.key_name
+	}
+}
+
+resource "ovh_dedicated_server_install_task" "server_install" {
+  service_name      = data.ovh_dedicated_server.server.service_name
+  template_name     = ovh_me_installation_template.debian.template_name
+  bootid_on_destroy = data.ovh_dedicated_server_boots.rescue.result[0]
+  user_metadata     {
+    image_url              = "https://myimage.qcow2"
+    image_type             = "qcow2"
+    http_headers_0_key     = "Authorization"
+    http_headers_0_value   = "Basic bG9naW46xxxxxxx="
+    image_checksum_type    = "sha512"
+    language               = "en"
+    image_checksum         = "047122c9ff4d2a69512212104b06c678f5a9cdb22b75467353613ff87ccd03b57b38967e56d810e61366f9d22d6bd39ac0addf4e00a4c6445112a2416af8f225"
+    config_drive_user_data = "#cloud-config\nssh_authorized_keys:\n  - ${data.ovh_me_ssh_key.mykey.key}\n\nusers:\n  - name: patient0\n    sudo: ALL=(ALL) NOPASSWD:ALL\n    groups: users, sudo\n    shell: /bin/bash\n    lock_passwd: false\n    ssh_authorized_keys:\n      - ${data.ovh_me_ssh_key.mykey.key}\ndisable_root: false\npackages:\n  - vim\n  - tree\nfinal_message: The system is finally up, after $UPTIME seconds\n"
+  }
+  details {
+      custom_hostname = "mytest"
+  }
+}
+```
 
 ## Argument Reference
 
@@ -54,19 +99,34 @@ The following arguments are supported:
 * `template_name` - (Required) Template name.
 * `bootid_on_destroy` - If set, reboot the server on the specified boot id during destroy phase.
 * `details` - see `details` block below.
+* `user_metadata` - see `user_metadata` block below.
+
 
 The `details` block supports:
 
 * `custom_hostname` - Set up the server using the provided hostname instead of the default hostname.
 * `disk_group_id` - Disk group id.
-* `install_sql_server` - set to true to install sql server (Windows template only).
-* `language` - language.
-* `no_raid` - set to true to disable RAID.
+* `install_sql_server` - Set to true to install sql server (Windows template only).
+* `language` - Language.
+* `no_raid` - Set to true to disable RAID.
 * `post_installation_script_link` - Indicate the URL where your postinstall customisation script is located.
 * `post_installation_script_return` - Indicate the string returned by your postinstall customisation script on successful execution. Advice: your script should return a unique validation string in case of succes. A good example is 'loh1Xee7eo OK OK OK UGh8Ang1Gu'.
 * `soft_raid_devices` - soft raid devices.
 * `ssh_key_name` - Name of the ssh key that should be installed. Password login will be disabled.
-* `use_spla` - set to true to use SPLA.
+* `use_spla` - Set to true to use SPLA.
+
+The `user_metadata` block supports:
+
+* `image_url` - Your Linux image URL
+* `image_type` - Your Linux image type (qcow2, raw)
+* `image_checksum` - Your image's checksum
+* `image_checksum_type` - Your image's checksum type
+* `http_headers_0_key` - Your image's HTTP headers key (up to 5)
+* `http_headers_0_value` - Your image's HTTP headers value (up to 5)
+* `config_drive_user_data` - Your user config drive user data
+* `language` - Language.
+* `use_spla` - Set to true to use SPLA.
+
 
 ## Attributes Reference
 


### PR DESCRIPTION
# Description

To reflect APIV6 changes , we need to add the userMetadata option on dedicated server resource

Fixes #xx (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Improvement (improve existing resource(s) or datasource(s))
- [x] Documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Test A: `make testacc TESTARGS="-run TestAccDedicatedServerInstall_usermetadata"`

**Test Configuration**:
* Terraform version: `terraform version`: Terraform 1.6.6
* Existing HCL configuration you used: 
```hcl
resource ovh_dedicated_server_install_task "server_install" {
  service_name      = data.ovh_dedicated_server_boots.harddisk.service_name
  template_name     = ovh_me_installation_template.byolinux.template_name
  user_metadata     {
    image_url              = "https://github.com/ashmonger/akution_test/releases/download/0.6-fixCache/deb11k6.qcow2"
    image_type             = "qcow2"
    http_headers_0_key     = "Authorization"
    http_headers_0_value   = "Basic bG9naW46cGFzc3dvcmQ="
    image_checksum_type    = "sha512"
    image_checksum         = "047122c9ff4d2a69512212104b06c678f5a9cdb22b75467353613ff87ccd03b57b38967e56d810e61366f9d22d6bd39ac0addf4e00a4c6445112a2416af8f225"
    config_drive_user_data = "#cloud-config\nssh_authorized_keys:\n  - %s\n\nusers:\n  - name: aautret\n    sudo: ALL=(ALL) NOPASSWD:ALL\n    groups: users, sudo\n    shell: /bin/bash\n    lock_passwd: false\n    ssh_authorized_keys:\n      - %s\ndisable_root: false\npackages:\n  - vim\n  - tree\nfinal_message: The system is finally up, after $UPTIME seconds\n"
  }
}
```

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or issues
- [x] I have added acceptance tests that prove my fix is effective or that my feature works
- [x] New and existing acceptance tests pass locally with my changes
- [ ] I ran succesfully `go mod vendor` if I added or modify `go.mod` file
