### PR TITLE
Expose gateway's external information and interfaces

### DIFF
--- a/ovh/resource_cloud_project_gateway.go
+++ b/ovh/resource_cloud_project_gateway.go
@@ -74,6 +74,68 @@ func resourceCloudProjectGateway() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"external_information": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Description: "External information of the gateway",
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"network_id": {
+							Type:        schema.TypeString,
+							Description: "External network ID of the gateway",
+							Computed:    true,
+						},
+						"ips": {
+							Type:        schema.TypeList,
+							Description: "List of external ips of the gateway",
+							Computed:    true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"ip": {
+										Type:        schema.TypeString,
+										Description: "External IP of the gateway",
+										Computed:    true,
+									},
+									"subnet_id": {
+										Type:        schema.TypeString,
+										Description: "Subnet ID of the ip",
+										Computed:    true,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			"interfaces": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Description: "Interfaces list of the gateway",
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:        schema.TypeString,
+							Description: "ID of the interface",
+							Computed:    true,
+						},
+						"ip": {
+							Type:        schema.TypeString,
+							Description: "IP of the interface",
+							Computed:    true,
+						},
+						"network_id": {
+							Type:        schema.TypeString,
+							Description: "Network ID of the interface",
+							Computed:    true,
+						},
+						"subnet_id": {
+							Type:        schema.TypeString,
+							Description: "Subnet ID of the interface",
+							Computed:    true,
+						},
+					},
+				},
+			},
 		},
 	}
 }
@@ -163,7 +225,32 @@ func resourceCloudProjectGatewayRead(d *schema.ResourceData, meta interface{}) e
 	d.SetId(r.Id)
 	d.Set("service_name", serviceName)
 
-	// TODO : add response fields "externalInformation" and "interfaces"
+	externalInfos := make([]map[string]interface{}, 0)
+	if r.ExternalInformation != nil {
+		externalInfo := make(map[string]interface{})
+		ips := make([]map[string]interface{}, 0)
+		for _, externalIp := range r.ExternalInformation.Ips {
+			ip := make(map[string]interface{})
+			ip["ip"] = externalIp.Ip
+			ip["subnet_id"] = externalIp.SubnetId
+			ips = append(ips, ip)
+		}
+		externalInfo["ips"] = ips
+		externalInfo["network_id"] = r.ExternalInformation.NetworkId
+		externalInfos = append(externalInfos, externalInfo)
+	}
+	d.Set("external_information", externalInfos)
+
+	interfaces := make([]map[string]string, 0)
+	for _, responseInterface := range r.Interfaces {
+		itf := make(map[string]string)
+		itf["id"] = responseInterface.Id
+		itf["ip"] = responseInterface.Ip
+		itf["subnet_id"] = responseInterface.SubnetId
+		itf["network_id"] = responseInterface.NetworkId
+		interfaces = append(interfaces, itf)
+	}
+	d.Set("interfaces", interfaces)
 
 	log.Printf("[DEBUG] Read Public Cloud Gateway %+v", r)
 	return nil

--- a/ovh/resource_cloud_project_gateway_test.go
+++ b/ovh/resource_cloud_project_gateway_test.go
@@ -52,6 +52,7 @@ func TestAccCloudProjectGateway(t *testing.T) {
 	gatewayName := acctest.RandomWithPrefix(test_prefix)
 	vlanId := acctest.RandIntRange(100, 200)
 	region := os.Getenv("OVH_CLOUD_PROJECT_KUBE_REGION_TEST")
+	resourcePath := "ovh_cloud_project_gateway.gateway"
 
 	config := fmt.Sprintf(
 		testAccCloudProjectGatewayConfig,
@@ -76,13 +77,20 @@ func TestAccCloudProjectGateway(t *testing.T) {
 			{
 				Config: config,
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttrSet("ovh_cloud_project_gateway.gateway", "service_name"),
-					resource.TestCheckResourceAttrSet("ovh_cloud_project_gateway.gateway", "network_id"),
-					resource.TestCheckResourceAttrSet("ovh_cloud_project_gateway.gateway", "subnet_id"),
-					resource.TestCheckResourceAttrSet("ovh_cloud_project_gateway.gateway", "model"),
-					resource.TestCheckResourceAttr("ovh_cloud_project_gateway.gateway", "region", region),
-					resource.TestCheckResourceAttr("ovh_cloud_project_gateway.gateway", "name", gatewayName),
-					resource.TestCheckResourceAttr("ovh_cloud_project_gateway.gateway", "model", "s"),
+					resource.TestCheckResourceAttrSet(resourcePath, "service_name"),
+					resource.TestCheckResourceAttrSet(resourcePath, "network_id"),
+					resource.TestCheckResourceAttrSet(resourcePath, "subnet_id"),
+					resource.TestCheckResourceAttrSet(resourcePath, "model"),
+					resource.TestCheckResourceAttrSet(resourcePath, "external_information.0.network_id"),
+					resource.TestCheckResourceAttrSet(resourcePath, "external_information.0.ips.0.ip"),
+					resource.TestCheckResourceAttrSet(resourcePath, "external_information.0.ips.0.subnet_id"),
+					resource.TestCheckResourceAttrSet(resourcePath, "interfaces.0.id"),
+					resource.TestCheckResourceAttrSet(resourcePath, "interfaces.0.ip"),
+					resource.TestCheckResourceAttrSet(resourcePath, "interfaces.0.subnet_id"),
+					resource.TestCheckResourceAttrSet(resourcePath, "interfaces.0.network_id"),
+					resource.TestCheckResourceAttr(resourcePath, "region", region),
+					resource.TestCheckResourceAttr(resourcePath, "name", gatewayName),
+					resource.TestCheckResourceAttr(resourcePath, "model", "s"),
 				),
 			},
 		},

--- a/ovh/types_cloud.go
+++ b/ovh/types_cloud.go
@@ -35,7 +35,7 @@ type CloudProjectGatewayExternalIp struct {
 }
 
 type CloudProjectGatewayExternal struct {
-	Ips       []*CloudProjectGatewayExternalIp `json:"ip"`
+	Ips       []*CloudProjectGatewayExternalIp `json:"ips"`
 	NetworkId string                           `json:"networkId"`
 }
 

--- a/website/docs/r/cloud_project_gateway.html.markdown
+++ b/website/docs/r/cloud_project_gateway.html.markdown
@@ -58,6 +58,16 @@ The following attributes are exported:
 * `model` - See Argument Reference above.
 * `network_id` - See Argument Reference above.
 * `subnet_id` - See Argument Reference above.
+* `external_information` - List of External Information of the gateway.
+  * `network_id` - External network ID of the gateway.
+  * `ips` - List of external ips of the gateway.
+    * `ip` - External IP of the gateway.
+    * `subnet_id` - Subnet ID of the ip.
+* `interfaces` - Interfaces list of the gateway.
+  * `id` - ID of the interface.
+  * `ip` - IP of the interface.
+  * `network_id` - Network ID of the interface.
+  * `subnet_id` - Subnet ID of the interface.
 * `status` - Status of the gateway.
 
 ## Import


### PR DESCRIPTION
# Description

 * expose gateway's external information
 * expose gateway's interfaces
 * fix a mapping issue in the REST response of a gateway's external information

This is done to implement [this todo](https://github.com/ovh/terraform-provider-ovh/blob/f29ec136c6b9d2eeb2aa1fd492dc0b206923ce29/ovh/resource_cloud_project_gateway.go#L166).

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Improvement (improve existing resource(s) or datasource(s))
- [x] Documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

Run locally using my own OVH public cloud account.

**Test Configuration**:
* Terraform version: `terraform version`: Terraform v1.8.2
* Existing HCL configuration you used: 
```hcl
resource "ovh_cloud_project_network_private" "priv_net" {
        service_name = var.ovh_project_number
        name = "private_network"
        regions = ["GRA11", "RBX-A"]
}

resource "ovh_cloud_project_network_private_subnet" "priv_subnet" {
        service_name = var.ovh_project_number
        network_id = ovh_cloud_project_network_private.priv_net.id
        dhcp = true
        region = "GRA11"
        start = "12.0.0.2"
        end = "12.0.0.254"
        network = "12.0.0.0/24"
        no_gateway = false
}

resource "ovh_cloud_project_gateway" "subnet_gateway" {
        service_name = var.ovh_project_number
        name = "gateway-GRA11"
        model = "m"
        region = "GRA11"
        network_id = ovh_cloud_project_network_private.priv_net.regions_attributes[0].openstackid
        subnet_id = ovh_cloud_project_network_private_subnet.priv_subnet.id
}

```

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or issues
- [x] I have added acceptance tests that prove my fix is effective or that my feature works
- [x] New and existing acceptance tests pass locally with my changes
- [x] I ran succesfully `go mod vendor` if I added or modify `go.mod` file
