### PR TITLE
feat: add write_token field in resource/datasource ovh_dbaas_logs_output_graylog_stream

### DIFF
--- a/ovh/data_dbaas_logs_output_graylog_stream_test.go
+++ b/ovh/data_dbaas_logs_output_graylog_stream_test.go
@@ -52,6 +52,10 @@ func TestAccDataSourceDbaasLogsOutputGraylogStream_basic(t *testing.T) {
 						"title",
 						title,
 					),
+					resource.TestCheckResourceAttrSet(
+						"data.ovh_dbaas_logs_output_graylog_stream.stream",
+						"write_token",
+					),
 				),
 			},
 		},

--- a/ovh/resource_dbaas_logs_output_graylog_stream_test.go
+++ b/ovh/resource_dbaas_logs_output_graylog_stream_test.go
@@ -127,6 +127,10 @@ func TestAccResourceDbaasLogsOutputGraylogStream_basic(t *testing.T) {
 						"title",
 						title,
 					),
+					resource.TestCheckResourceAttrSet(
+						"ovh_dbaas_logs_output_graylog_stream.stream",
+						"write_token",
+					),
 				),
 			},
 		},

--- a/ovh/types_dbaas_logs_output_graylog_stream.go
+++ b/ovh/types_dbaas_logs_output_graylog_stream.go
@@ -155,3 +155,8 @@ func (opts *DbaasLogsOutputGraylogStreamUpdateOpts) FromResource(d *schema.Resou
 
 	return opts
 }
+
+type DbaasLogsOutputGraylogStreamRule struct {
+	Field string `json:"field"`
+	Value string `json:"value"`
+}

--- a/website/docs/d/dbaas_logs_output_graylog_stream.html.markdown
+++ b/website/docs/d/dbaas_logs_output_graylog_stream.html.markdown
@@ -46,3 +46,4 @@ data "ovh_dbaas_logs_output_graylog_stream" "stream" {
 * `stream_id` - Stream ID
 * `updated_at` - Stream last update
 * `web_socket_enabled` - Enable Websocket
+* `write_token` - Write token of the stream (empty if the caller is not the owner of the stream)

--- a/website/docs/r/dbaas_logs_graylog_output_stream.html.markdown
+++ b/website/docs/r/dbaas_logs_graylog_output_stream.html.markdown
@@ -48,3 +48,4 @@ Id is set to the output stream Id. In addition, the following attributes are exp
 * `nb_archive` - Number of coldstored archivesr
 * `stream_id` - Stream ID
 * `updated_at` - Stream last updater
+* `write_token` - Write token of the stream (empty if the caller is not the owner of the stream)


### PR DESCRIPTION
# Description

Added field `write_token` in resource and datasource `ovh_dbaas_logs_output_graylog_stream`.

Fixes #686

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (improve existing resource(s) or datasource(s))
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

# How Has This Been Tested?

- [x] Test A: `make testacc TESTARGS="-run TestAccDataSourceDbaasLogsOutputGraylogStream_basic"`
- [x] Test B: `make testacc TESTARGS="-run TestAccResourceDbaasLogsOutputGraylogStream_basic"`

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or issues
- [x] I have added acceptance tests that prove my fix is effective or that my feature works
- [x] New and existing acceptance tests pass locally with my changes
- [x] I ran succesfully `go mod vendor` if I added or modify `go.mod` file
