### PR TITLE
fix: Add missing autoscaling params to resource ovh_dbaas_logs_input

### DIFF
--- a/ovh/resource_dbaas_logs_input.go
+++ b/ovh/resource_dbaas_logs_input.go
@@ -153,10 +153,26 @@ func resourceDbaasLogsInputSchema() map[string]*schema.Schema {
 			Computed:    true,
 		},
 		"nb_instance": {
+			Type:          schema.TypeInt,
+			Description:   "Number of instance running",
+			Optional:      true,
+			ConflictsWith: []string{"autoscale"},
+		},
+		"autoscale": {
+			Type:          schema.TypeBool,
+			Description:   "Whether the workload is auto-scaled",
+			Optional:      true,
+			ConflictsWith: []string{"nb_instance"},
+		},
+		"min_scale_instance": {
 			Type:        schema.TypeInt,
-			Description: "Number of instance running",
+			Description: "Minimum number of instances in auto-scaled mode",
 			Optional:    true,
-			Computed:    true,
+		},
+		"max_scale_instance": {
+			Type:        schema.TypeInt,
+			Description: "Maximum number of instances in auto-scaled mode",
+			Optional:    true,
 		},
 
 		// computed
@@ -201,6 +217,11 @@ func resourceDbaasLogsInputSchema() map[string]*schema.Schema {
 			Description: "Input last update",
 			Computed:    true,
 		},
+		"current_nb_instance": {
+			Type:        schema.TypeInt,
+			Description: "Number of instance running (returned by the API)",
+			Computed:    true,
+		},
 	}
 
 	return schema
@@ -210,7 +231,7 @@ func resourceDbaasLogsInputImportState(d *schema.ResourceData, meta interface{})
 	givenID := d.Id()
 	splitID := strings.SplitN(givenID, "/", 2)
 	if len(splitID) != 2 {
-		return nil, fmt.Errorf("Import Id is not service_name/id formatted")
+		return nil, fmt.Errorf("import ID is not service_name/id formatted")
 	}
 	serviceName := splitID[0]
 	id := splitID[1]
@@ -387,7 +408,7 @@ func dbaasLogsInputConfigurationUpdate(ctx context.Context, d *schema.ResourceDa
 			url.PathEscape(id),
 		)
 		if err := config.OVHClient.Put(endpoint, flowggerOpts, res); err != nil {
-			return fmt.Errorf("Error calling Put %s:\n\t %q", endpoint, err)
+			return fmt.Errorf("error calling Put %s:\n\t %q", endpoint, err)
 		}
 	}
 
@@ -401,7 +422,7 @@ func dbaasLogsInputConfigurationUpdate(ctx context.Context, d *schema.ResourceDa
 			url.PathEscape(id),
 		)
 		if err := config.OVHClient.Put(endpoint, logstashOpts, res); err != nil {
-			return fmt.Errorf("Error calling Put %s:\n\t %q", endpoint, err)
+			return fmt.Errorf("error calling Put %s:\n\t %q", endpoint, err)
 		}
 	}
 
@@ -486,7 +507,7 @@ func dbaasLogsInputStart(ctx context.Context, d *schema.ResourceData, meta inter
 			url.PathEscape(id),
 		)
 		if err := config.OVHClient.Post(endpoint, nil, res); err != nil {
-			return fmt.Errorf("Error calling Put %s:\n\t %q", endpoint, err)
+			return fmt.Errorf("error calling Put %s:\n\t %q", endpoint, err)
 		}
 	}
 
@@ -497,7 +518,7 @@ func dbaasLogsInputStart(ctx context.Context, d *schema.ResourceData, meta inter
 			url.PathEscape(id),
 		)
 		if err := config.OVHClient.Post(endpoint, nil, res); err != nil {
-			return fmt.Errorf("Error calling Put %s:\n\t %q", endpoint, err)
+			return fmt.Errorf("error calling Put %s:\n\t %q", endpoint, err)
 		}
 	}
 
@@ -538,7 +559,7 @@ func dbaasLogsInputEnd(ctx context.Context, d *schema.ResourceData, meta interfa
 		url.PathEscape(id),
 	)
 	if err := config.OVHClient.Post(endpoint, nil, res); err != nil {
-		return fmt.Errorf("Error calling Put %s:\n\t %q", endpoint, err)
+		return fmt.Errorf("error calling Put %s:\n\t %q", endpoint, err)
 	}
 
 	// Wait for operation status

--- a/ovh/types_dbaas_logs_input.go
+++ b/ovh/types_dbaas_logs_input.go
@@ -18,6 +18,9 @@ type DbaasLogsInput struct {
 	InputId           string   `json:"inputId"`
 	IsRestartRequired bool     `json:"isRestartRequired"`
 	NbInstance        *int64   `json:"nbInstance"`
+	Autoscale         bool     `json:"autoscale"`
+	MaxScaleInstance  *int     `json:"maxScaleInstance"`
+	MinScaleInstance  *int     `json:"minScaleInstance"`
 	PublicAddress     string   `json:"publicAddress"`
 	SslCertificate    string   `json:"sslCertificate"`
 	Status            string   `json:"status"`
@@ -40,6 +43,7 @@ func (v DbaasLogsInput) ToMap() map[string]interface{} {
 	obj["stream_id"] = v.StreamId
 	obj["title"] = v.Title
 	obj["updated_at"] = v.UpdatedAt
+	obj["autoscale"] = v.Autoscale
 
 	if v.AllowedNetworks != nil {
 		obj["allowed_networks"] = v.AllowedNetworks
@@ -48,20 +52,29 @@ func (v DbaasLogsInput) ToMap() map[string]interface{} {
 		obj["exposed_port"] = *v.ExposedPort
 	}
 	if v.NbInstance != nil {
-		obj["nb_instance"] = *v.NbInstance
+		obj["current_nb_instance"] = *v.NbInstance
+	}
+	if v.MaxScaleInstance != nil {
+		obj["max_scale_instance"] = *v.MaxScaleInstance
+	}
+	if v.MinScaleInstance != nil {
+		obj["min_scale_instance"] = *v.MinScaleInstance
 	}
 
 	return obj
 }
 
 type DbaasLogsInputOpts struct {
-	Description     string   `json:"description"`
-	EngineId        string   `json:"engineId"`
-	StreamId        string   `json:"streamId"`
-	Title           string   `json:"title"`
-	AllowedNetworks []string `json:"allowedNetworks,omitempty"`
-	ExposedPort     *string  `json:"exposedPort,omitempty"`
-	NbInstance      *int64   `json:"nbInstance,omitempty"`
+	Description      string   `json:"description"`
+	EngineId         string   `json:"engineId"`
+	StreamId         string   `json:"streamId"`
+	Title            string   `json:"title"`
+	AllowedNetworks  []string `json:"allowedNetworks,omitempty"`
+	ExposedPort      *string  `json:"exposedPort,omitempty"`
+	NbInstance       *int64   `json:"nbInstance,omitempty"`
+	Autoscale        bool     `json:"autoscale"`
+	MaxScaleInstance *int     `json:"maxScaleInstance,omitempty"`
+	MinScaleInstance *int     `json:"minScaleInstance,omitempty"`
 }
 
 func (opts *DbaasLogsInputOpts) FromResource(d *schema.ResourceData) *DbaasLogsInputOpts {
@@ -71,7 +84,7 @@ func (opts *DbaasLogsInputOpts) FromResource(d *schema.ResourceData) *DbaasLogsI
 	opts.Title = d.Get("title").(string)
 
 	networks := d.Get("allowed_networks").([]interface{})
-	if networks != nil && len(networks) > 0 {
+	if len(networks) > 0 {
 		networksString := make([]string, len(networks))
 		for i, net := range networks {
 			networksString[i] = net.(string)
@@ -81,6 +94,12 @@ func (opts *DbaasLogsInputOpts) FromResource(d *schema.ResourceData) *DbaasLogsI
 
 	opts.ExposedPort = helpers.GetNilStringPointerFromData(d, "exposed_port")
 	opts.NbInstance = helpers.GetNilInt64PointerFromData(d, "nb_instance")
+	if autoscale, ok := d.GetOk("autoscale"); ok {
+		opts.Autoscale = autoscale.(bool)
+	}
+	opts.MaxScaleInstance = helpers.GetNilIntPointerFromDataAndNilIfNotPresent(d, "max_scale_instance")
+	opts.MinScaleInstance = helpers.GetNilIntPointerFromDataAndNilIfNotPresent(d, "min_scale_instance")
+
 	return opts
 }
 

--- a/website/docs/r/dbaas_logs_input.html.markdown
+++ b/website/docs/r/dbaas_logs_input.html.markdown
@@ -63,7 +63,10 @@ The following arguments are supported:
 * `description` - (Required) Input description
 * `engine_id` - (Required) Input engine ID
 * `exposed_port` - Port
-* `nb_instance` - Number of instance running
+* `nb_instance` - Number of instance running (input, mutually exclusive with parameter `autoscale`)
+* `autoscale` - Whether the workload is auto-scaled (mutually exclusive with parameter `nb_instance`)
+* `min_scale_instance` - Minimum number of instances in auto-scaled mode
+* `max_scale_instance` - Maximum number of instances in auto-scaled mode
 * `service_name` - (Required) service name
 * `stream_id` - (Required) Associated Graylog stream
 * `title` - (Required) Input title
@@ -80,3 +83,4 @@ Id is set to the input Id. In addition, the following attributes are exported:
 * `ssl_certificate` - Input SSL certificate
 * `status` - init: configuration required, pending: ready to start, running: available
 * `updated_at` - Input last update
+* `current_nb_instance` - Number of instance running (returned by the API)


### PR DESCRIPTION
# Description

Fixes #714 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (improve existing resource(s) or datasource(s))
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

# How Has This Been Tested?

- [ ] Test A: `make testacc TESTARGS="-run TestAccResourceDbaasLogsInput_basic"`

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or issues
- [x] I have added acceptance tests that prove my fix is effective or that my feature works
- [x] New and existing acceptance tests pass locally with my changes
- [x] I ran succesfully `go mod vendor` if I added or modify `go.mod` file
