### PR TITLE
feat(okms): support the new region name format

### DIFF
--- a/ovh/resource_okms.go
+++ b/ovh/resource_okms.go
@@ -204,6 +204,12 @@ func (r *okmsResource) Update(ctx context.Context, req resource.UpdateRequest, r
 		data.OvhSubsidiary = planData.OvhSubsidiary
 	}
 
+	if data.Region != planData.Region {
+		// This will happen when we change the region format.
+		// No need to update resource, just take the value from the plan.
+		data.Region = planData.Region
+	}
+
 	if planData.DisplayName.ValueString() != data.DisplayName.ValueString() {
 		// Update service displayName
 		log.Printf("[OKMS] updating display name for %s to %s", data.Id.ValueString(), planData.DisplayName.ValueString())

--- a/ovh/resource_okms_credential_test.go
+++ b/ovh/resource_okms_credential_test.go
@@ -111,7 +111,7 @@ data "ovh_me" "current_account" {
 resource "ovh_okms" "kms" {
   ovh_subsidiary = "FR"
   display_name = "%[1]s"
-  region = "EU_WEST_SBG"
+  region = "eu-west-sbg"
 }
 
 resource "ovh_okms_credential" "cred" {

--- a/ovh/resource_okms_service_key_test.go
+++ b/ovh/resource_okms_service_key_test.go
@@ -135,7 +135,7 @@ data "ovh_me" "current_account" {
 resource "ovh_okms" "kms" {
   ovh_subsidiary = "FR"
   display_name = "%[1]s"
-  region = "EU_WEST_SBG"
+  region = "eu-west-sbg"
 }
 
 resource "ovh_okms_service_key" "key_oct" {

--- a/ovh/resource_okms_test.go
+++ b/ovh/resource_okms_test.go
@@ -123,7 +123,7 @@ data "ovh_okms_resource" "datakms" {
 func TestAccOkmsOrder(t *testing.T) {
 	compareValuesSame := statecheck.CompareValue(compare.ValuesSame())
 	displayName := acctest.RandomWithPrefix(test_prefix)
-	region := "EU_WEST_SBG"
+	region := "eu-west-sbg"
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheckCredentials(t) },
@@ -181,7 +181,7 @@ func TestAccOkmsImport(t *testing.T) {
 				ResourceName:  "ovh_okms.kms",
 				ImportState:   true,
 				ImportStateId: kmsId,
-				Config:        fmt.Sprintf(confOkmsResourceOrder, displayName, "EU_WEST_SBG"),
+				Config:        fmt.Sprintf(confOkmsResourceOrder, displayName, "eu-west-sbg"),
 			},
 		},
 	})

--- a/website/docs/r/okms.html.markdown
+++ b/website/docs/r/okms.html.markdown
@@ -16,7 +16,7 @@ Creates an OVHcloud Key Management Service (okms).
 ```hcl
 resource "ovh_okms" "new_kms" {
   ovh_subsidiary = "FR"
-  region         = "EU_WEST_RBX"
+  region         = "eu-west-rbx"
   display_name   = "terraformed KMS"
 }
 ```


### PR DESCRIPTION
# Description

In order to support the change in the region format from PLATE_LOCATION_DC to plate-location-dc we need to add some custom handling for the KMS region parameter :
- Never recreate the kms when we only have a region format mismatch, update it instead.
- On update, use the value from the plan for the region. (which can only happen in case of a format mismatch)
- Warn when the old format is used

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (improve existing resource(s) or datasource(s))
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

# How Has This Been Tested?

- [ ] To test that existing conf is still working with the old API : `make testacc TESTARGS="-run TestAccOkmsOrder" `

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings or issues -> we explicitly add a warning 
- [ ] I have added acceptance tests that prove my fix is effective or that my feature works
- [x] New and existing acceptance tests pass locally with my changes
- [ ] I ran successfully `go mod vendor` if I added or modify `go.mod` file
