### PR TITLE
feat(iplb): add support for deniedSource on tcp frontends

### DIFF
--- a/ovh/resource_iploadbalancing_tcp_frontend.go
+++ b/ovh/resource_iploadbalancing_tcp_frontend.go
@@ -56,6 +56,11 @@ func resourceIpLoadbalancingTcpFrontend() *schema.Resource {
 				Optional: true,
 				ForceNew: false,
 			},
+			"denied_source": {
+				Type:     schema.TypeSet,
+				Optional: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
 			"disabled": {
 				Type:     schema.TypeBool,
 				Default:  false,
@@ -95,11 +100,18 @@ func resourceIpLoadbalancingTcpFrontendCreate(d *schema.ResourceData, meta inter
 	config := meta.(*Config)
 
 	allowedSources, _ := helpers.StringsFromSchema(d, "allowed_source")
+	deniedSources, _ := helpers.StringsFromSchema(d, "denied_source")
 	dedicatedIpFo, _ := helpers.StringsFromSchema(d, "dedicated_ipfo")
 
 	for _, s := range allowedSources {
 		if err := helpers.ValidateIpBlock(s); err != nil {
 			return fmt.Errorf("Error validating `allowed_source` value: %s", err)
+		}
+	}
+
+	for _, s := range deniedSources {
+		if err := helpers.ValidateIpBlock(s); err != nil {
+			return fmt.Errorf("Error validating `denied_source` value: %s", err)
 		}
 	}
 
@@ -114,6 +126,7 @@ func resourceIpLoadbalancingTcpFrontendCreate(d *schema.ResourceData, meta inter
 		Zone:          d.Get("zone").(string),
 		AllowedSource: allowedSources,
 		DedicatedIpFo: dedicatedIpFo,
+		DeniedSource:  deniedSources,
 		Disabled:      d.Get("disabled").(bool),
 		Ssl:           d.Get("ssl").(bool),
 		DisplayName:   d.Get("display_name").(string),
@@ -151,6 +164,9 @@ func resourceIpLoadbalancingTcpFrontendRead(d *schema.ResourceData, meta interfa
 	allowedSources := make([]string, 0)
 	allowedSources = append(allowedSources, r.AllowedSource...)
 
+	deniedSources := make([]string, 0)
+	deniedSources = append(deniedSources, r.DeniedSource...)
+
 	dedicatedIpFos := make([]string, 0)
 	dedicatedIpFos = append(dedicatedIpFos, r.DedicatedIpFo...)
 
@@ -163,6 +179,7 @@ func resourceIpLoadbalancingTcpFrontendRead(d *schema.ResourceData, meta interfa
 	d.Set("ssl", r.Ssl)
 	d.Set("zone", r.Zone)
 	d.Set("allowed_source", allowedSources)
+	d.Set("denied_source", deniedSources)
 
 	return nil
 }
@@ -173,11 +190,18 @@ func resourceIpLoadbalancingTcpFrontendUpdate(d *schema.ResourceData, meta inter
 	endpoint := fmt.Sprintf("/ipLoadbalancing/%s/tcp/frontend/%s", service, d.Id())
 
 	allowedSources, _ := helpers.StringsFromSchema(d, "allowed_source")
+	deniedSources, _ := helpers.StringsFromSchema(d, "denied_source")
 	dedicatedIpFo, _ := helpers.StringsFromSchema(d, "dedicated_ipfo")
 
 	for _, s := range allowedSources {
 		if err := helpers.ValidateIpBlock(s); err != nil {
 			return fmt.Errorf("Error validating `allowed_source` value: %s", err)
+		}
+	}
+
+	for _, s := range deniedSources {
+		if err := helpers.ValidateIpBlock(s); err != nil {
+			return fmt.Errorf("Error validating `denied_source` value: %s", err)
 		}
 	}
 
@@ -192,6 +216,7 @@ func resourceIpLoadbalancingTcpFrontendUpdate(d *schema.ResourceData, meta inter
 		Zone:          d.Get("zone").(string),
 		AllowedSource: allowedSources,
 		DedicatedIpFo: dedicatedIpFo,
+		DeniedSource:  deniedSources,
 		Disabled:      d.Get("disabled").(bool),
 		Ssl:           d.Get("ssl").(bool),
 		DisplayName:   d.Get("display_name").(string),

--- a/ovh/resource_iploadbalancing_tcp_frontend_test.go
+++ b/ovh/resource_iploadbalancing_tcp_frontend_test.go
@@ -86,6 +86,8 @@ func TestAccIpLoadbalancingTcpFrontend_basic(t *testing.T) {
 						"ovh_iploadbalancing_tcp_frontend.testfrontend", "disabled", "true"),
 					resource.TestCheckResourceAttr(
 						"ovh_iploadbalancing_tcp_frontend.testfrontend", "allowed_source.#", "0"),
+					resource.TestCheckResourceAttr(
+						"ovh_iploadbalancing_tcp_frontend.testfrontend", "denied_source.#", "0"),
 				),
 			},
 			{
@@ -101,6 +103,25 @@ func TestAccIpLoadbalancingTcpFrontend_basic(t *testing.T) {
 						"ovh_iploadbalancing_tcp_frontend.testfrontend", "disabled", "false"),
 					resource.TestCheckResourceAttr(
 						"ovh_iploadbalancing_tcp_frontend.testfrontend", "allowed_source.#", "1"),
+					resource.TestCheckResourceAttr(
+						"ovh_iploadbalancing_tcp_frontend.testfrontend", "denied_source.#", "0"),
+				),
+			},
+			{
+				Config: fmt.Sprintf(testAccCheckOvhIpLoadbalancingTcpFrontendConfig_denied_source, iplb, test_prefix),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(
+						"ovh_iploadbalancing_tcp_frontend.testfrontend", "display_name", test_prefix),
+					resource.TestCheckResourceAttr(
+						"ovh_iploadbalancing_tcp_frontend.testfrontend", "ssl", "false"),
+					resource.TestCheckResourceAttr(
+						"ovh_iploadbalancing_tcp_frontend.testfrontend", "port", "22280,22443"),
+					resource.TestCheckResourceAttr(
+						"ovh_iploadbalancing_tcp_frontend.testfrontend", "disabled", "false"),
+					resource.TestCheckResourceAttr(
+						"ovh_iploadbalancing_tcp_frontend.testfrontend", "allowed_source.#", "0"),
+					resource.TestCheckResourceAttr(
+						"ovh_iploadbalancing_tcp_frontend.testfrontend", "denied_source.#", "1"),
 				),
 			},
 			{
@@ -116,6 +137,8 @@ func TestAccIpLoadbalancingTcpFrontend_basic(t *testing.T) {
 						"ovh_iploadbalancing_tcp_frontend.testfrontend", "disabled", "true"),
 					resource.TestCheckResourceAttr(
 						"ovh_iploadbalancing_tcp_frontend.testfrontend", "allowed_source.#", "0"),
+					resource.TestCheckResourceAttr(
+						"ovh_iploadbalancing_tcp_frontend.testfrontend", "denied_source.#", "0"),
 				),
 			},
 		},
@@ -159,6 +182,16 @@ resource "ovh_iploadbalancing_tcp_frontend" "testfrontend" {
    zone           = "all"
    port           = "22280,22443"
    allowed_source = ["8.8.8.8/32"]
+}
+`
+
+const testAccCheckOvhIpLoadbalancingTcpFrontendConfig_denied_source = `
+resource "ovh_iploadbalancing_tcp_frontend" "testfrontend" {
+   service_name   = "%s"
+   display_name   = "%s"
+   zone           = "all"
+   port           = "22280,22443"
+   denied_source  = ["8.8.8.8/32"]
 }
 `
 

--- a/ovh/types_iploadbalancing.go
+++ b/ovh/types_iploadbalancing.go
@@ -499,6 +499,7 @@ type IpLoadbalancingTcpFrontend struct {
 	DedicatedIpFo []string `json:"dedicatedIpfo"`
 	DefaultFarmId *int     `json:"defaultFarmId,omitempty"`
 	DefaultSslId  *int     `json:"defaultSslId,omitempty"`
+	DeniedSource  []string `json:"deniedSource"`
 	Disabled      bool     `json:"disabled"`
 	Ssl           bool     `json:"ssl"`
 	DisplayName   string   `json:"displayName"`

--- a/website/docs/r/iploadbalancing_tcp_frontend.html.markdown
+++ b/website/docs/r/iploadbalancing_tcp_frontend.html.markdown
@@ -41,6 +41,7 @@ The following arguments are supported:
    and/or 'range'. Each port must be in the [1;49151] range
 * `zone` - (Required) Zone where the frontend will be defined (ie. `gra`, `bhs` also supports `all`)
 * `allowed_source` - Restrict IP Load Balancing access to these ip block. No restriction if null. List of IP blocks.
+* `denied_source` - Deny IP Load Balancing access to these ip block. No restriction if null. You cannot specify both `allowed_source` and `denied_source` at the same time. List of IP blocks.
 * `dedicated_ipfo` - Only attach frontend on these ip. No restriction if null. List of Ip blocks.
 * `default_farm_id` - Default TCP Farm of your frontend
 * `default_ssl_id` - Default ssl served to your customer
@@ -55,6 +56,7 @@ The following attributes are exported:
 * `id` - Id of your frontend
 * `display_name` - See Argument Reference above.
 * `allowed_source` - See Argument Reference above.
+* `denied_source` - See Argument Reference above.
 * `dedicated_ipfo` - See Argument Reference above.
 * `default_farm_id` - See Argument Reference above.
 * `default_ssl_id` - See Argument Reference above.


### PR DESCRIPTION
# Description

Adds support for the [`deniedSource` parameter](https://eu.api.ovh.com/console-preview/?section=%2FipLoadbalancing&branch=v1#post-/ipLoadbalancing/-serviceName-/tcp/frontend) on the IPLB tcp frontends

## Type of change

- [x] Improvement (improve existing resource(s) or datasource(s))

# How Has This Been Tested?

Tested update/refresh on my IPLB LB2 with configuration :

**Test Configuration**:
* Terraform version: `terraform version`: Terraform v1.8.1
* Existing HCL configuration you used: 
```hcl
resource "ovh_iploadbalancing_tcp_frontend" "frontend-rest-kmip" {
  service_name    = data.ovh_iploadbalancing.iplb-a.service_name
  display_name    = "${var.lbname}"
  zone                  = var.region
  port                   = "${var.rest_api_port}"
  ssl                     = false
  default_farm_id = ovh_iploadbalancing_tcp_farm.farm.id
  allowed_source = var.allowed_sources                                                                               
  denied_source  = length(var.allowed_sources) == 0 ? var.denied_sources : []
}

```

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings or issues
- [ ] I have added acceptance tests that prove my fix is effective or that my feature works
- [ ] New and existing acceptance tests pass locally with my changes
- [ ] I ran succesfully `go mod vendor` if I added or modify `go.mod` file
