### PR TITLE
fix: Add missing fields in ovh_cloud_project_kube datasource

### DIFF
--- a/ovh/data_cloud_project_kube.go
+++ b/ovh/data_cloud_project_kube.go
@@ -258,6 +258,14 @@ func dataSourceCloudProjectKube() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			kubeClusterLoadBalancersSubnetIdKey: {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			kubeClusterNodesSubnetIdKey: {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 		},
 	}
 }

--- a/website/docs/d/cloud_project_kube.html.markdown
+++ b/website/docs/d/cloud_project_kube.html.markdown
@@ -36,6 +36,8 @@ The following attributes are exported:
 * `region` - The OVHcloud public cloud region ID of the managed kubernetes cluster.
 * `version` - Kubernetes version of the managed kubernetes cluster.
 * `private_network_id` - OpenStack private network (or vrack) ID to use.
+* `load_balancers_subnet_id` - Openstack private network (or vRack) ID to use for load balancers.
+* `nodes_subnet_id` - Openstack private network (or vRack) ID to use for nodes.
 * `control_plane_is_up_to_date` - True if control-plane is up-to-date.
 * `is_up_to_date` - True if all nodes and control-plane are up-to-date.
 * `next_upgrade_versions` - Kubernetes versions available for upgrade.


### PR DESCRIPTION
# Description

Fixes an issue coming from https://github.com/ovh/terraform-provider-ovh/pull/661 : the added fields are missing in the related datasource.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (improve existing resource(s) or datasource(s))
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

# How Has This Been Tested?

- [ ] Test A: `make testacc TESTARGS="-run TestAccCloudProjectKubeDataSource_basic"`
