### PR TITLE
feat: Update vRack to be imported by service_name instead of order_id

### DIFF
--- a/ovh/order.go
+++ b/ovh/order.go
@@ -166,6 +166,7 @@ func genericOrderSchema(withOptions bool) map[string]*schema.Schema {
 		"order": {
 			Type:        schema.TypeList,
 			Computed:    true,
+			Optional:    true,
 			Description: "Details about an Order",
 			Elem: &schema.Resource{
 				Schema: map[string]*schema.Schema{

--- a/ovh/resource_vrack_test.go
+++ b/ovh/resource_vrack_test.go
@@ -44,8 +44,7 @@ func TestAccResourceVrack_basic(t *testing.T) {
 		desc,
 	)
 	resource.Test(t, resource.TestCase{
-		PreCheck: func() { testAccPreCheckOrderVrack(t) },
-
+		PreCheck:  func() { testAccPreCheckOrderVrack(t) },
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{

--- a/ovh/types_service.go
+++ b/ovh/types_service.go
@@ -45,6 +45,16 @@ func (s *Service) ToPlanValue(ctx context.Context, existingPlans types.TfListNes
 	return &planValue
 }
 
+func (s *Service) ToSDKv2PlanValue() []interface{} {
+	obj := make(map[string]interface{})
+
+	obj["plan_code"] = s.Billing.Plan.Code
+	obj["duration"] = s.Billing.Pricing.Duration
+	obj["pricing_mode"] = s.Billing.Pricing.PricingMode
+
+	return []interface{}{obj}
+}
+
 type ServiceBilling struct {
 	Plan    ServiceBillingPlan    `json:"plan"`
 	Pricing ServiceBillingPricing `json:"pricing"`

--- a/website/docs/r/vrack.html.markdown
+++ b/website/docs/r/vrack.html.markdown
@@ -85,7 +85,9 @@ Id is set to the order Id. In addition, the following attributes are exported:
 * `service_name` - The internal name of your vrack
 
 ## Import
-vRack can be imported using the `order_id` that can be retrieved in the [order page](https://www.ovh.com/manager/#/dedicated/billing/orders/orders). 
+
+vRack can be imported using the `service_name`.
+
 ```bash
-$ terraform import ovh_vrack.vrack order_id
+$ terraform import ovh_vrack.vrack service_name
 ```


### PR DESCRIPTION
# Description

Change the way we import a vRack to use its `service_name` instead of its `order_id`.

Related to [#618](https://github.com/ovh/terraform-provider-ovh/issues/618)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (improve existing resource(s) or datasource(s))
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or issues
- [x] I have added acceptance tests that prove my fix is effective or that my feature works
- [x] New and existing acceptance tests pass locally with my changes
- [x] I ran succesfully `go mod vendor` if I added or modify `go.mod` file
