### PR TITLE
Add efiBootloaderPath for dedicated server resource & update

### DIFF
--- a/ovh/data_dedicated_server.go
+++ b/ovh/data_dedicated_server.go
@@ -51,6 +51,11 @@ func dataSourceDedicatedServer() *schema.Resource {
 				Computed:    true,
 				Description: "Dedicated datacenter localisation (bhs1,bhs2,...)",
 			},
+			"efi_bootloader_path": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "path of the EFI bootloader",
+			},
 			"ip": {
 				Type:        schema.TypeString,
 				Computed:    true,
@@ -243,6 +248,7 @@ func dataSourceDedicatedServerRead(d *schema.ResourceData, meta interface{}) err
 	d.Set("boot_script", ds.BootScript)
 	d.Set("commercial_range", ds.CommercialRange)
 	d.Set("datacenter", ds.Datacenter)
+	d.Set("efi_bootloader_path", ds.EfiBootloaderPath)
 	d.Set("ip", ds.Ip)
 	d.Set("link_speed", ds.LinkSpeed)
 	d.Set("monitoring", ds.Monitoring)

--- a/ovh/data_dedicated_server_test.go
+++ b/ovh/data_dedicated_server_test.go
@@ -37,9 +37,9 @@ func TestAccDedicatedServerDataSource_basic(t *testing.T) {
 					resource.TestCheckResourceAttrSet(
 						"data.ovh_dedicated_server.server", "display_name"),
 					resource.TestCheckResourceAttr(
-						"data.ovh_dedicated_server.server", "region", "eu-west-sbg"),
+						"data.ovh_dedicated_server.server", "region", "ca-east-bhs"),
 					resource.TestCheckResourceAttr(
-						"data.ovh_dedicated_server.server", "availability_zone", "eu-west-sbg-a"),
+						"data.ovh_dedicated_server.server", "availability_zone", "ca-east-bhs-a"),
 					resource.TestCheckResourceAttr(
 						"data.ovh_dedicated_server.server", "new_upgrade_system", "true"),
 					resource.TestCheckResourceAttr(

--- a/ovh/resource_dedicated_server_gen.go
+++ b/ovh/resource_dedicated_server_gen.go
@@ -152,6 +152,13 @@ func DedicatedServerResourceSchema(ctx context.Context) schema.Schema {
 			Description:         "The display name of your dedicated server",
 			MarkdownDescription: "The display name of your dedicated server",
 		},
+		"efi_bootloader_path": schema.StringAttribute{
+			CustomType:          ovhtypes.TfStringType{},
+			Optional:            true,
+			Computed:            true,
+			Description:         "Path of the EFI bootloader served on boot",
+			MarkdownDescription: "Path of the EFI bootloader served on boot",
+		},
 		"iam": schema.SingleNestedAttribute{
 			Attributes: map[string]schema.Attribute{
 				"display_name": schema.StringAttribute{
@@ -375,6 +382,7 @@ type DedicatedServerModel struct {
 	Datacenter          ovhtypes.TfStringValue                        `tfsdk:"datacenter" json:"datacenter"`
 	Details             DetailsValue                                  `tfsdk:"details" json:"details"`
 	DisplayName         ovhtypes.TfStringValue                        `tfsdk:"display_name" json:"displayName"`
+	EfiBootloaderPath   ovhtypes.TfStringValue                        `tfsdk:"efi_bootloader_path" json:"efiBootloaderPath"`
 	Iam                 IamValue                                      `tfsdk:"iam" json:"iam"`
 	Ip                  ovhtypes.TfStringValue                        `tfsdk:"ip" json:"ip"`
 	LinkSpeed           ovhtypes.TfInt64Value                         `tfsdk:"link_speed" json:"linkSpeed"`
@@ -433,6 +441,10 @@ func (v *DedicatedServerModel) MergeWith(other *DedicatedServerModel) {
 
 	if (v.DisplayName.IsUnknown() || v.DisplayName.IsNull()) && !other.DisplayName.IsUnknown() {
 		v.DisplayName = other.DisplayName
+	}
+
+	if (v.EfiBootloaderPath.IsUnknown() || v.EfiBootloaderPath.IsNull()) && !other.EfiBootloaderPath.IsUnknown() {
+		v.EfiBootloaderPath = other.EfiBootloaderPath
 	}
 
 	if v.Iam.IsUnknown() && !other.Iam.IsUnknown() {
@@ -574,6 +586,7 @@ type DedicatedServerWritableModel struct {
 	BootId              *ovhtypes.TfInt64Value                                 `tfsdk:"boot_id" json:"bootId,omitempty"`
 	BootScript          *ovhtypes.TfStringValue                                `tfsdk:"boot_script" json:"bootScript,omitempty"`
 	Details             *DetailsWritableValue                                  `tfsdk:"details" json:"details,omitempty"`
+	EfiBootloaderPath   *ovhtypes.TfStringValue                                `tfsdk:"efi_bootloader_path" json:"efiBootloaderPath,omitempty"`
 	Monitoring          *ovhtypes.TfBoolValue                                  `tfsdk:"monitoring" json:"monitoring,omitempty"`
 	NoIntervention      *ovhtypes.TfBoolValue                                  `tfsdk:"no_intervention" json:"noIntervention,omitempty"`
 	PartitionSchemeName *ovhtypes.TfStringValue                                `tfsdk:"partition_scheme_name" json:"partitionSchemeName,omitempty"`
@@ -594,6 +607,10 @@ func (v DedicatedServerModel) ToCreate() *DedicatedServerWritableModel {
 
 	if !v.BootScript.IsUnknown() {
 		res.BootScript = &v.BootScript
+	}
+
+	if !v.EfiBootloaderPath.IsUnknown() {
+		res.EfiBootloaderPath = &v.EfiBootloaderPath
 	}
 
 	if !v.Monitoring.IsUnknown() {
@@ -664,6 +681,10 @@ func (v DedicatedServerModel) ToUpdate() *DedicatedServerWritableModel {
 
 	if !v.BootScript.IsUnknown() {
 		res.BootScript = &v.BootScript
+	}
+
+	if !v.EfiBootloaderPath.IsUnknown() {
+		res.EfiBootloaderPath = &v.EfiBootloaderPath
 	}
 
 	if !v.Monitoring.IsUnknown() {

--- a/ovh/resource_dedicated_server_install_task_test.go
+++ b/ovh/resource_dedicated_server_install_task_test.go
@@ -144,10 +144,11 @@ data ovh_dedicated_server_boots "harddisk" {
 }
 
 resource ovh_dedicated_server_update "server" {
-  service_name = data.ovh_dedicated_server_boots.harddisk.service_name
-  boot_id      = data.ovh_dedicated_server_boots.harddisk.result[0]
-  monitoring   = true
-  state        = "ok"
+  service_name        = data.ovh_dedicated_server_boots.harddisk.service_name
+  boot_id             = data.ovh_dedicated_server_boots.harddisk.result[0]
+  monitoring          = true
+  state               = "ok"
+  efi_bootloader_path = "\\efi\\debian\\grubx64.efi"
 }
 
 resource "ovh_me_installation_template" "debian" {
@@ -186,10 +187,11 @@ data ovh_dedicated_server_boots "rescue" {
 }
 
 resource ovh_dedicated_server_update "server" {
-  service_name = data.ovh_dedicated_server_boots.harddisk.service_name
-  boot_id      = data.ovh_dedicated_server_boots.harddisk.result[0]
-  monitoring   = true
-  state        = "ok"
+  service_name        = data.ovh_dedicated_server_boots.harddisk.service_name
+  boot_id             = data.ovh_dedicated_server_boots.harddisk.result[0]
+  monitoring          = true
+  state               = "ok"
+  efi_bootloader_path = "\\efi\\debian\\grubx64.efi"
 }
 
 resource ovh_dedicated_server_install_task "server_install" {
@@ -209,9 +211,10 @@ data ovh_dedicated_server_boots "harddisk" {
 }
 
 resource ovh_dedicated_server_update "server" {
-  service_name = data.ovh_dedicated_server_boots.harddisk.service_name
-  monitoring   = true
-  state        = "ok"
+  service_name        = data.ovh_dedicated_server_boots.harddisk.service_name
+  boot_id             = data.ovh_dedicated_server_boots.harddisk.result[0]
+  monitoring          = true
+  state               = "ok"
 }
 
 resource ovh_dedicated_server_install_task "server_install" {

--- a/ovh/resource_dedicated_server_test.go
+++ b/ovh/resource_dedicated_server_test.go
@@ -11,10 +11,11 @@ import (
 
 func dedicatedServerResourceTestConfig(updated bool) string {
 	var (
-		monitoring     = true
-		noIntervention = false
-		baseTemplate   = "debian11_64"
-		displayName    = "First display name"
+		monitoring        = true
+		noIntervention    = false
+		baseTemplate      = "debian11_64"
+		displayName       = "First display name"
+		efiBootloaderPath = ""
 	)
 
 	if updated {
@@ -22,6 +23,7 @@ func dedicatedServerResourceTestConfig(updated bool) string {
 		noIntervention = true
 		baseTemplate = "debian12_64"
 		displayName = "Second display name"
+		efiBootloaderPath = "\\efi\\debian\\grubx64.efi"
 	}
 
 	return fmt.Sprintf(`
@@ -33,6 +35,7 @@ func dedicatedServerResourceTestConfig(updated bool) string {
 		no_intervention = %t
 		display_name = "%s"
 		template_name = "%s"
+		efi_bootloader_path = "%s"
 
 		plan = [
 			{
@@ -84,7 +87,7 @@ func dedicatedServerResourceTestConfig(updated bool) string {
 			}
 		]
 	}
-	`, monitoring, noIntervention, displayName, baseTemplate)
+	`, monitoring, noIntervention, displayName, baseTemplate, efiBootloaderPath)
 }
 
 func TestAccDedicatedServer_basic(t *testing.T) {
@@ -107,6 +110,8 @@ func TestAccDedicatedServer_basic(t *testing.T) {
 						"ovh_dedicated_server.server", "iam.display_name", "First display name"),
 					resource.TestCheckResourceAttr(
 						"ovh_dedicated_server.server", "os", "debian11_64"),
+					resource.TestCheckResourceAttr(
+						"ovh_dedicated_server.server", "efi_bootloader_path", ""),
 				),
 			},
 			{
@@ -122,6 +127,8 @@ func TestAccDedicatedServer_basic(t *testing.T) {
 						"ovh_dedicated_server.server", "iam.display_name", "Second display name"),
 					resource.TestCheckResourceAttr(
 						"ovh_dedicated_server.server", "os", "debian12_64"),
+					resource.TestCheckResourceAttr(
+						"ovh_dedicated_server.server", "efi_bootloader_path", "\\efi\\debian\\grubx64.efi"),
 				),
 			},
 			{

--- a/ovh/resource_dedicated_server_update.go
+++ b/ovh/resource_dedicated_server_update.go
@@ -34,6 +34,12 @@ func resourceDedicatedServerUpdate() *schema.Resource {
 				Description: "The boot script of your dedicated server.",
 				Optional:    true,
 			},
+			"efi_bootloader_path": {
+				Type:        schema.TypeString,
+				Description: "The path of the EFI bootloader.",
+				Computed:    true,
+				Optional:    true,
+			},
 			"monitoring": {
 				Type:        schema.TypeBool,
 				Computed:    true,
@@ -113,6 +119,7 @@ func resourceDedicatedServerUpdateRead(ctx context.Context, d *schema.ResourceDa
 
 	d.Set("boot_id", ds.BootId)
 	d.Set("boot_script", ds.BootScript)
+	d.Set("efi_bootloader_path", ds.EfiBootloaderPath)
 	d.Set("monitoring", ds.Monitoring)
 	d.Set("state", ds.State)
 	d.Set("display_name", ds.DisplayName)

--- a/ovh/resource_dedicated_server_update_test.go
+++ b/ovh/resource_dedicated_server_update_test.go
@@ -27,6 +27,8 @@ func TestAccDedicatedServerUpdate_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"ovh_dedicated_server_update.server", "boot_script", ""),
 					resource.TestCheckResourceAttr(
+						"ovh_dedicated_server_update.server", "efi_bootloader_path", "\\efi\\boot\\bootx64.efi"),
+					resource.TestCheckResourceAttr(
 						"ovh_dedicated_server_update.server", "display_name", "An awesome display name"),
 				),
 			},
@@ -40,6 +42,8 @@ func TestAccDedicatedServerUpdate_basic(t *testing.T) {
 						"ovh_dedicated_server_update.server", "state", "ok"),
 					resource.TestCheckResourceAttr(
 						"ovh_dedicated_server_update.server", "boot_script", ""),
+					resource.TestCheckResourceAttr(
+						"ovh_dedicated_server_update.server", "efi_bootloader_path", "\\efi\\boot\\bootx64.efi"),
 					resource.TestCheckResourceAttr(
 						"ovh_dedicated_server_update.server", "display_name", "An awesome display name restored"),
 				),
@@ -76,6 +80,7 @@ resource ovh_dedicated_server_update "server" {
   monitoring   = true
   state        = "ok"
   display_name = "An awesome display name"
+  efi_bootloader_path = "\\efi\\boot\\bootx64.efi"
 }
 
 output test {
@@ -95,6 +100,7 @@ resource ovh_dedicated_server_update "server" {
   monitoring   = false
   state        = "ok"
   display_name = "An awesome display name restored"
+  efi_bootloader_path = "\\efi\\boot\\bootx64.efi"
 }
 
 output test {

--- a/ovh/types_dedicated_server.go
+++ b/ovh/types_dedicated_server.go
@@ -15,6 +15,7 @@ type DedicatedServer struct {
 	BootScript         string `json:"bootScript"`
 	CommercialRange    string `json:"commercialRange"`
 	Datacenter         string `json:"datacenter"`
+	EfiBootloaderPath  string `json:"efiBootloaderPath"`
 	Ip                 string `json:"ip"`
 	LinkSpeed          int    `json:"linkSpeed"`
 	Monitoring         bool   `json:"monitoring"`
@@ -46,15 +47,17 @@ func (ds DedicatedServer) String() string {
 }
 
 type DedicatedServerUpdateOpts struct {
-	BootId     *int64  `json:"bootId,omitempty"`
-	BootScript *string `json:"bootScript,omitempty"`
-	Monitoring *bool   `json:"monitoring,omitempty"`
-	State      *string `json:"state,omitempty"`
+	BootId            *int64  `json:"bootId,omitempty"`
+	BootScript        *string `json:"bootScript,omitempty"`
+	EfiBootloaderPath *string `json:"efiBootloaderPath,omitempty"`
+	Monitoring        *bool   `json:"monitoring,omitempty"`
+	State             *string `json:"state,omitempty"`
 }
 
 func (opts *DedicatedServerUpdateOpts) FromResource(d *schema.ResourceData) *DedicatedServerUpdateOpts {
 	opts.BootId = helpers.GetNilInt64PointerFromData(d, "boot_id")
 	opts.BootScript = helpers.GetNilStringPointerFromData(d, "boot_script")
+	opts.EfiBootloaderPath = helpers.GetNilStringPointerFromData(d, "efi_bootloader_path")
 	opts.Monitoring = helpers.GetNilBoolPointerFromData(d, "monitoring")
 	opts.State = helpers.GetNilStringPointerFromData(d, "state")
 	return opts

--- a/website/docs/d/dedicated_server.html.markdown
+++ b/website/docs/d/dedicated_server.html.markdown
@@ -29,6 +29,7 @@ In addition, the following attributes are exported:
 * `urn` - URN of the dedicated server instance
 * `commercial_range` - Dedicated server commercial range
 * `datacenter` - Dedicated datacenter localisation (bhs1,bhs2,...)
+* `efi_bootloader_path` - Path of the EFI bootloader of the dedicated server
 * `ip` - Dedicated server ip (IPv4)
 * `ips` - Dedicated server ip blocks
 * `link_speed` - Link speed of the server

--- a/website/docs/r/dedicated_server.html.markdown
+++ b/website/docs/r/dedicated_server.html.markdown
@@ -142,6 +142,7 @@ The `user_metadata` block supports many arguments, here is a non-exhaustive list
   * `tags` - Resource tags. Tags that were internally computed are prefixed with `ovh:`
 * `boot_id` - Boot id of the server
 * `boot_script` - Boot script of the server
+* `efi_bootloader_path` - Path of the EFI bootloader
 * `link_speed` - Link speed of the server
 * `monitoring` - Icmp monitoring state
 * `no_intervention` - Prevent datacenter intervention

--- a/website/docs/r/dedicated_server_update.html.markdown
+++ b/website/docs/r/dedicated_server_update.html.markdown
@@ -36,6 +36,7 @@ The following arguments are supported:
 * `service_name` - (Required) The service_name of your dedicated server.
 * `boot_id` - boot id of the server
 * `boot_script` - boot script of the server
+* `efi_bootloader_path` - path of the EFI bootloader
 * `monitoring` - Icmp monitoring state
 * `state` - error, hacked, hackedBlocked, ok
 * `display_name` - display name of the dedicated server
@@ -46,6 +47,7 @@ The following attributes are exported:
 
 * `service_name` - See Argument Reference above.
 * `boot_id` - See Argument Reference above.
+* `efi_bootloader_path` - See Argument Reference above.
 * `monitoring` - See Argument Reference above.
 * `state` - See Argument Reference above.
 * `display_name` - See Argument Reference above.


### PR DESCRIPTION
Add efiBootloaderPath for dedicated server resource & dedicated server update

# Description

Possibility to GET and PUT the efi_bootloader_path on a dedicated server

Fixes #xx (issue)

## Type of change

Please delete options that are not relevant.

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (improve existing resource(s) or datasource(s))
- [ ] Documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A: `make testacc TESTARGS="-run TestAccDedicatedServerDataSource_basic"`
- [ ] make testacc TESTARGS="-run TestAccDedicatedServerUpdate_basic"

**Test Configuration**:
* Terraform version: `terraform version`: Terraform 1.6.6
* Existing HCL configuration you used: 
```hcl
resource "" "" {
a dedicated serer
}
```

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings or issues
- [ ] I have added acceptance tests that prove my fix is effective or that my feature works
- [ ] New and existing acceptance tests pass locally with my changes
- [ ] I ran succesfully `go mod vendor` if I added or modify `go.mod` file
