### PR TITLE
subnet v2 resource (regionalized API)

### DIFF
--- a/ovh/helpers/helpers.go
+++ b/ovh/helpers/helpers.go
@@ -403,24 +403,8 @@ func StringsFromSchema(d *schema.ResourceData, id string) ([]string, error) {
 func StringMapFromSchema(d *schema.ResourceData, id string, keys ...string) ([]map[string]string, error) {
 	xs := []map[string]string{}
 	if v := d.Get(id); v != nil {
-		switch vv := v.(type) {
-		case *schema.Set:
-			rs := vv.List()
-			if len(rs) > 0 {
-				for _, vvv := range vv.List() {
-					if mapValue, ok := vvv.(map[string]string); ok {
-						for _, key := range keys {
-							if _, ok := mapValue[key]; !ok {
-								return nil, fmt.Errorf("invalid value in field %s: %v: expected key: %s", id, vvv, key)
-							}
-						}
-						xs = append(xs, mapValue)
-					} else {
-						return nil, fmt.Errorf("invalid value in field %s: %v: expected a map", id, vvv)
-					}
-				}
-			}
-		case []interface{}:
+		vv, ok := v.([]interface{})
+		if ok {
 			for _, vvv := range vv {
 				if mapValue, ok := vvv.(map[string]interface{}); ok {
 					mapStringValue := map[string]string{}
@@ -440,7 +424,7 @@ func StringMapFromSchema(d *schema.ResourceData, id string, keys ...string) ([]m
 					return nil, fmt.Errorf("invalid value in field %s: %v: expected a map", id, vvv)
 				}
 			}
-		default:
+		} else {
 			return nil, fmt.Errorf("attribute %v is not a list or set", id)
 		}
 	}

--- a/ovh/helpers/helpers.go
+++ b/ovh/helpers/helpers.go
@@ -400,6 +400,53 @@ func StringsFromSchema(d *schema.ResourceData, id string) ([]string, error) {
 	return xs, nil
 }
 
+func StringMapFromSchema(d *schema.ResourceData, id string, keys ...string) ([]map[string]string, error) {
+	xs := []map[string]string{}
+	if v := d.Get(id); v != nil {
+		switch vv := v.(type) {
+		case *schema.Set:
+			rs := vv.List()
+			if len(rs) > 0 {
+				for _, vvv := range vv.List() {
+					if mapValue, ok := vvv.(map[string]string); ok {
+						for _, key := range keys {
+							if _, ok := mapValue[key]; !ok {
+								return nil, fmt.Errorf("invalid value in field %s: %v: expected key: %s", id, vvv, key)
+							}
+						}
+						xs = append(xs, mapValue)
+					} else {
+						return nil, fmt.Errorf("invalid value in field %s: %v: expected a map", id, vvv)
+					}
+				}
+			}
+		case []interface{}:
+			for _, vvv := range vv {
+				if mapValue, ok := vvv.(map[string]interface{}); ok {
+					mapStringValue := map[string]string{}
+					for _, key := range keys {
+						vvvv, ok := mapValue[key]
+						if !ok {
+							return nil, fmt.Errorf("invalid value in field %s: %v: expected key: %s", id, vvv, key)
+						}
+						value, ok := vvvv.(string)
+						if !ok {
+							return nil, fmt.Errorf("invalid value in field %s with key %s: expected string: %s", id, key, vvvv)
+						}
+						mapStringValue[key] = value
+					}
+					xs = append(xs, mapStringValue)
+				} else {
+					return nil, fmt.Errorf("invalid value in field %s: %v: expected a map", id, vvv)
+				}
+			}
+		default:
+			return nil, fmt.Errorf("attribute %v is not a list or set", id)
+		}
+	}
+	return xs, nil
+}
+
 // WaitAvailable wait for a ressource to become available in the API (aka non 404)
 func WaitAvailable(client *ovh.Client, endpoint string, timeout time.Duration) error {
 	return resource.Retry(timeout, func() *resource.RetryError {

--- a/ovh/provider.go
+++ b/ovh/provider.go
@@ -212,6 +212,7 @@ func Provider() *schema.Provider {
 			"ovh_cloud_project_kube_iprestrictions":                          resourceCloudProjectKubeIpRestrictions(),
 			"ovh_cloud_project_network_private":                              resourceCloudProjectNetworkPrivate(),
 			"ovh_cloud_project_network_private_subnet":                       resourceCloudProjectNetworkPrivateSubnet(),
+			"ovh_cloud_project_network_private_subnet_v2":                    resourceCloudProjectNetworkPrivateSubnetV2(),
 			"ovh_cloud_project_region_storage_presign":                       resourceCloudProjectRegionStoragePresign(),
 			"ovh_cloud_project_region_loadbalancer_log_subscription":         resourceCloudProjectRegionLoadbalancerLogSubscription(),
 			"ovh_cloud_project_user":                                         resourceCloudProjectUser(),

--- a/ovh/resource_cloud_project_network_private_subnet_v2.go
+++ b/ovh/resource_cloud_project_network_private_subnet_v2.go
@@ -1,0 +1,267 @@
+package ovh
+
+import (
+	"fmt"
+	"log"
+	"net/url"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/ovh/terraform-provider-ovh/ovh/helpers"
+)
+
+func resourceOvhCloudProjectNetworkPrivateSubnetV2ImportState(
+	d *schema.ResourceData,
+	meta interface{}) ([]*schema.ResourceData, error) {
+	givenId := d.Id()
+	splitId := strings.SplitN(givenId, "/", 3)
+	if len(splitId) != 3 {
+		return nil, fmt.Errorf("Import Id is not service_name/network_id/subnet_id formatted")
+	}
+	d.SetId(splitId[2])
+	d.Set("network_id", splitId[1])
+	d.Set("service_name", splitId[0])
+	results := make([]*schema.ResourceData, 1)
+	results[0] = d
+	log.Printf(
+		"[DEBUG] Will Import ovh_cloud_project_network_private_subnet with project %s, network %s, id %s",
+		d.Get("service_name"),
+		d.Get("network_id"),
+		d.Id(),
+	)
+	return results, nil
+}
+
+func resourceCloudProjectNetworkPrivateSubnetV2() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceCloudProjectNetworkPrivateSubnetV2Create,
+		Read:   resourceCloudProjectNetworkPrivateSubnetV2Read,
+		Delete: resourceCloudProjectNetworkPrivateSubnetV2Delete,
+		Importer: &schema.ResourceImporter{
+			State: resourceOvhCloudProjectNetworkPrivateSubnetV2ImportState,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"service_name": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				DefaultFunc: schema.EnvDefaultFunc("OVH_CLOUD_PROJECT_SERVICE", nil),
+				Description: "Service name of the resource representing the id of the cloud project.",
+			},
+			"network_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"region": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"dhcp": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				ForceNew: true,
+				Default:  true,
+			},
+			"cidr": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: resourceCloudProjectNetworkPrivateSubnetValidateNetwork,
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"gateway_ip": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+				Computed: true,
+			},
+			"enable_gateway_ip": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				ForceNew: true,
+				Default:  true,
+			},
+			"dns_nameservers": {
+				Type:     schema.TypeList,
+				Optional: true,
+				ForceNew: true,
+				Elem: &schema.Schema{
+					Type:         schema.TypeString,
+					ValidateFunc: resourceCloudProjectNetworkPrivateSubnetValidateIP,
+				},
+				Description: "List of DNS nameservers, default: 213.186.33.99",
+			},
+			"host_routes": {
+				Type:     schema.TypeList,
+				Optional: true,
+				ForceNew: true,
+				Elem: &schema.Schema{
+					Type: schema.TypeMap,
+					Set:  schema.HashString,
+				},
+			},
+			"allocation_pools": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+				Elem: &schema.Schema{
+					Type: schema.TypeMap,
+					Set:  schema.HashString,
+				},
+			},
+		},
+	}
+}
+
+func resourceCloudProjectNetworkPrivateSubnetV2Create(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+	serviceName := d.Get("service_name").(string)
+	regionName := d.Get("region").(string)
+	networkId := d.Get("network_id").(string)
+	subnetName := d.Get("name").(string)
+	cidr := d.Get("cidr").(string)
+	enableGatewayIP := d.Get("enable_gateway_ip").(bool)
+	enableDHCP := d.Get("dhcp").(bool)
+	gatewayIp := d.Get("gateway_ip").(string)
+
+	hostRoutesStrings, err := helpers.StringMapFromSchema(d, "host_routes", "destination", "nexthop")
+	if err != nil {
+		return err
+	}
+
+	hostRoutes := []HostRoute{}
+	for _, hostRouteStrings := range hostRoutesStrings {
+		hostRoutes = append(hostRoutes, HostRoute{
+			Destination: hostRouteStrings["destination"],
+			Nexthop:     hostRouteStrings["nexthop"],
+		})
+	}
+
+	allocationPoolsStrings, err := helpers.StringMapFromSchema(d, "allocation_pools", "start", "end")
+	if err != nil {
+		return err
+	}
+
+	allocationPools := []AllocationPool{}
+	for _, allocationPoolStrings := range allocationPoolsStrings {
+		allocationPools = append(allocationPools, AllocationPool{
+			Start: allocationPoolStrings["start"],
+			End:   allocationPoolStrings["end"],
+		})
+	}
+
+	dnsNameServers, err := helpers.StringsFromSchema(d, "dns_nameservers")
+	if err != nil {
+		return err
+	}
+
+	createSubnetParams := &CloudProjectNetworkPrivateV2CreateOpts{
+		Name:            subnetName,
+		Cidr:            cidr,
+		IpVersion:       4,
+		AllocationPools: allocationPools,
+		DnsNameServers:  dnsNameServers,
+		GatewayIp:       gatewayIp,
+		EnableGatewayIP: enableGatewayIP,
+		EnableDHCP:      enableDHCP,
+		HostRoutes:      hostRoutes,
+	}
+
+	subnetResponse := &CloudProjectNetworkPrivateV2Response{}
+	endpointPostSubnet := fmt.Sprintf("/cloud/project/%s/region/%s/network/%s/subnet",
+		url.PathEscape(serviceName),
+		url.PathEscape(regionName),
+		url.PathEscape(networkId),
+	)
+	err = config.OVHClient.Post(endpointPostSubnet, createSubnetParams, subnetResponse)
+	if err != nil {
+		return fmt.Errorf("calling POST %s with params %v:\n\t %q", endpointPostSubnet, createSubnetParams, err)
+	}
+
+	d.Set("gateway_ip", subnetResponse.GatewayIp)
+	d.Set("cidr", subnetResponse.Cidr)
+	d.Set("enable_gateway_ip", subnetResponse.GatewayIp != nil)
+	d.Set("service_name", serviceName)
+	d.Set("network_id", networkId)
+	d.Set("dhcp", subnetResponse.DHCPEnabled)
+	d.Set("region", regionName)
+	d.SetId(subnetResponse.Id)
+	log.Printf("[DEBUG] Read Public Cloud Private Network %v", subnetResponse)
+	return nil
+}
+
+func resourceCloudProjectNetworkPrivateSubnetV2Read(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+	serviceName := d.Get("service_name").(string)
+	networkId := d.Get("network_id").(string)
+	regionName := d.Get("region").(string)
+
+	subnets := []*CloudProjectNetworkPrivateV2Response{}
+
+	log.Printf("[DEBUG] Will read public cloud private network subnet for project: %s, region: %s, network: %s, id: %s", serviceName, regionName, networkId, d.Id())
+
+	endpoint := fmt.Sprintf("/cloud/project/%s/region/%s/network/%s/subnet", serviceName, regionName, networkId)
+
+	if err := config.OVHClient.Get(endpoint, &subnets); err != nil {
+		return helpers.CheckDeleted(d, err, endpoint)
+	}
+
+	var r *CloudProjectNetworkPrivateV2Response
+	for i := range subnets {
+		if subnets[i].Id == d.Id() {
+			r = subnets[i]
+			break
+		}
+	}
+
+	if r == nil {
+		d.SetId("")
+		return nil
+	}
+
+	d.Set("gateway_ip", r.GatewayIp)
+	d.Set("cidr", r.Cidr)
+	d.Set("dhcp", r.DHCPEnabled)
+	d.Set("enable_gateway_ip", r.GatewayIp != nil)
+	d.Set("service_name", serviceName)
+	d.Set("network_id", networkId)
+	d.Set("region", regionName)
+	d.SetId(r.Id)
+	log.Printf("[DEBUG] Read Public Cloud Private Network %v", r)
+	return nil
+}
+
+func resourceCloudProjectNetworkPrivateSubnetV2Delete(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+
+	serviceName := d.Get("service_name").(string)
+	networkId := d.Get("network_id").(string)
+	regionName := d.Get("region").(string)
+	id := d.Id()
+
+	log.Printf("[DEBUG] Will delete public cloud private network subnet V2 for project: %s, region: %s, network: %s, id: %s", serviceName, regionName, networkId, id)
+
+	endpoint := fmt.Sprintf("/cloud/project/%s/region/%s/network/%s/subnet/%s",
+		url.PathEscape(serviceName),
+		url.PathEscape(regionName),
+		url.PathEscape(networkId),
+		url.PathEscape(id),
+	)
+
+	if err := config.OVHClient.Delete(endpoint, nil); err != nil {
+		return fmt.Errorf("calling DELETE %s:\n\t %q", endpoint, err)
+	}
+
+	d.SetId("")
+
+	log.Printf("[DEBUG] Deleted Public Cloud %s Private Network %s Subnet %s", serviceName, networkId, id)
+	return nil
+}

--- a/ovh/resource_cloud_project_network_private_subnet_v2.go
+++ b/ovh/resource_cloud_project_network_private_subnet_v2.go
@@ -92,7 +92,7 @@ func resourceCloudProjectNetworkPrivateSubnetV2() *schema.Resource {
 			},
 			"enable_gateway_ip": {
 				Type:        schema.TypeBool,
-				Optional:    true,
+				Required:    true,
 				ForceNew:    true,
 				Default:     true,
 				Description: "Enable gateway IP in subnet",

--- a/ovh/resource_cloud_project_network_private_subnet_v2_test.go
+++ b/ovh/resource_cloud_project_network_private_subnet_v2_test.go
@@ -10,7 +10,6 @@ import (
 
 func testAccCloudProjectNetworkPrivateV2SubnetConfig(config string) string {
 	var testAccCloudProjectNetworkPrivateSubnetV2Config_attachVrack = `
-	
 	resource "ovh_vrack_cloudproject" "attach" {
 		service_name = "%s"
 		project_id   = "%s"
@@ -35,7 +34,6 @@ func testAccCloudProjectNetworkPrivateV2SubnetConfig(config string) string {
 	)
 
 	var testAccCloudProjectNetworkPrivateSubnetV2Config_noAttachVrack = `
-	
 	data "ovh_cloud_project_regions" "regions" {
 		service_name = "%s"
 		has_services_up = ["network"]

--- a/ovh/resource_cloud_project_network_private_subnet_v2_test.go
+++ b/ovh/resource_cloud_project_network_private_subnet_v2_test.go
@@ -1,0 +1,130 @@
+package ovh
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+var testAccCloudProjectNetworkPrivateSubnetV2Config_attachVrack = `
+resource "ovh_vrack_cloudproject" "attach" {
+  service_name = "%s"
+  project_id   = "%s"
+}
+
+data "ovh_cloud_project_regions" "regions" {
+  service_name = ovh_vrack_cloudproject.attach.project_id
+
+  has_services_up = ["network"]
+}
+
+resource "ovh_cloud_project_network_private" "network" {
+  service_name = ovh_vrack_cloudproject.attach.project_id
+  vlan_id    = 1
+  name       = "terraform_testacc_private_net"
+  regions    = slice(sort(tolist(data.ovh_cloud_project_regions.regions.names)), 0, 3)
+}
+`
+
+var testAccCloudProjectNetworkPrivateSubnetV2Config_noAttachVrack = `
+data "ovh_cloud_project_regions" "regions" {
+  service_name = "%s"
+
+  has_services_up = ["network"]
+}
+
+resource "ovh_cloud_project_network_private" "network" {
+  service_name = data.ovh_cloud_project_regions.regions.service_name
+  vlan_id    = 1
+  name       = "terraform_testacc_private_net"
+  regions    = slice(sort(tolist(data.ovh_cloud_project_regions.regions.names)), 0, 3)
+}
+`
+
+func testAccCloudProjectNetworkPrivateV2SubnetConfig(config string) string {
+	attachVrack := fmt.Sprintf(
+		testAccCloudProjectNetworkPrivateSubnetV2Config_attachVrack,
+		os.Getenv("OVH_VRACK_SERVICE_TEST"),
+		os.Getenv("OVH_CLOUD_PROJECT_SERVICE_TEST"),
+	)
+	noAttachVrack := fmt.Sprintf(
+		testAccCloudProjectNetworkPrivateSubnetV2Config_noAttachVrack,
+		os.Getenv("OVH_CLOUD_PROJECT_SERVICE_TEST"),
+	)
+
+	if os.Getenv("OVH_ATTACH_VRACK") == "0" {
+		return fmt.Sprintf(
+			config,
+			noAttachVrack,
+		)
+	}
+
+	return fmt.Sprintf(
+		config,
+		attachVrack,
+	)
+}
+
+var testAccCloudProjectNetworkPrivateSubnetV2Config_basic = `
+%s
+
+resource "ovh_cloud_project_network_private_subnet_v2" "subnet" {
+  service_name = ovh_cloud_project_network_private.network.service_name
+
+  # whatever region, for test purpose
+  network_id        = element(tolist(ovh_cloud_project_network_private.network.regions_attributes), 0).openstackid
+  region            = element(tolist(ovh_cloud_project_network_private.network.regions), 0)
+  name              = "my_new_subnet"
+  cidr              = "192.168.169.0/24"
+  dns_nameservers   = ["1.1.1.1"]
+  host_routes     = [
+    {
+      destination = "192.168.169.0/24", 
+      nexthop = "192.168.169.254"
+    }
+  ]
+  allocation_pools   = [
+    {
+      start = "192.168.169.100", 
+      end = "192.168.169.200"
+    }
+  ]
+  dhcp              = true
+  gateway_ip        = "192.168.169.253"
+  enable_gateway_ip = true
+}
+`
+
+func TestAccCloudProjectNetworkPrivateSubnetV2_basic(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccCheckcCloudProjectNetworkPrivateSubnetV2PreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCloudProjectNetworkPrivateV2SubnetConfig(testAccCloudProjectNetworkPrivateSubnetV2Config_basic),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("ovh_cloud_project_network_private_subnet_v2.subnet", "service_name"),
+					resource.TestCheckResourceAttrSet("ovh_cloud_project_network_private_subnet_v2.subnet", "network_id"),
+					resource.TestCheckResourceAttrSet("ovh_cloud_project_network_private_subnet_v2.subnet", "region"),
+					resource.TestCheckResourceAttr("ovh_cloud_project_network_private_subnet_v2.subnet", "gateway_ip", "192.168.169.253"),
+					resource.TestCheckResourceAttr("ovh_cloud_project_network_private_subnet_v2.subnet", "allocation_pools.0.start", "192.168.169.100"),
+					resource.TestCheckResourceAttr("ovh_cloud_project_network_private_subnet_v2.subnet", "allocation_pools.0.end", "192.168.169.200"),
+					resource.TestCheckResourceAttr("ovh_cloud_project_network_private_subnet_v2.subnet", "host_routes.0.destination", "192.168.169.0/24"),
+					resource.TestCheckResourceAttr("ovh_cloud_project_network_private_subnet_v2.subnet", "host_routes.0.nexthop", "192.168.169.254"),
+					resource.TestCheckResourceAttr("ovh_cloud_project_network_private_subnet_v2.subnet", "dns_nameservers.0", "1.1.1.1"),
+					resource.TestCheckResourceAttr("ovh_cloud_project_network_private_subnet_v2.subnet", "dhcp", "true"),
+					resource.TestCheckResourceAttr("ovh_cloud_project_network_private_subnet_v2.subnet", "enable_gateway_ip", "true"),
+					resource.TestCheckResourceAttr("ovh_cloud_project_network_private_subnet_v2.subnet", "cidr", "192.168.169.0/24"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckcCloudProjectNetworkPrivateSubnetV2PreCheck(t *testing.T) {
+	testAccPreCheckCloud(t)
+	testAccCheckCloudProjectExists(t)
+	testAccPreCheckVRack(t)
+}

--- a/ovh/resource_cloud_project_workflow_backup_test.go
+++ b/ovh/resource_cloud_project_workflow_backup_test.go
@@ -67,7 +67,7 @@ func testSweepCloudProjectWorkflowBackup(region string) error {
 
 	for _, wf := range wfToSweep {
 		var deleteEndpoint = endpoint + "/%s"
-		client.Delete(fmt.Sprintf(deleteEndpoint, wf.Id), nil)
+		err := client.Delete(fmt.Sprintf(deleteEndpoint, wf.Id), nil)
 		if err != nil {
 			return fmt.Errorf("Error while deleting workflow with id %s through endpoint %s", wf.Id, deleteEndpoint)
 		}

--- a/ovh/resource_dedicated_server_install_task.go
+++ b/ovh/resource_dedicated_server_install_task.go
@@ -174,11 +174,11 @@ func resourceDedicatedServerInstallTaskCreate(d *schema.ResourceData, meta inter
 		url.PathEscape(serviceName),
 	)
 	opts := (&DedicatedServerInstallTaskCreateOpts{}).FromResource(d)
-	task := &DedicatedServerTask{}
+	task := DedicatedServerTask{}
 
-	if err := config.OVHClient.Post(endpoint, opts, task); err != nil {
+	if err := config.OVHClient.Post(endpoint, opts, &task); err != nil {
 		// If task was not created because of an error, return it immediately.
-		if task != nil && task.Id == 0 {
+		if task.Id == 0 {
 			return fmt.Errorf("failed to create install task: %w", err)
 		}
 
@@ -187,7 +187,7 @@ func resourceDedicatedServerInstallTaskCreate(d *schema.ResourceData, meta inter
 		log.Printf("[WARN] Ignored error when calling POST %s: %v", endpoint, err)
 	}
 
-	if err := waitForDedicatedServerTask(serviceName, task, config.OVHClient); err != nil {
+	if err := waitForDedicatedServerTask(serviceName, &task, config.OVHClient); err != nil {
 		return err
 	}
 

--- a/ovh/resource_hosting_privatedatabase.go
+++ b/ovh/resource_hosting_privatedatabase.go
@@ -179,16 +179,9 @@ func resourceHostingPrivateDatabaseRead(d *schema.ResourceData, meta interface{}
 	log.Printf("[DEBUG] Will read privateDatabase: %s", serviceName)
 	ds := &HostingPrivateDatabase{}
 	endpoint := fmt.Sprintf("/hosting/privateDatabase/%s", serviceName)
-	if err := config.OVHClient.Get(endpoint, &ds); err != nil {
-		return helpers.CheckDeleted(d, err, endpoint)
-	}
-
+	err = config.OVHClient.Get(endpoint, &ds)
 	if err != nil {
-		return fmt.Errorf(
-			"error reading Hosting privateDatabase for %s: %q",
-			serviceName,
-			err,
-		)
+		return helpers.CheckDeleted(d, err, endpoint)
 	}
 
 	for k, v := range ds.ToMap() {

--- a/ovh/types_cloud.go
+++ b/ovh/types_cloud.go
@@ -96,6 +96,50 @@ func (p *CloudProjectNetworkPrivatesCreateOpts) String() string {
 		p.ServiceName, p.NetworkId, p.Dhcp, p.NoGateway, p.Network, p.Start, p.End, p.Region)
 }
 
+type CloudProjectNetworkPrivateV2CreateOpts struct {
+	Name            string           `json:"name"`
+	Cidr            string           `json:"cidr"`
+	IpVersion       int              `json:"ipVersion"`
+	AllocationPools []AllocationPool `json:"allocationPools"`
+	DnsNameServers  []string         `json:"dnsNameServers"`
+	HostRoutes      []HostRoute      `json:"hostRoutes"`
+	EnableDHCP      bool             `json:"enableDhcp"`
+	GatewayIp       string           `json:"gatewayIp,omitempty"`
+	EnableGatewayIP bool             `json:"enableGatewayIp"`
+}
+
+func (p *CloudProjectNetworkPrivateV2CreateOpts) String() string {
+	return fmt.Sprintf("PCPNSCreateOpts[name: %s, cidr:%s, ipVersion: %d, allocationPools: %+v, dnsNameServers: %s, hostRoutes: %+v, enableDHCP: %t, gatewayIP: %v, enableGatewayIP: %t]",
+		p.Name, p.Cidr, p.IpVersion, p.AllocationPools, p.DnsNameServers, p.HostRoutes, p.EnableDHCP, p.GatewayIp, p.EnableGatewayIP)
+}
+
+type HostRoute struct {
+	Destination string `json:"destination"`
+	Nexthop     string `json:"nextHop"`
+}
+
+type AllocationPool struct {
+	Start string `json:"start"`
+	End   string `json:"end"`
+}
+
+type CloudProjectNetworkPrivateV2Response struct {
+	Id              string           `json:"id"`
+	Name            string           `json:"name"`
+	Cidr            string           `json:"cidr"`
+	IPVersion       int              `json:"ipVersion"`
+	DHCPEnabled     bool             `json:"dhcpEnabled"`
+	GatewayIp       *string          `json:"gatewayIp" description:"Gateway IP, null means no gateway"`
+	AllocationPools []AllocationPool `json:"allocationPools"`
+	HostRoutes      []HostRoute      `json:"hostRoutes"`
+	DnsNameservers  []string         `json:"dnsNameServers"`
+}
+
+func (p *CloudProjectNetworkPrivateV2Response) String() string {
+	return fmt.Sprintf("PCPNSResponse[Id: %s, Name: %s, Cidr: %s, IPVersion: %d, DHCPEnabled: %t, GatewayIp: %v, AllocationPools: %v, HostRoutes: %v, DnsNameservers: %s]",
+		p.Id, p.Name, p.Cidr, p.IPVersion, p.DHCPEnabled, p.GatewayIp, p.AllocationPools, p.HostRoutes, p.DnsNameservers)
+}
+
 type CloudProjectNetworkPrivatesResponse struct {
 	Id        string    `json:"id"`
 	GatewayIp string    `json:"gatewayIp"`

--- a/website/docs/r/cloud_project_network_private_subnet_v2.html.markdown
+++ b/website/docs/r/cloud_project_network_private_subnet_v2.html.markdown
@@ -1,0 +1,79 @@
+---
+subcategory : "Public Cloud Network"
+---
+
+# ovh_cloud_project_network_private_subnet_v2
+
+Creates a subnet in a private network of a public cloud region.
+
+## Example Usage
+
+```hcl
+resource "ovh_cloud_project_network_private_subnet_v2" "subnet" {
+  service_name      = "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+  network_id        = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
+  name              = "my_private_subnet"
+  region            = "XXX1"
+  dns_nameservers   = ["1.1.1.1"]
+  cidr              = "192.168.168.0/24"
+  dhcp              = true
+  enable_gateway_ip = true
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `service_name` - (Required) The id of the public cloud project. If omitted,
+    the `OVH_CLOUD_PROJECT_SERVICE` environment variable is used. 
+
+* `network_id` - (Required) The id of the network.
+   Changing this forces a new resource to be created.
+
+* `dhcp` - (Optional) Enable DHCP.
+   Changing this forces a new resource to be created. Defaults to true.
+
+* `cidr` - (Required) IP range of the subnet
+   Changing this value recreates the subnet.
+
+* `name` - (Required) Name of the subnet
+   Changing this value recreates the subnet.
+
+* `region` - (Required) The region in which the network subnet will be created.
+   Ex.: "GRA1". Changing this value recreates the resource.
+
+* `enable_gateway_ip` - (Required) Set to true if you want to set a default gateway IP.
+   Changing this value recreates the resource. Defaults to true.
+
+* `dns_nameservers` - DNS nameservers used by DHCP
+   Changing this value recreates the resource. Defaults to OVH default DNS nameserver.
+
+* `host_routes` - List of custom host routes.
+   Changing this value recreates the resource.
+
+* `allocation_pools` - List of IP allocation pools
+   Changing this value recreates the resource.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `service_name` - See Argument Reference above.
+* `network_id` - See Argument Reference above.
+* `cidr` - See Argument Reference above.
+* `dhcp` - See Argument Reference above.
+* `region` - See Argument Reference above.
+* `gateway_ip` - See Argument Reference above.
+* `enable_gateway_ip` - See Argument Reference above.
+* `dns_nameservers` - See Argument Reference above.
+* `host_routes` - See Argument Reference above.
+* `allocation_pools` - See Argument Reference above.
+
+## Import
+
+Subnet in a private network of a public cloud project can be imported using the `service_name` , the `network_id` and the `subnet_id`, separated by "/" E.g.,
+
+```bash
+$ terraform import ovh_cloud_project_network_private_subnet_v2.mysubnet ookie9mee8Shaeghaeleeju7Xeghohv6e/25807101-8aaa-4ea5-b507-61f0d661b101/0f0b73a4-403b-45e4-86d0-b438f1291909
+```

--- a/website/docs/r/cloud_project_network_private_subnet_v2.html.markdown
+++ b/website/docs/r/cloud_project_network_private_subnet_v2.html.markdown
@@ -72,7 +72,7 @@ The following attributes are exported:
 
 ## Import
 
-Subnet in a private network of a public cloud project can be imported using the `service_name` , the `network_id` and the `subnet_id`, separated by "/" E.g.,
+Subnet in a private network of a public cloud project can be imported using the `service_name` , `network_id`, `region` and the `subnet_id`, separated by "/" E.g.,
 
 ```bash
 $ terraform import ovh_cloud_project_network_private_subnet_v2.mysubnet ookie9mee8Shaeghaeleeju7Xeghohv6e/25807101-8aaa-4ea5-b507-61f0d661b101/0f0b73a4-403b-45e4-86d0-b438f1291909

--- a/website/docs/r/cloud_project_network_private_subnet_v2.html.markdown
+++ b/website/docs/r/cloud_project_network_private_subnet_v2.html.markdown
@@ -72,8 +72,8 @@ The following attributes are exported:
 
 ## Import
 
-Subnet in a private network of a public cloud project can be imported using the `service_name` , `network_id`, `region` and the `subnet_id`, separated by "/" E.g.,
+Subnet in a private network of a public cloud project can be imported using the `service_name`, `region`, `network_id` and `subnet_id`, separated by "/" E.g.,
 
 ```bash
-$ terraform import ovh_cloud_project_network_private_subnet_v2.mysubnet ookie9mee8Shaeghaeleeju7Xeghohv6e/25807101-8aaa-4ea5-b507-61f0d661b101/0f0b73a4-403b-45e4-86d0-b438f1291909
+$ terraform import ovh_cloud_project_network_private_subnet_v2.mysubnet 5ceb661434891538b54a4f2c66fc4b746e/BHS5/25807101-8aaa-4ea5-b507-61f0d661b101/0f0b73a4-403b-45e4-86d0-b438f1291909
 ```


### PR DESCRIPTION
# Description

Add a new regionalized resource ovh_cloud_project_network_private_subnet_v2, it is not really a v2, but a regionalized subnet, so it may be preferable to call it ovh_cloud_project_network_private_subnet_on_region or something like this...

Related to https://github.com/ovh/public-cloud-roadmap/issues/582

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Improvement (improve existing resource(s) or datasource(s))
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A: ` make testacc TESTARGS="-run TestAccCloudProjectNetworkPrivateSubnetV2_basic"`

**Test Configuration**:
* Terraform version: `terraform version`: Terraform vx.y.z
* Existing HCL configuration you used: 
```hcl
resource "ovh_cloud_project_network_private_subnet_v2" "subnet" {
    service_name      = ovh_cloud_project_network_private.network.service_name
    name              = "my_new_subnet"
    network_id        = element(tolist(ovh_cloud_project_network_private.network.regions_attributes), 0).openstackid
    region            = element(tolist(ovh_cloud_project_network_private.network.regions), 0)
    cidr              = "192.168.0.0/24"
    dns_nameservers   = ["1.1.1.1"]
    host_route {
            destination = "192.168.0.0/24"
            nexthop = "192.168.0.254"
    }
    allocation_pool {
            start = "192.168.0.100"
            end = "192.168.0.200"
    }
    dhcp              = true
    gateway_ip        = "192.168.0.253"
    enable_gateway_ip = true
}
```

# Checklist:

- [ ] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings or issues
- [ ] I have added acceptance tests that prove my fix is effective or that my feature works
- [ ] New and existing acceptance tests pass locally with my changes
- [ ] I ran successfully `go mod vendor` if I added or modify `go.mod` file
