### PR TITLE
fix: CloudProjectLoadbalancerLogSubscription tests were failing

### DIFF
--- a/.cds/terraform-provider-ovh.yml
+++ b/.cds/terraform-provider-ovh.yml
@@ -375,6 +375,18 @@ workflow:
     pipeline: terraform-provider-ovh-testacc
     when:
     - success
+  Tests_CloudProjectLoadBalancer:
+    application: terraform-provider-ovh
+    depends_on:
+    - terraform-provider-ovh-pre-sweepers
+    environment: acctests
+    one_at_a_time: true
+    parameters:
+      testargs: -run CloudProjectLoadBalancer
+      skipthispipeline: "{{.workflow.terraform-provider-ovh.pip.skipthistest.cloudproject}}"
+    pipeline: terraform-provider-ovh-testacc
+    when:
+    - success
   Tests_DbaasLogs:
     application: terraform-provider-ovh
     depends_on:
@@ -756,6 +768,7 @@ workflow:
     - Tests_CloudProjectKube_basic
     - Tests_TestAccCloudProjectRegions
     - Tests_CloudProjectUser
+    - Tests_CloudProjectLoadBalancer
     - Tests_DbaasLogs
     - Tests_DedicatedCeph
     - Tests_TestAccDedicatedInstallationTemplate

--- a/ovh/data_cloud_project_region_loadbalancer_log_subscription_test.go
+++ b/ovh/data_cloud_project_region_loadbalancer_log_subscription_test.go
@@ -5,15 +5,17 @@ import (
 	"os"
 	"testing"
 
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 )
 
 func TestAccCloudProjectLoadBalancerGetLogSubscription_basic(t *testing.T) {
 	config := fmt.Sprintf(testAccCloudProjectSubscription,
+		os.Getenv("OVH_DBAAS_LOGS_SERVICE_TEST"),
+		acctest.RandomWithPrefix(test_prefix),
+		acctest.RandomWithPrefix(test_prefix),
 		os.Getenv("OVH_CLOUD_PROJECT_SERVICE_TEST"),
-		os.Getenv("OVH_CLOUD_PROJECT_WORKFLOW_BACKUP_REGION_TEST"),
 		os.Getenv("OVH_CLOUD_LOADBALANCER_ID_TEST"),
-		os.Getenv("OVH_CLOUD_STREAM_ID_TEST"),
 	)
 
 	resource.Test(t, resource.TestCase{
@@ -36,12 +38,18 @@ func TestAccCloudProjectLoadBalancerGetLogSubscription_basic(t *testing.T) {
 }
 
 var testAccCloudProjectSubscription = `
+resource "ovh_dbaas_logs_output_graylog_stream" "stream" {
+	service_name = "%s"
+	title        = "%s"
+	description  = "%s"
+}
+
 resource "ovh_cloud_project_region_loadbalancer_log_subscription" "subscription" {
 	service_name = "%s"
-	region_name = "%s"
+	region_name = "GRA11"
 	loadbalancer_id = "%s"
 	kind = "haproxy"
-	stream_id = "%s"
+	stream_id = ovh_dbaas_logs_output_graylog_stream.stream.stream_id
 }
 
 data "ovh_cloud_project_region_loadbalancer_log_subscription" "test" {

--- a/ovh/data_cloud_project_region_loadbalancer_log_subscriptions_test.go
+++ b/ovh/data_cloud_project_region_loadbalancer_log_subscriptions_test.go
@@ -5,15 +5,17 @@ import (
 	"os"
 	"testing"
 
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 )
 
 func TestAccCloudProjectLoadBalancerGetLogSubscriptions_basic(t *testing.T) {
 	config := fmt.Sprintf(testAccCloudProjectSubscriptions,
+		os.Getenv("OVH_DBAAS_LOGS_SERVICE_TEST"),
+		acctest.RandomWithPrefix(test_prefix),
+		acctest.RandomWithPrefix(test_prefix),
 		os.Getenv("OVH_CLOUD_PROJECT_SERVICE_TEST"),
-		os.Getenv("OVH_CLOUD_PROJECT_WORKFLOW_BACKUP_REGION_TEST"),
 		os.Getenv("OVH_CLOUD_LOADBALANCER_ID_TEST"),
-		os.Getenv("OVH_CLOUD_STREAM_ID_TEST"),
 	)
 
 	resource.Test(t, resource.TestCase{
@@ -35,12 +37,18 @@ func TestAccCloudProjectLoadBalancerGetLogSubscriptions_basic(t *testing.T) {
 }
 
 var testAccCloudProjectSubscriptions = `
+	resource "ovh_dbaas_logs_output_graylog_stream" "stream" {
+		service_name = "%s"
+		title        = "%s"
+		description  = "%s"
+	}
+
 	resource "ovh_cloud_project_region_loadbalancer_log_subscription" "subscription" {
 		service_name = "%s"
-		region_name = "%s"
+		region_name = "GRA11"
 		loadbalancer_id = "%s"
 		kind = "haproxy"
-		stream_id = "%s"
+		stream_id = ovh_dbaas_logs_output_graylog_stream.stream.stream_id
 	}
 
 	data "ovh_cloud_project_region_loadbalancer_log_subscriptions" "test" {

--- a/ovh/resource_cloud_project_region_loadbalancer_log_subscription.go
+++ b/ovh/resource_cloud_project_region_loadbalancer_log_subscription.go
@@ -117,6 +117,7 @@ func resourceCloudProjectRegionLoadbalancerSubscriptionsCreate(ctx context.Conte
 	}
 
 	d.SetId(*op.SubscriptionID)
+	d.Set("operation_id", res.OperationID)
 
 	return resourceCloudProjectRegionLoadbalancerSubscriptionsRead(ctx, d, meta)
 }
@@ -142,11 +143,10 @@ func resourceCloudProjectRegionLoadbalancerSubscriptionsRead(ctx context.Context
 	}
 
 	for k, v := range res.ToMap() {
-		if k != "subscription_id" {
-			d.Set(k, fmt.Sprint(v))
-		} else {
+		if k == "subscription_id" {
 			d.SetId(fmt.Sprint(v))
 		}
+		d.Set(k, fmt.Sprint(v))
 	}
 
 	log.Printf("[DEBUG] Read log subscrition %+v", res)
@@ -167,7 +167,7 @@ func resourceCloudProjectRegionLoadbalancerSubscriptionsDelete(ctx context.Conte
 		url.PathEscape(id),
 	)
 
-	res := &GetCloudProjectRegionLoadbalancerLogSubscriptioDeletionResponse{}
+	res := &GetCloudProjectRegionLoadbalancerLogSubscriptionDeletionResponse{}
 
 	log.Printf("[DEBUG] Will delete Log subscrition for loadbalancer %s on region %s from project %s", loadbalancerID, regionName, serviceName)
 	err := config.OVHClient.DeleteWithContext(ctx, endpoint, res)

--- a/ovh/resource_cloud_project_region_loadbalancer_log_subscription_test.go
+++ b/ovh/resource_cloud_project_region_loadbalancer_log_subscription_test.go
@@ -5,19 +5,30 @@ import (
 	"os"
 	"testing"
 
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 )
 
 func TestAccCloudProjectLoadBalancerLogSubscription_basic(t *testing.T) {
+	dbaasLogsServiceName := os.Getenv("OVH_DBAAS_LOGS_SERVICE_TEST")
+	cloudProject := os.Getenv("OVH_CLOUD_PROJECT_SERVICE_TEST")
+	loadBalancerId := os.Getenv("OVH_CLOUD_LOADBALANCER_ID_TEST")
+
 	var testCreateLoadBalancerLogSubscription = fmt.Sprintf(`
-		resource "ovh_cloud_project_region_loadbalancer_log_subscription" "CreateLogSubscription" {
-		service_name = "%s"
-		region_name = "GRA11"
-		loadbalancer_id = "%s"
-		kind = "haproxy"
-		stream_id = "%s"
+		resource "ovh_dbaas_logs_output_graylog_stream" "stream" {
+			service_name = "%s"
+			title        = "%s"
+			description  = "%s"
 		}
-`, os.Getenv("OVH_CLOUD_PROJECT_SERVICE_TEST"), os.Getenv("OVH_CLOUD_LOADBALANCER_ID_TEST"), os.Getenv("OVH_CLOUD_STREAM_ID_TEST"))
+
+		resource "ovh_cloud_project_region_loadbalancer_log_subscription" "CreateLogSubscription" {
+			service_name = "%s"
+			region_name = "GRA11"
+			loadbalancer_id = "%s"
+			kind = "haproxy"
+			stream_id = ovh_dbaas_logs_output_graylog_stream.stream.stream_id
+		}
+	`, dbaasLogsServiceName, acctest.RandomWithPrefix(test_prefix), acctest.RandomWithPrefix(test_prefix), cloudProject, loadBalancerId)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {

--- a/ovh/types_cloud_project_region_loadbalancer.go
+++ b/ovh/types_cloud_project_region_loadbalancer.go
@@ -12,7 +12,7 @@ type GetCloudProjectRegionLoadbalancerLogSubscriptionResponse struct {
 	UpdatedAt      string                                                        `json:"updatedAt"`
 }
 
-type GetCloudProjectRegionLoadbalancerLogSubscriptioDeletionResponse struct {
+type GetCloudProjectRegionLoadbalancerLogSubscriptionDeletionResponse struct {
 	OperationId string `json:"operationId"`
 	ServiceName string `json:"serviceName"`
 }
@@ -33,10 +33,12 @@ func (v CreateCloudProjectRegionLoadbalancerLogSubscriptionResponse) ToMap() map
 
 func (v GetCloudProjectRegionLoadbalancerLogSubscriptionResponse) ToMap() map[string]interface{} {
 	obj := make(map[string]interface{})
+	resourceMap := v.Resource.ToMap()
 
 	obj["created_at"] = v.CreatedAt
 	obj["kind"] = v.Kind
-	obj["resource_type"] = v.Resource.ToMap()
+	obj["resource_type"] = resourceMap["type"]
+	obj["resource_name"] = resourceMap["name"]
 	obj["ldp_service_name"] = v.LDPServiceName
 	obj["stream_id"] = v.StreamID
 	obj["subscription_id"] = v.SubscriptionID

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -267,8 +267,6 @@ variables must also be set:
 * `OVH_CLOUD_PROJECT_KUBE_VERSION_TEST` - The version of your public cloud kubernetes project.
 * `OVH_CLOUD_PROJECT_KUBE_PREV_VERSION_TEST` - The previous version of your public cloud kubernetes project. This is used to test upgrade.
 
-* `OVH_CLOUD_STREAM_ID_TEST` - The ID of the LogSubscription to use.
-
 * `OVH_DEDICATED_SERVER` - The name of the dedicated server to test dedicated_server_networking resource.
 
 * `OVH_NASHA_SERVICE_TEST` - The name of your HA-NAS service.


### PR DESCRIPTION
# Description

Fix tests of resource/datasources `ovh_cloud_project_region_loadbalancer_log_subscription`.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (improve existing resource(s) or datasource(s))
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

# How Has This Been Tested?

- [x] Test A: `make testacc TESTARGS="-run CloudProjectLoadBalancer"`