### PR TITLE
fix kafka + add kafka_schema_registry attribute

### DIFF
--- a/ovh/data_cloud_project_database.go
+++ b/ovh/data_cloud_project_database.go
@@ -135,6 +135,11 @@ func dataSourceCloudProjectDatabase() *schema.Resource {
 				Description: "Defines whether the REST API is enabled on a Kafka cluster",
 				Computed:    true,
 			},
+			"kafka_schema_registry": {
+				Type:        schema.TypeBool,
+				Description: "Defines whether the schema registry is enabled on a Kafka cluster",
+				Computed:    true,
+			},
 			"maintenance_time": {
 				Type:        schema.TypeString,
 				Description: "Time on which maintenances can start every day",
@@ -232,16 +237,16 @@ func dataSourceCloudProjectDatabaseRead(ctx context.Context, d *schema.ResourceD
 	nodesEndpoint := fmt.Sprintf("%s/node", serviceEndpoint)
 	nodeList := &[]string{}
 	if err := config.OVHClient.GetWithContext(ctx, nodesEndpoint, nodeList); err != nil {
-		return diag.Errorf("unable to get database %s nodes: %v", res.Id, err)
+		return diag.Errorf("unable to get database %s nodes: %v", res.ID, err)
 	}
 
 	if len(*nodeList) == 0 {
-		return diag.Errorf("no node found for database %s", res.Id)
+		return diag.Errorf("no node found for database %s", res.ID)
 	}
 	nodeEndpoint := fmt.Sprintf("%s/%s", nodesEndpoint, url.PathEscape((*nodeList)[0]))
 	node := &CloudProjectDatabaseNodes{}
 	if err := config.OVHClient.GetWithContext(ctx, nodeEndpoint, node); err != nil {
-		return diag.Errorf("unable to get database %s node %s: %v", res.Id, (*nodeList)[0], err)
+		return diag.Errorf("unable to get database %s node %s: %v", res.ID, (*nodeList)[0], err)
 	}
 
 	res.Region = node.Region
@@ -250,12 +255,12 @@ func dataSourceCloudProjectDatabaseRead(ctx context.Context, d *schema.ResourceD
 		advancedConfigEndpoint := fmt.Sprintf("%s/advancedConfiguration", serviceEndpoint)
 		advancedConfigMap := &map[string]string{}
 		if err := config.OVHClient.GetWithContext(ctx, advancedConfigEndpoint, advancedConfigMap); err != nil {
-			return diag.Errorf("unable to get database %s advanced configuration: %v", res.Id, err)
+			return diag.Errorf("unable to get database %s advanced configuration: %v", res.ID, err)
 		}
 		res.AdvancedConfiguration = *advancedConfigMap
 	}
 
-	for k, v := range res.ToMap() {
+	for k, v := range res.toMap() {
 		if k != "id" {
 			d.Set(k, v)
 		} else {

--- a/website/docs/d/cloud_project_database.html.markdown
+++ b/website/docs/d/cloud_project_database.html.markdown
@@ -61,6 +61,7 @@ The following attributes are exported:
   * `ip` - Authorized IP
   * `status` - Current status of the IP restriction.
 * `kafka_rest_api` - Defines whether the REST API is enabled on a kafka cluster.
+* `kafka_schema_registry` - Defines whether the schema registry is enabled on a Kafka cluster
 * `maintenance_time` - Time on which maintenances can start every day.
 * `network_type` - Type of network of the cluster.
 * `nodes` - List of nodes object.

--- a/website/docs/r/cloud_project_database.html.markdown
+++ b/website/docs/r/cloud_project_database.html.markdown
@@ -45,6 +45,7 @@ resource "ovh_cloud_project_database" "kafkadb" {
   version         = "3.4"
   plan            = "business"
   kafka_rest_api  = true
+  kafka_schema_registry = true
   nodes {
     region  = "DE"
   }
@@ -209,45 +210,33 @@ The following arguments are supported:
 
 * `service_name` - (Required, Forces new resource) The id of the public cloud project. If omitted,
   the `OVH_CLOUD_PROJECT_SERVICE` environment variable is used.
-
 * `description` - (Optional) Small description of the database service.
-
 * `engine` - (Required, Forces new resource) The database engine you want to deploy. To get a full list of available engine visit.
 [public documentation](https://docs.ovh.com/gb/en/publiccloud/databases).
-
 * `flavor` -  (Required) A valid OVHcloud public cloud database flavor name in which the nodes will be started.
   Ex: "db1-7". Changing this value upgrade the nodes with the new flavor.
   You can find the list of flavor names: https://www.ovhcloud.com/fr/public-cloud/prices/
-
 * `ip_restrictions` - (Optional) IP Blocks authorized to access to the cluster.
   * `description` - (Optional) Description of the IP restriction
   * `ip` - (Optional) Authorized IP
-
 * `kafka_rest_api` -  (Optional) Defines whether the REST API is enabled on a kafka cluster
-
+* `kafka_schema_registry` - (Optional) Defines whether the schema registry is enabled on a Kafka cluster
 * `nodes` - (Required, Minimum Items: 1) List of nodes object.
   Multi region cluster are not yet available, all node should be identical.
   * `network_id` - (Optional, Forces new resource) Private network id in which the node should be deployed. It's the regional openstackId of the private network
   * `region` - (Required, Forces new resource) Public cloud region in which the node should be deployed.
     Ex: "GRA'.
   * `subnet_id` - (Optional, Forces new resource) Private subnet ID in which the node is.
-
 * `opensearch_acls_enabled` -  (Optional) Defines whether the ACLs are enabled on an OpenSearch cluster
-
 * `disk_size` -  (Optional) The disk size (in GB) of the database service.
-
 * `advanced_configuration` -  (Optional) Advanced configuration key / value.
-
 * `plan` - (Required) Plan of the cluster.
   * MongoDB: Enum: "discovery", "production", "advanced".
   * Mysql, PosgreSQL, Cassandra, M3DB, : Enum: "essential", "business", "enterprise".
   * M3 Aggregator: "business", "enterprise".
   * Redis: "essential", "business"
-
 * `version` - (Required) The version of the engine in which the service should be deployed
-
 * `backup_regions` - List of region where backups are pushed. Not more than 1 regions for MongoDB. Not more than 2 regions for the other engines with one being the same as the nodes[].region field
-
 * `backup_time` - Time on which backups start every day.
 
 ## Attributes Reference
@@ -276,6 +265,7 @@ The following attributes are exported:
   * `ip` - See Argument Reference above.
   * `status` - Current status of the IP restriction.
 * `kafka_rest_api` - See Argument Reference above.
+* `kafka_schema_registry` - See Argument Reference above.
 * `maintenance_time` - Time on which maintenances can start every day.
 * `network_type` - Type of network of the cluster.
 * `nodes` - See Argument Reference above.


### PR DESCRIPTION
# Description

- Fix an issue on Kafka update and/or create (when kafka_rest_api or advanced_configuration set).
  - Kafka update API does not have `backups` field, this is a corner case of the resource `ovh_cloud_project_database`
- Add kafka_schema_registry attribute, following API

Fixe an issue reported directly to me.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Improvement (improve existing resource(s) or datasource(s))
- [ ] Documentation update