### PR TITLE
fix: ovh_dedicated_server: Save user_metadata coming from plan only

### DIFF
--- a/ovh/resource_dedicated_server.go
+++ b/ovh/resource_dedicated_server.go
@@ -220,6 +220,10 @@ func (r *dedicatedServerResource) Update(ctx context.Context, req resource.Updat
 	responseData.MergeWith(&planData)
 	responseData.MergeWith(&stateData)
 
+	// Explicitely set UserMetadata to what was defined in the plan
+	// as we can't determine the right thing to do in MergeWith function
+	responseData.UserMetadata = planData.UserMetadata
+
 	// Save updated data into Terraform state
 	resp.Diagnostics.Append(resp.State.Set(ctx, &responseData)...)
 }

--- a/ovh/resource_dedicated_server_gen.go
+++ b/ovh/resource_dedicated_server_gen.go
@@ -525,29 +525,6 @@ func (v *DedicatedServerModel) MergeWith(other *DedicatedServerModel) {
 		v.TemplateName = other.TemplateName
 	}
 
-	if (v.UserMetadata.IsUnknown() || v.UserMetadata.IsNull()) && !other.UserMetadata.IsUnknown() {
-		v.UserMetadata = other.UserMetadata
-	} else if !other.UserMetadata.IsUnknown() && !other.UserMetadata.IsNull() {
-		newSlice := make([]attr.Value, 0)
-		elems := v.UserMetadata.Elements()
-		newElems := other.UserMetadata.Elements()
-
-		if len(elems) != len(newElems) {
-			v.UserMetadata = other.UserMetadata
-		} else {
-			for idx, e := range elems {
-				tmp := e.(UserMetadataValue)
-				tmp2 := newElems[idx].(UserMetadataValue)
-				tmp.MergeWith(&tmp2)
-				newSlice = append(newSlice, tmp)
-			}
-
-			v.UserMetadata = ovhtypes.TfListNestedValue[UserMetadataValue]{
-				ListValue: basetypes.NewListValueMust(UserMetadataValue{}.Type(context.Background()), newSlice),
-			}
-		}
-	}
-
 	if (v.Order.IsUnknown() || v.Order.IsNull()) && !other.Order.IsUnknown() {
 		v.Order = other.Order
 	}
@@ -582,7 +559,6 @@ func (v *DedicatedServerModel) MergeWith(other *DedicatedServerModel) {
 			}
 		}
 	}
-
 }
 
 func (v *DedicatedServerModel) ToOrder() *OrderModel {


### PR DESCRIPTION
# Description

`user_metadata` field was not saved correctly in the state. Since it's not a computed attribute, save the value given in config file.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (improve existing resource(s) or datasource(s))
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or issues
- [x] I have added acceptance tests that prove my fix is effective or that my feature works
- [x] New and existing acceptance tests pass locally with my changes
- [x] I ran succesfully `go mod vendor` if I added or modify `go.mod` file
