### PR TITLE
fix(hosting_privatedatabase_whitelist): Add default netmask when user do not define it

### DIFF
--- a/ovh/data_hosting_privatedatabase_whitelist.go
+++ b/ovh/data_hosting_privatedatabase_whitelist.go
@@ -60,7 +60,7 @@ func dataSourceHostingPrivateDatabaseWhitelist() *schema.Resource {
 func dataSourceHostingPrivateDatabaseWhitelistRead(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
 	serviceName := d.Get("service_name").(string)
-	ip := d.Get("ip").(string)
+	ip := HostingPrivateDatabaseWhitelistefaultNetmask(d.Get("ip").(string))
 
 	ds := &HostingPrivateDatabaseWhitelist{}
 	err := config.OVHClient.Get(

--- a/ovh/resource_hosting_privatedatabase_whitelist.go
+++ b/ovh/resource_hosting_privatedatabase_whitelist.go
@@ -54,7 +54,7 @@ func resourceHostingPrivateDatabaseWhitelist() *schema.Resource {
 func resourceHostingPrivateDatabaseWhitelistCreate(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
 	serviceName := d.Get("service_name").(string)
-	ip := d.Get("ip").(string)
+	ip := HostingPrivateDatabaseWhitelistefaultNetmask(d.Get("ip").(string))
 
 	opts := (&HostingPrivateDatabaseWhitelistCreateOpts{}).FromResource(d)
 	ds := &HostingPrivateDatabaseWhitelist{}
@@ -80,7 +80,7 @@ func resourceHostingPrivateDatabaseWhitelistCreate(d *schema.ResourceData, meta 
 func resourceHostingPrivateDatabaseWhitelistUpdate(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
 	serviceName := d.Get("service_name").(string)
-	ip := d.Get("ip").(string)
+	ip := HostingPrivateDatabaseWhitelistefaultNetmask(d.Get("ip").(string))
 
 	opts := (&HostingPrivateDatabaseWhitelistUpdateOpts{}).FromResource(d)
 
@@ -98,7 +98,7 @@ func resourceHostingPrivateDatabaseWhitelistUpdate(d *schema.ResourceData, meta 
 func resourceHostingPrivateDatabaseWhitelistRead(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
 	serviceName := d.Get("service_name").(string)
-	ip := d.Get("ip").(string)
+	ip := HostingPrivateDatabaseWhitelistefaultNetmask(d.Get("ip").(string))
 
 	ds := &HostingPrivateDatabaseWhitelist{}
 
@@ -119,7 +119,7 @@ func resourceHostingPrivateDatabaseWhitelistRead(d *schema.ResourceData, meta in
 func resourceHostingPrivateDatabaseWhitelistDelete(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
 	serviceName := d.Get("service_name").(string)
-	ip := d.Get("ip").(string)
+	ip := HostingPrivateDatabaseWhitelistefaultNetmask(d.Get("ip").(string))
 
 	ds := &HostingPrivateDatabaseWhitelist{}
 

--- a/ovh/types_hostingPrivatedatabase.go
+++ b/ovh/types_hostingPrivatedatabase.go
@@ -3,6 +3,7 @@ package ovh
 import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/ovh/terraform-provider-ovh/ovh/helpers"
+	"strings"
 )
 
 type HostingPrivateDatabase struct {
@@ -285,4 +286,11 @@ func (opts *HostingPrivateDatabaseWhitelistUpdateOpts) FromResource(d *schema.Re
 	opts.Sftp = d.Get("sftp").(bool)
 
 	return opts
+}
+
+func HostingPrivateDatabaseWhitelistefaultNetmask(ip string) string {
+	if !strings.Contains(ip, "/") {
+		ip = ip + "/32"
+	}
+	return ip
 }


### PR DESCRIPTION
# Description

OVH API v6 authorize to create a whitelist without a nemask but will add it if it's undefined.
Then, when you execute a plan/apply it throws an error

```sh
module.whitelist[0].ovh_hosting_privatedatabase_whitelist.whitelist: Creating...
╷
│ Error: calling /hosting/privateDatabase/om55704-038/whitelist/5.196.197.1:
│        OVHcloud API error (status code 400): Client::BadRequest: "[ip] Given data (w.x.y.z) is not valid for type ipv4Block" (X-OVH-Query-Id: EU.ext-xxxx)
│ 
│   with module.whitelist[0].ovh_hosting_privatedatabase_whitelist.whitelist,
│   on ../../modules/whitelist/main.tf line 1, in resource "ovh_hosting_privatedatabase_whitelist" "whitelist":
│    1: resource "ovh_hosting_privatedatabase_whitelist" "whitelist" {
│ 
```

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Improvement (improve existing resource(s) and datasource(s))

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Test A: `make testacc TESTARGS="-run TestAccDataSourceHostingPrivateDatabaseWhitelist_basic"`
- [x] Test B: `make testacc TESTARGS="-run TestAccHostingPrivateDatabaseWhitelist_basic"`

```sh
$ export OVH_HOSTING_PRIVATEDATABASE_WHITELIST_IP_TEST=w.x.y.z
$ make testacc TESTARGS="-run TestAccDataSourceHostingPrivateDatabaseWhitelist_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -run TestAccDataSourceHostingPrivateDatabaseWhitelist_basic -timeout 600m -p 10
?       github.com/ovh/terraform-provider-ovh   [no test files]
?       github.com/ovh/terraform-provider-ovh/ovh/helpers       [no test files]
?       github.com/ovh/terraform-provider-ovh/ovh/types [no test files]
=== RUN   TestAccDataSourceHostingPrivateDatabaseWhitelist_basic
--- PASS: TestAccDataSourceHostingPrivateDatabaseWhitelist_basic (182.06s)
PASS
ok      github.com/ovh/terraform-provider-ovh/ovh       182.071s
testing: warning: no tests to run
PASS
ok      github.com/ovh/terraform-provider-ovh/ovh/helpers/hashcode      (cached) [no tests to run]
```

```sh
$ export OVH_HOSTING_PRIVATEDATABASE_WHITELIST_IP_TEST=w.x.y.z/32
$ make testacc TESTARGS="-run TestAccDataSourceHostingPrivateDatabaseWhitelist_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -run TestAccDataSourceHostingPrivateDatabaseWhitelist_basic -timeout 600m -p 10
?       github.com/ovh/terraform-provider-ovh   [no test files]
?       github.com/ovh/terraform-provider-ovh/ovh/helpers       [no test files]
?       github.com/ovh/terraform-provider-ovh/ovh/types [no test files]
=== RUN   TestAccDataSourceHostingPrivateDatabaseWhitelist_basic
--- PASS: TestAccDataSourceHostingPrivateDatabaseWhitelist_basic (182.06s)
PASS
ok      github.com/ovh/terraform-provider-ovh/ovh       182.071s
testing: warning: no tests to run
PASS
ok      github.com/ovh/terraform-provider-ovh/ovh/helpers/hashcode      (cached) [no tests to run]
```

```sh
$ export OVH_HOSTING_PRIVATEDATABASE_WHITELIST_IP_TEST=w.x.y.z/32
$ make testacc TESTARGS="-run TestAccHostingPrivateDatabaseWhitelist_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -run TestAccHostingPrivateDatabaseWhitelist_basic -timeout 600m -p 10
?       github.com/ovh/terraform-provider-ovh   [no test files]
?       github.com/ovh/terraform-provider-ovh/ovh/helpers       [no test files]
?       github.com/ovh/terraform-provider-ovh/ovh/types [no test files]
=== RUN   TestAccHostingPrivateDatabaseWhitelist_basic
--- PASS: TestAccHostingPrivateDatabaseWhitelist_basic (9.01s)
PASS
ok      github.com/ovh/terraform-provider-ovh/ovh       9.029s
testing: warning: no tests to run
PASS
ok      github.com/ovh/terraform-provider-ovh/ovh/helpers/hashcode      (cached) [no tests to run]
```

```sh
$ export OVH_HOSTING_PRIVATEDATABASE_WHITELIST_IP_TEST=w.x.y.z
$ make testacc TESTARGS="-run TestAccHostingPrivateDatabaseWhitelist_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -run TestAccHostingPrivateDatabaseWhitelist_basic -timeout 600m -p 10
?       github.com/ovh/terraform-provider-ovh   [no test files]
?       github.com/ovh/terraform-provider-ovh/ovh/helpers       [no test files]
?       github.com/ovh/terraform-provider-ovh/ovh/types [no test files]
=== RUN   TestAccHostingPrivateDatabaseWhitelist_basic
--- PASS: TestAccHostingPrivateDatabaseWhitelist_basic (9.06s)
PASS
ok      github.com/ovh/terraform-provider-ovh/ovh       9.070s
testing: warning: no tests to run
PASS
ok      github.com/ovh/terraform-provider-ovh/ovh/helpers/hashcode      (cached) [no tests to run]
```
**Test Configuration**:
* Terraform version: `terraform version`: Terraform v1.9.3

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or issues
- [x] I have added acceptance tests that prove my fix is effective or that my feature works
- [x] New and existing acceptance tests pass locally with my changes
- [ ] I ran succesfully `go mod vendor` if I added or modify `go.mod` file
