### PR TITLE
fix: cloud_project_user: Don't check role is not given in config

### DIFF
--- a/ovh/resource_cloud_project_user.go
+++ b/ovh/resource_cloud_project_user.go
@@ -108,7 +108,6 @@ func resourceCloudProjectUser() *schema.Resource {
 }
 
 func validateCloudProjectUserRoleFunc(config *Config, serviceName string, roles []string, role string) (*CloudProjectrolesResponse, error) {
-
 	endpoint := fmt.Sprintf("/cloud/project/%s/role",
 		url.PathEscape(serviceName),
 	)
@@ -122,9 +121,13 @@ func validateCloudProjectUserRoleFunc(config *Config, serviceName string, roles 
 		ovhRole = append(ovhRole, val.Name)
 	}
 
-	for _, role := range append(roles, role) {
+	rolesToCheck := roles
+	if role != "" {
+		rolesToCheck = append(rolesToCheck, role)
+	}
+	for _, role := range rolesToCheck {
 		if !slices.Contains(ovhRole, role) {
-			return nil, fmt.Errorf("Role %q does not exist", role)
+			return nil, fmt.Errorf("role %q does not exist", role)
 		}
 	}
 


### PR DESCRIPTION
# Description

`ovh_cloud_project_user`: field `role` is optional, so value should not be checked against the API if not defined.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (improve existing resource(s) or datasource(s))
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or issues
- [x] I have added acceptance tests that prove my fix is effective or that my feature works
- [x] New and existing acceptance tests pass locally with my changes
- [x] I ran succesfully `go mod vendor` if I added or modify `go.mod` file
