### PR TITLE
feat: Allow vrack resource removal since termination is now available on the API

### DIFF
--- a/ovh/resource_vrack_test.go
+++ b/ovh/resource_vrack_test.go
@@ -9,9 +9,11 @@ import (
 )
 
 const testAccVrackBasic = `
+data "ovh_me" "myaccount" {}
+
 data "ovh_order_cart" "mycart" {
- ovh_subsidiary = "fr"
- description    = "%s"
+	ovh_subsidiary = data.ovh_me.myaccount.ovh_subsidiary
+	description    = "%s"
 }
 
 data "ovh_order_cart_product_plan" "vrack" {

--- a/website/docs/r/vrack.html.markdown
+++ b/website/docs/r/vrack.html.markdown
@@ -10,10 +10,7 @@ Orders a vrack.
 
 -> __NOTE__ To order a product through Terraform, your account needs to have a default payment method defined. This can be done in the [OVHcloud Control Panel](https://www.ovh.com/manager/#/dedicated/billing/payment/method) or via API with the [/me/payment/method](https://api.ovh.com/console/#/me/payment/method~GET) endpoint.
 
-~> __WARNING__ Currently, the OVHcloud API doesn't support Vrack termination. You have to open a support ticket to ask for vrack termination. Otherwise, you may hit vrack quota issues.
-
 ~> __WARNING__ `BANK_ACCOUNT` is not supported anymore, please update your default payment_method to `SEPA_DIRECT_DEBIT`
-
 
 ## Example Usage
 
@@ -66,7 +63,6 @@ The following arguments are supported:
   * `configuration` - (Optional) Representation of a configuration item for personalizing product
     * `label` - (Required) Identifier of the resource
     * `value` - (Required) Path to the resource in API.OVH.COM
-
 
 ## Attributes Reference
 


### PR DESCRIPTION
# Description

vRacks can now be terminated, so this PR adds removal capability on `ovh_vrack` resource.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Improvement (improve existing resource(s) or datasource(s))
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

# How Has This Been Tested?

- [ ] Test A: `make testacc TESTARGS="-run TestAccResourceVrack_basic"`

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or issues
- [x] I have added acceptance tests that prove my fix is effective or that my feature works
- [x] New and existing acceptance tests pass locally with my changes
- [x] I ran succesfully `go mod vendor` if I added or modify `go.mod` file
