### PR TITLE
fix: ovh_cloud_project_database: prevent setting backup_time on some engines

### DIFF
--- a/website/docs/r/cloud_project_database.html.markdown
+++ b/website/docs/r/cloud_project_database.html.markdown
@@ -39,12 +39,13 @@ resource "ovh_cloud_project_database" "cassandradb" {
 }
 
 resource "ovh_cloud_project_database" "kafkadb" {
-  service_name    = "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
-  description     = "my-first-kafka"
-  engine          = "kafka"
-  version         = "3.4"
-  plan            = "business"
-  kafka_rest_api  = true
+  service_name          = "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+  description           = "my-first-kafka"
+  engine                = "kafka"
+  version               = "3.8"
+  flavor                = "db1-4"
+  plan                  = "business"
+  kafka_rest_api        = true
   kafka_schema_registry = true
   nodes {
     region  = "DE"
@@ -55,7 +56,6 @@ resource "ovh_cloud_project_database" "kafkadb" {
   nodes {
     region  = "DE"
   }
-  flavor           = "db1-4"
 }
 
 resource "ovh_cloud_project_database" "m3db" {
@@ -237,7 +237,7 @@ The following arguments are supported:
   * Redis: "essential", "business"
 * `version` - (Required) The version of the engine in which the service should be deployed
 * `backup_regions` - List of region where backups are pushed. Not more than 1 regions for MongoDB. Not more than 2 regions for the other engines with one being the same as the nodes[].region field
-* `backup_time` - Time on which backups start every day.
+* `backup_time` - Time on which backups start every day (this parameter is not usable on the following engines: "m3db", "grafana", "kafka", "kafkaconnect", "kafkamirrormaker", "opensearch", "m3aggregator").
 * `maintenance_time` - Time on which maintenances can start every day.
 
 ## Attributes Reference


### PR DESCRIPTION
# Description

Fixes #751 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (improve existing resource(s) or datasource(s))
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

# How Has This Been Tested?

- [x] Test A: `make testacc TESTARGS="-run TestAccCloudProjectDatabase_invalidBackupTime"`
- [x] Test B: `make testacc TESTARGS="-run TestAccCloudProjectDatabase_basic"`

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or issues
- [x] I have added acceptance tests that prove my fix is effective or that my feature works
- [x] New and existing acceptance tests pass locally with my changes
- [x] I ran succesfully `go mod vendor` if I added or modify `go.mod` file
