### PR TITLE
fix: Remove sweepers dependency on ovh_vrack_cloudproject

### DIFF
--- a/ovh/resource_vrack_cloudproject_test.go
+++ b/ovh/resource_vrack_cloudproject_test.go
@@ -21,9 +21,8 @@ resource "ovh_vrack_cloudproject" "vcp" {
 
 func init() {
 	resource.AddTestSweepers("ovh_vrack_cloudproject", &resource.Sweeper{
-		Name:         "ovh_vrack_cloudproject",
-		Dependencies: []string{"ovh_cloud_project_network_private"},
-		F:            testSweepVrackCloudProject,
+		Name: "ovh_vrack_cloudproject",
+		F:    testSweepVrackCloudProject,
 	})
 }
 


### PR DESCRIPTION
# Description

Test sweepers for resource `ovh_cloud_project_network_private` have been removed, so they must not be referenced as dependency in other resources tests.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (improve existing resource(s) or datasource(s))
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update