### PR TITLE
fix: ovh_domain_zone_record: wrong assertion in test + 0 ttl not sent

### DIFF
--- a/ovh/resource_domain_zone_record.go
+++ b/ovh/resource_domain_zone_record.go
@@ -18,7 +18,7 @@ type OvhDomainZoneRecord struct {
 	Id        int64  `json:"id,omitempty"`
 	Zone      string `json:"zone,omitempty"`
 	Target    string `json:"target"`
-	Ttl       int    `json:"ttl,omitempty"`
+	Ttl       int    `json:"ttl"`
 	FieldType string `json:"fieldType,omitempty"`
 	SubDomain string `json:"subDomain,omitempty"`
 }

--- a/ovh/resource_domain_zone_record_test.go
+++ b/ovh/resource_domain_zone_record_test.go
@@ -108,7 +108,7 @@ func TestAccDomainZoneRecord_Basic(t *testing.T) {
 			// provider shall send an error if the TTL is less than 60
 			{
 				Config:      testAccCheckOvhDomainZoneRecordConfig_CNAME(zone, subdomain, "google.com.", 10),
-				ExpectError: regexp.MustCompile(`must be greater`),
+				ExpectError: regexp.MustCompile(`must be either equal to 0 or, greater than or equal to 60`),
 			},
 			{
 				Config: testAccCheckOvhDomainZoneRecordConfig_A(zone, subdomain, "192.168.0.10", 3600),


### PR DESCRIPTION
# Description

Fixes two issues on resource `ovh_domain_zone_record`:
- When `ttl` is set to `0`, it is not sent at record creation
- Wrong error assertion in acceptance test

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (improve existing resource(s) or datasource(s))
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

# How Has This Been Tested?

- [x] Test A: `make testacc TESTARGS="-run TestAccDomainZoneRecord"`

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or issues
- [x] I have added acceptance tests that prove my fix is effective or that my feature works
- [x] New and existing acceptance tests pass locally with my changes
- [x] I ran succesfully `go mod vendor` if I added or modify `go.mod` file
