### PR TITLE
docs: Presign URLs are compatible with any storage class

### DIFF
--- a/website/docs/r/cloud_project_region_storage_presign.html.markdown
+++ b/website/docs/r/cloud_project_region_storage_presign.html.markdown
@@ -6,8 +6,6 @@ subcategory : "Object Storage"
 
 Generates a temporary presigned S3 URLs to download or upload an object.
 
--> __NOTE__ This resource is only compatible with the `High Performance - S3` solution for object storage.
-
 ## Example Usage
 
 ```hcl
@@ -29,14 +27,16 @@ output "presigned_url" {
 
 The following arguments are supported:
 
-* `service_name` - (Required) The id of the public cloud project. If omitted,
+- `service_name` - (Required) The id of the public cloud project. If omitted,
   the `OVH_CLOUD_PROJECT_SERVICE` environment variable is used.
-* `region_name` - (Required) The region in which your storage is located.
-  Ex.: "GRA".
-* `name` - (Required) The name of your S3 storage container/bucket.
-* `expire` - (Required) Define, in seconds, for how long your URL will be valid.
-* `method` - (Required) The method you want to use to interact with your object. Can be either 'GET' or 'PUT'.
-* `object` - (Required) The name of the object in your S3 bucket.
+- `region_name` - (Required) The region in which your storage is located. Must
+  be in **uppercase**. Ex.: "GRA".
+- `name` - (Required) The name of your S3 storage container/bucket.
+- `expire` - (Required) Define, in seconds, for how long your URL will be
+  valid.
+- `method` - (Required) The method you want to use to interact with your
+  object. Can be either 'GET' or 'PUT'.
+- `object` - (Required) The name of the object in your S3 bucket.
 
 
 ## Attributes Reference


### PR DESCRIPTION
# Description

- Remove the note on cloud_project_region_storage_presign resource telling it's compatible only with the High Performance storage class. Pre-signed URLs are compatible with any class.
- Region name must be in uppercase

## Type of change

Please delete options that are not relevant.

- Documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or issues
- [x] I have added acceptance tests that prove my fix is effective or that my feature works
- [x] New and existing acceptance tests pass locally with my changes
- [x] I ran succesfully `go mod vendor` if I added or modify `go.mod` file
