### PR TITLE
fix: set ip_restrictions type to set on containerregistry_ip_restrict…

### DIFF
--- a/ovh/data_cloud_project_containerregistry_ip_restrictions_management.go
+++ b/ovh/data_cloud_project_containerregistry_ip_restrictions_management.go
@@ -24,7 +24,7 @@ func dataSourceCloudProjectContainerRegistryIPRestrictionsManagement() *schema.R
 				Required:    true,
 			},
 			"ip_restrictions": {
-				Type:        schema.TypeList,
+				Type:        schema.TypeSet,
 				Description: "List your IP restrictions applied on artifact manager component",
 				Computed:    true,
 				Elem: &schema.Schema{

--- a/ovh/data_cloud_project_containerregistry_ip_restrictions_management_test.go
+++ b/ovh/data_cloud_project_containerregistry_ip_restrictions_management_test.go
@@ -28,9 +28,9 @@ resource "ovh_cloud_project_containerregistry_ip_restrictions_management" "my-mg
   registry_id  = ovh_cloud_project_containerregistry.registry.id
 	
   ip_restrictions = [
-    { 
+    {
       ip_block = "121.121.121.121/32"
-      description = "my awesome ip"  
+      description = "my awesome ip"
     }
   ]
   depends_on = [

--- a/ovh/data_cloud_project_containerregistry_ip_restrictions_registry.go
+++ b/ovh/data_cloud_project_containerregistry_ip_restrictions_registry.go
@@ -24,7 +24,7 @@ func dataSourceCloudProjectContainerRegistryIPRestrictionsRegistry() *schema.Res
 				Required:    true,
 			},
 			"ip_restrictions": {
-				Type:        schema.TypeList,
+				Type:        schema.TypeSet,
 				Description: "List your IP restrictions applied on artifact manager component",
 				Computed:    true,
 				Elem: &schema.Schema{

--- a/ovh/data_cloud_project_containerregistry_ip_restrictions_registry_test.go
+++ b/ovh/data_cloud_project_containerregistry_ip_restrictions_registry_test.go
@@ -28,9 +28,9 @@ resource "ovh_cloud_project_containerregistry_ip_restrictions_registry" "my-regi
   registry_id  = ovh_cloud_project_containerregistry.registry.id
 	
   ip_restrictions = [
-    { 
+    {
       ip_block = "121.121.121.121/32"
-      description = "my awesome ip"  
+      description = "my awesome ip"
     }
   ]
   depends_on = [

--- a/ovh/resource_cloud_project_containerregistry.go
+++ b/ovh/resource_cloud_project_containerregistry.go
@@ -379,7 +379,8 @@ func waitForCloudProjectContainerRegistry(c *ovh.Client, serviceName, id string)
 		)
 		err := c.Get(endpoint, r)
 		if err != nil {
-			if err.(*ovh.APIError).Code == 404 {
+			ovhError, isOvhApiError := err.(*ovh.APIError)
+			if isOvhApiError && ovhError.Code == 404 {
 				log.Printf("[INFO] container registry id %s on project %s deleted", id, serviceName)
 				return r, "deleted", nil
 			} else {

--- a/ovh/resource_cloud_project_containerregistry_ip_restrictions_management.go
+++ b/ovh/resource_cloud_project_containerregistry_ip_restrictions_management.go
@@ -37,7 +37,7 @@ func resourceCloudProjectContainerRegistryIPRestrictionsManagement() *schema.Res
 				Required:    true,
 			},
 			"ip_restrictions": {
-				Type:        schema.TypeList,
+				Type:        schema.TypeSet,
 				Description: "List your IP restrictions applied on artifact manager component",
 				Required:    true,
 				Elem: &schema.Schema{

--- a/ovh/resource_cloud_project_containerregistry_ip_restrictions_registry.go
+++ b/ovh/resource_cloud_project_containerregistry_ip_restrictions_registry.go
@@ -37,7 +37,7 @@ func resourceCloudProjectContainerRegistryIPRestrictionsRegistry() *schema.Resou
 				Required:    true,
 			},
 			"ip_restrictions": {
-				Type:        schema.TypeList,
+				Type:        schema.TypeSet,
 				Description: "List your IP restrictions applied on artifact manager component",
 				Required:    true,
 				Elem: &schema.Schema{

--- a/ovh/types_cloud_project_containerregistry_ip_restrictions.go
+++ b/ovh/types_cloud_project_containerregistry_ip_restrictions.go
@@ -22,13 +22,15 @@ func (opts *CloudProjectContainerRegistryIPRestrictionCreateOpts) FromResource(d
 func loadIPRestrictionsFromResource(i interface{}) []CloudProjectContainerRegistryIPRestriction {
 	ips := make([]CloudProjectContainerRegistryIPRestriction, 0)
 
-	iprestrictionsSet := i.([]interface{})
+	iprestrictionsSet := i.(*schema.Set)
 
-	for _, ipSet := range iprestrictionsSet {
-		ips = append(ips, CloudProjectContainerRegistryIPRestriction{
-			Description: ipSet.(map[string]interface{})["description"].(string),
-			IPBlock:     ipSet.(map[string]interface{})["ip_block"].(string),
-		})
+	for _, ipSet := range iprestrictionsSet.List() {
+		if len(ipSet.(map[string]interface{})) > 0 {
+			ips = append(ips, CloudProjectContainerRegistryIPRestriction{
+				Description: ipSet.(map[string]interface{})["description"].(string),
+				IPBlock:     ipSet.(map[string]interface{})["ip_block"].(string),
+			})
+		}
 	}
 
 	return ips


### PR DESCRIPTION
…ions

# Description

Changes the type of ip_restrictions in containerregistry_ip_restrictions resources and data from `schema.TypeList` to `schema.TypeSet`.

Fixes #636 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Tests have been added to verify that the order of the ip_restrictions does not influence the configuration and the state. 

- [x] Test A: `make testacc TESTARGS="-run ^.*ContainerRegistry.*$"`

**Test Configuration**:
* Terraform version: `terraform version`: Terraform v1.5.6
* Existing HCL configuration you used: 

```hcl

terraform {
  required_providers {
    ovh = {
      source = "ovh/ovh"
      source = "terraform.local/local/ovh"
    }
  }
}

provider "ovh" {
  endpoint           = "ovh-eu"
  application_key    = "xxx"
  application_secret = "yyy"
  consumer_key       = "zzz"
}

data "ovh_cloud_project_capabilities_containerregistry_filter" "regcap" {
  service_name = "xxx"
  plan_name    = "SMALL"
  region       = "GRA"
}

resource "ovh_cloud_project_containerregistry" "registry" {
  service_name = data.ovh_cloud_project_capabilities_containerregistry_filter.regcap.service_name
  plan_id      = data.ovh_cloud_project_capabilities_containerregistry_filter.regcap.id
  region       = data.ovh_cloud_project_capabilities_containerregistry_filter.regcap.region
  name         = "mydockerregistry"
}

resource "ovh_cloud_project_containerregistry_ip_restrictions_management" "my-mgt-iprestrictions" {
  service_name = ovh_cloud_project_containerregistry.registry.service_name
  registry_id  = ovh_cloud_project_containerregistry.registry.id

  ip_restrictions = [
    {
      ip_block    = "192.168.0.1/32"
      description = "xxxxxxx"
    },
    {
      ip_block    = "192.168.0.3/32"
      description = "xxxxxxx"
    }
  ]
}

resource "ovh_cloud_project_containerregistry_ip_restrictions_registry" "my-registry-iprestrictions" {
  service_name = ovh_cloud_project_containerregistry.registry.service_name
  registry_id  = ovh_cloud_project_containerregistry.registry.id

  ip_restrictions = [
    {
      ip_block    = "192.168.0.1/32"
      description = "xxxxxxx"
    },
    {
      ip_block    = "192.168.0.4/32"
      description = "xxxxxxx"
    }
  ]
}


```

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or issues
- [x] I have added acceptance tests that prove my fix is effective or that my feature works
- [x] New and existing acceptance tests pass locally with my changes
- [x] I ran successfully `go mod vendor` if I added or modify `go.mod` file
