### PR TITLE
fix: Use URN returned by the API for me_identity_group

### DIFF
--- a/ovh/data_me_identity_group.go
+++ b/ovh/data_me_identity_group.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"net/url"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -37,6 +38,10 @@ func dataSourceMeIdentityGroup() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"urn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 		},
 	}
 }
@@ -46,7 +51,7 @@ func dataSourceMeIdentityGroupRead(ctx context.Context, d *schema.ResourceData, 
 
 	group := d.Get("name").(string)
 
-	endpoint := fmt.Sprintf("/me/identity/group/%s", group)
+	endpoint := fmt.Sprintf("/me/identity/group/%s", url.PathEscape(group))
 
 	var resp MeIdentityGroupResponse
 	err := config.OVHClient.GetWithContext(
@@ -68,6 +73,7 @@ func dataSourceMeIdentityGroupRead(ctx context.Context, d *schema.ResourceData, 
 	d.Set("creation", resp.Creation)
 	d.Set("description", resp.Description)
 	d.Set("role", resp.Role)
+	d.Set("urn", resp.URN)
 
 	return nil
 }

--- a/ovh/helpers/urn.go
+++ b/ovh/helpers/urn.go
@@ -2,10 +2,6 @@ package helpers
 
 import "fmt"
 
-const (
-	VPSkind string = "vps"
-)
-
 func ServiceURN(plate, kind, name string) string {
 	return fmt.Sprintf("urn:v1:%s:resource:%s:%s", plate, kind, name)
 }

--- a/ovh/resource_me_identity_group.go
+++ b/ovh/resource_me_identity_group.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"net/url"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -66,7 +67,7 @@ func resourceMeIdentityGroupRead(ctx context.Context, d *schema.ResourceData, me
 
 	identityGroup := &MeIdentityGroupResponse{}
 
-	endpoint := fmt.Sprintf("/me/identity/group/%s", d.Id())
+	endpoint := fmt.Sprintf("/me/identity/group/%s", url.PathEscape(d.Id()))
 	if err := config.OVHClient.GetWithContext(ctx, endpoint, identityGroup); err != nil {
 		return diag.FromErr(helpers.CheckDeleted(d, err, endpoint))
 	}
@@ -76,8 +77,7 @@ func resourceMeIdentityGroupRead(ctx context.Context, d *schema.ResourceData, me
 	d.Set("creation", identityGroup.Creation)
 	d.Set("description", identityGroup.Description)
 	d.Set("role", identityGroup.Role)
-
-	d.Set("urn", fmt.Sprintf("urn:v1:%s:identity:group:%s/%s", config.Plate, config.Account, identityGroup.Name))
+	d.Set("urn", identityGroup.URN)
 
 	return nil
 }
@@ -118,7 +118,7 @@ func resourceMeIdentityGroupUpdate(ctx context.Context, d *schema.ResourceData, 
 		Role:        role,
 	}
 	err := config.OVHClient.PutWithContext(ctx,
-		fmt.Sprintf("/me/identity/group/%s", d.Id()),
+		fmt.Sprintf("/me/identity/group/%s", url.PathEscape(d.Id())),
 		params,
 		nil,
 	)
@@ -134,7 +134,7 @@ func resourceMeIdentityGroupDelete(ctx context.Context, d *schema.ResourceData, 
 	config := meta.(*Config)
 
 	err := config.OVHClient.DeleteWithContext(ctx,
-		fmt.Sprintf("/me/identity/group/%s", d.Id()),
+		fmt.Sprintf("/me/identity/group/%s", url.PathEscape(d.Id())),
 		nil,
 	)
 	if err != nil {

--- a/ovh/types_me.go
+++ b/ovh/types_me.go
@@ -139,6 +139,7 @@ type MeIdentityGroupResponse struct {
 	Creation     string `json:"creation"`
 	Description  string `json:"description"`
 	LastUpdate   string `json:"lastUpdate"`
+	URN          string `json:"urn"`
 }
 
 type MeIdentityGroupCreateOpts struct {


### PR DESCRIPTION
# Description

- Add URN in datasource `ovh_me_identity_group`
- Use URN returned by the API in resource `ovh_me_identity_group`

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (improve existing resource(s) or datasource(s))
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

# How Has This Been Tested?

- [x] Test A: `make testacc TESTARGS="-run TestAccMeIdentityGroupDataSource_basic"`
- [x] Test B: `make testacc TESTARGS="-run TestAccMeIdentityGroup_basic"`
