### PR TITLE
[DOC] Fix vrack name allowed

### DIFF
--- a/website/docs/r/vrack.html.markdown
+++ b/website/docs/r/vrack.html.markdown
@@ -30,7 +30,7 @@ data "ovh_order_cart_product_plan" "vrack" {
 
 resource "ovh_vrack" "vrack" {
   ovh_subsidiary = data.ovh_order_cart.mycart.ovh_subsidiary
-  name           = "my vrack"
+  name           = "my-vrack"
   description    = "my vrack"
 
   plan {


### PR DESCRIPTION
# Description

It appears that we can't name a vrack "my name".

```
$ terraform apply
data.ovh_me.myaccount: Reading...
data.ovh_me.myaccount: Read complete after 0s [id=xxxxxxx-ovh]
data.ovh_order_cart.mycart: Reading...
data.ovh_order_cart.mycart: Read complete after 0s [id=xxxxx-xxxx-xxxx-xxxx-xxxxxxxx]
data.ovh_order_cart_product_plan.vrack: Reading...
data.ovh_order_cart_product_plan.vrack: Read complete after 0s [id=vrack]

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # ovh_vrack.vrack will be created
  + resource "ovh_vrack" "vrack" {
      + description    = "my vrack"
      + id             = (known after apply)
      + name           = "my vrack"
      + ovh_subsidiary = "FR"
      + service_name   = (known after apply)
      + urn            = (known after apply)

      + plan {
          + duration     = "P1M"
          + plan_code    = "vrack"
          + pricing_mode = "default"
        }
    }

Plan: 1 to add, 0 to change, 0 to destroy.

Do you want to perform these actions?
  Terraform will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: yes

ovh_vrack.vrack: Creating...
ovh_vrack.vrack: Still creating... [10s elapsed]
ovh_vrack.vrack: Still creating... [20s elapsed]
ovh_vrack.vrack: Still creating... [30s elapsed]
ovh_vrack.vrack: Still creating... [40s elapsed]
ovh_vrack.vrack: Still creating... [50s elapsed]
ovh_vrack.vrack: Still creating... [1m0s elapsed]
ovh_vrack.vrack: Still creating... [1m10s elapsed]
ovh_vrack.vrack: Still creating... [1m20s elapsed]
╷
│ Error: calling Put /vrack/pn-1181464: "OVHcloud API error (status code 404): \"name is not in conformity\" (X-OVH-Query-Id: EU.ext-4.66ed1a36.5607.c5d21b92b48b2d2c4ba9ee8089c576a4)"
│
│   with ovh_vrack.vrack,
│   on kube_private.tf line 24, in resource "ovh_vrack" "vrack":
│   24: resource "ovh_vrack" "vrack" {
│
╵
```

Changing the name to "my-vrack" fixed the issue.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (improve existing resource(s) or datasource(s))
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
