### PR TITLE
fix: Use Set instead of List in ovh_dbaas_logs_input.allowed_networks

### DIFF
--- a/ovh/resource_dbaas_logs_input.go
+++ b/ovh/resource_dbaas_logs_input.go
@@ -140,7 +140,7 @@ func resourceDbaasLogsInputSchema() map[string]*schema.Schema {
 
 		// Optional
 		"allowed_networks": {
-			Type:        schema.TypeList,
+			Type:        schema.TypeSet,
 			Description: "IP blocks",
 			Elem:        &schema.Schema{Type: schema.TypeString},
 			Optional:    true,

--- a/ovh/types_dbaas_logs_input.go
+++ b/ovh/types_dbaas_logs_input.go
@@ -83,7 +83,7 @@ func (opts *DbaasLogsInputOpts) FromResource(d *schema.ResourceData) *DbaasLogsI
 	opts.StreamId = d.Get("stream_id").(string)
 	opts.Title = d.Get("title").(string)
 
-	networks := d.Get("allowed_networks").([]interface{})
+	networks := d.Get("allowed_networks").(*schema.Set).List()
 	if len(networks) > 0 {
 		networksString := make([]string, len(networks))
 		for i, net := range networks {


### PR DESCRIPTION
# Description

Related to #781 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (improve existing resource(s) or datasource(s))
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

# How Has This Been Tested?

- [ ] Test A: `make testacc TESTARGS="-run TestAccResourceDbaasLogsInput_basic"`