### PR TITLE
fix: correctly set cluster_id field in datasource ovh_dbaas_logs_cluster

### DIFF
--- a/ovh/data_dbaas_logs_cluster.go
+++ b/ovh/data_dbaas_logs_cluster.go
@@ -23,6 +23,7 @@ func dataSourceDbaasLogsCluster() *schema.Resource {
 			"cluster_id": {
 				Type:     schema.TypeString,
 				Optional: true,
+				Computed: true,
 			},
 			// Computed
 			"urn": {
@@ -137,8 +138,9 @@ func dataSourceDbaasLogsClusterRead(d *schema.ResourceData, meta interface{}) er
 		var err error
 		clusterId, err = dbaasGetClusterID(config, serviceName)
 		if err != nil {
-			return fmt.Errorf("Error retrieving clusterId for %s:\n\t %q", serviceName, err)
+			return fmt.Errorf("error retrieving cluster_id for %s:\n\t %q", serviceName, err)
 		}
+		d.Set("cluster_id", clusterId)
 	}
 
 	log.Printf("[DEBUG] Will read dbaas logs cluster %s/%s", serviceName, clusterId)
@@ -155,7 +157,7 @@ func dataSourceDbaasLogsClusterRead(d *schema.ResourceData, meta interface{}) er
 
 	res := map[string]interface{}{}
 	if err := config.OVHClient.Get(endpoint, &res); err != nil {
-		return fmt.Errorf("Error calling GET %s:\n\t %q", endpoint, err)
+		return fmt.Errorf("error calling GET %s:\n\t %q", endpoint, err)
 	}
 
 	d.Set("archive_allowed_networks", res["archiveAllowedNetworks"])

--- a/ovh/data_dbaas_logs_cluster_test.go
+++ b/ovh/data_dbaas_logs_cluster_test.go
@@ -8,19 +8,15 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 )
 
-const testAccDataSourceDbaasLogsCluster = `
-data "ovh_dbaas_logs_cluster" "ldp" {
-  service_name = "%s"
-  cluster_id   = "%s"
-}
-`
-
 func TestAccDataSourceDbaasLogsCluster(t *testing.T) {
 	serviceName := os.Getenv("OVH_DBAAS_LOGS_SERVICE_TEST")
 	clusterId := os.Getenv("OVH_DBAAS_LOGS_CLUSTER_ID")
 
-	config := fmt.Sprintf(
-		testAccDataSourceDbaasLogsCluster,
+	config := fmt.Sprintf(`
+		data "ovh_dbaas_logs_cluster" "ldp" {
+			service_name = "%s"
+			cluster_id   = "%s"
+		}`,
 		serviceName,
 		clusterId,
 	)
@@ -37,6 +33,46 @@ func TestAccDataSourceDbaasLogsCluster(t *testing.T) {
 						"data.ovh_dbaas_logs_cluster.ldp",
 						"service_name",
 						serviceName,
+					),
+					resource.TestCheckResourceAttr(
+						"data.ovh_dbaas_logs_cluster.ldp",
+						"cluster_id",
+						clusterId,
+					),
+				),
+			},
+		},
+	})
+}
+
+func TestAccDataSourceDbaasLogsClusterDefault(t *testing.T) {
+	serviceName := os.Getenv("OVH_DBAAS_LOGS_SERVICE_TEST")
+	clusterId := os.Getenv("OVH_DBAAS_LOGS_CLUSTER_ID")
+
+	config := fmt.Sprintf(`
+		data "ovh_dbaas_logs_cluster" "ldp" {
+			service_name = "%s"
+		}`,
+		serviceName,
+	)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() { testAccPreCheckDbaasLogsCluster(t) },
+
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(
+						"data.ovh_dbaas_logs_cluster.ldp",
+						"service_name",
+						serviceName,
+					),
+					resource.TestCheckResourceAttr(
+						"data.ovh_dbaas_logs_cluster.ldp",
+						"cluster_id",
+						clusterId,
 					),
 				),
 			},


### PR DESCRIPTION
# Description

When not defined in the configuration, the field `cluster_id` of datasource `ovh_dbaas_logs_cluster` was not set. 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (improve existing resource(s) or datasource(s))
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

# How Has This Been Tested?

- [x] Test A: `make testacc TESTARGS="-run TestAccDataSourceDbaasLogsCluster"`
- [x] Test B: `make testacc TESTARGS="-run TestAccDataSourceDbaasLogsClusterDefault"`