### PR TITLE
IPLB HTTP farm resource: added uri as a possible balance value

### DIFF
--- a/ovh/resource_iploadbalancing_http_farm.go
+++ b/ovh/resource_iploadbalancing_http_farm.go
@@ -29,7 +29,7 @@ func resourceIpLoadbalancingHttpFarm() *schema.Resource {
 				Optional: true,
 				ForceNew: false,
 				ValidateFunc: func(v interface{}, k string) (ws []string, errors []error) {
-					err := helpers.ValidateStringEnum(v.(string), []string{"first", "leastconn", "roundrobin", "source"})
+					err := helpers.ValidateStringEnum(v.(string), []string{"first", "leastconn", "roundrobin", "source", "uri"})
 					if err != nil {
 						errors = append(errors, err)
 					}

--- a/website/docs/r/iploadbalancing_http_farm.html.markdown
+++ b/website/docs/r/iploadbalancing_http_farm.html.markdown
@@ -26,7 +26,7 @@ resource "ovh_iploadbalancing_http_farm" "farmname" {
 The following arguments are supported:
 
 * `service_name` - (Required) The internal name of your IP load balancing
-* `balance` - Load balancing algorithm. `roundrobin` if null (`first`, `leastconn`, `roundrobin`, `source`)
+* `balance` - Load balancing algorithm. `roundrobin` if null (`first`, `leastconn`, `roundrobin`, `source`, `uri`)
 * `display_name` - Readable label for loadbalancer farm
 * `port` - Port attached to your farm ([1..49151]). Inherited from frontend if null
 * `stickiness` - 	Stickiness type. No stickiness if null (`sourceIp`, `cookie`)


### PR DESCRIPTION
# Description

The IPLB HTTP farm resource should be able to use "uri" as a possible balance value.

## Type of change

- [*] Bug fix (non-breaking change which fixes an issue)

## misc
reference: https://eu.api.ovh.com/console/?section=%2FipLoadbalancing&branch=v1#post-/ipLoadbalancing/-serviceName-/http/farm
