### PR TITLE
fix: resource DedicatedServerInstallTask: don't retry task if creation failed

### DIFF
--- a/ovh/resource_dedicated_server_install_task.go
+++ b/ovh/resource_dedicated_server_install_task.go
@@ -189,6 +189,11 @@ func resourceDedicatedServerInstallTaskCreate(d *schema.ResourceData, meta inter
 	task := &DedicatedServerTask{}
 
 	if err := config.OVHClient.Post(endpoint, opts, task); err != nil {
+		// If task was not created because of an error, return it immediately.
+		if task != nil && task.Id == 0 {
+			return fmt.Errorf("failed to create install task: %w", err)
+		}
+
 		// POST on install tasks can fail randomly so in order to avoid issues, let's allow
 		// a retry via waitForDedicatedServerTask
 		log.Printf("[WARN] Ignored error when calling POST %s: %v", endpoint, err)


### PR DESCRIPTION
# Description

When creating an install task, the returned error is ignored. We then try to fetch the task many times, even if the task was not created.

Fixes #671 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (improve existing resource(s) or datasource(s))
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

# How Has This Been Tested?

- [x] Test A: `make testacc TESTARGS="-run TestAccDedicatedServerInstall_basic"`
- [x] Test B: `make testacc TESTARGS="-run TestAccDedicatedServerInstall_rebootondestroy"`
- [x] Test C: `make testacc TESTARGS="-run TestAccDedicatedServerInstall_usermetadata"`