### PR TITLE
add subnet usedefault public dns

### DIFF
--- a/ovh/resource_cloud_project_network_private_subnet_v2.go
+++ b/ovh/resource_cloud_project_network_private_subnet_v2.go
@@ -97,6 +97,12 @@ func resourceCloudProjectNetworkPrivateSubnetV2() *schema.Resource {
 				Default:     true,
 				Description: "Enable gateway IP in subnet",
 			},
+			"use_default_public_dns_resolver": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				ForceNew:    true,
+				Description: "Use OVH default DNS",
+			},
 			"dns_nameservers": {
 				Type:     schema.TypeList,
 				Optional: true,
@@ -161,6 +167,12 @@ func resourceCloudProjectNetworkPrivateSubnetV2Create(d *schema.ResourceData, me
 	cidr := d.Get("cidr").(string)
 	enableGatewayIP := d.Get("enable_gateway_ip").(bool)
 	enableDHCP := d.Get("dhcp").(bool)
+	useDefaultPublicDNSResolverbool, ok := d.GetOkExists("use_default_public_dns_resolver")
+	var useDefaultPublicDNSResolver *bool
+	if ok {
+		i := useDefaultPublicDNSResolverbool.(bool)
+		useDefaultPublicDNSResolver = &i
+	}
 	gatewayIp := d.Get("gateway_ip").(string)
 
 	hostRoutesStrings, err := helpers.StringMapFromSchema(d, "host_route", "destination", "nexthop")
@@ -195,15 +207,16 @@ func resourceCloudProjectNetworkPrivateSubnetV2Create(d *schema.ResourceData, me
 	}
 
 	createSubnetParams := &CloudProjectNetworkPrivateV2CreateOpts{
-		Name:            subnetName,
-		Cidr:            cidr,
-		IpVersion:       4,
-		AllocationPools: allocationPools,
-		DnsNameServers:  dnsNameServers,
-		GatewayIp:       gatewayIp,
-		EnableGatewayIP: enableGatewayIP,
-		EnableDHCP:      enableDHCP,
-		HostRoutes:      hostRoutes,
+		Name:                        subnetName,
+		Cidr:                        cidr,
+		IpVersion:                   4,
+		AllocationPools:             allocationPools,
+		DnsNameServers:              dnsNameServers,
+		GatewayIp:                   gatewayIp,
+		EnableGatewayIP:             enableGatewayIP,
+		EnableDHCP:                  enableDHCP,
+		HostRoutes:                  hostRoutes,
+		UseDefaultPublicDNSResolver: useDefaultPublicDNSResolver,
 	}
 
 	subnetResponse := &CloudProjectNetworkPrivateV2Response{}

--- a/ovh/resource_cloud_project_network_private_subnet_v2.go
+++ b/ovh/resource_cloud_project_network_private_subnet_v2.go
@@ -107,6 +107,7 @@ func resourceCloudProjectNetworkPrivateSubnetV2() *schema.Resource {
 				Type:     schema.TypeList,
 				Optional: true,
 				ForceNew: true,
+				Computed: true,
 				Elem: &schema.Schema{
 					Type:         schema.TypeString,
 					ValidateFunc: resourceCloudProjectNetworkPrivateSubnetValidateIP,
@@ -238,6 +239,8 @@ func resourceCloudProjectNetworkPrivateSubnetV2Create(d *schema.ResourceData, me
 	d.Set("dhcp", subnetResponse.DHCPEnabled)
 	d.Set("region", regionName)
 	d.SetId(subnetResponse.Id)
+	d.Set("dns_nameservers", subnetResponse.DnsNameservers)
+
 	log.Printf("[DEBUG] Read Public Cloud Private Network %v", subnetResponse)
 	return nil
 }
@@ -263,6 +266,8 @@ func resourceCloudProjectNetworkPrivateSubnetV2Read(d *schema.ResourceData, meta
 	d.Set("service_name", serviceName)
 	d.Set("network_id", networkId)
 	d.Set("region", regionName)
+
+	d.Set("dns_nameservers", subnet.DnsNameservers)
 	d.SetId(subnet.Id)
 	log.Printf("[DEBUG] Read Public Cloud Private Network %v", subnet)
 	return nil

--- a/ovh/resource_cloud_project_network_private_subnet_v2_test.go
+++ b/ovh/resource_cloud_project_network_private_subnet_v2_test.go
@@ -8,71 +8,23 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 )
 
-func testAccCloudProjectNetworkPrivateV2SubnetConfig(config string) string {
-	var testAccCloudProjectNetworkPrivateSubnetV2Config_attachVrack = `
-	resource "ovh_vrack_cloudproject" "attach" {
-		service_name = "%s"
-		project_id   = "%s"
-	}
+func TestAccCloudProjectNetworkPrivateSubnetV2_basic(t *testing.T) {
 
-	data "ovh_cloud_project_regions" "regions" {
-		service_name = ovh_vrack_cloudproject.attach.project_id
-		has_services_up = ["network"]
-	}
-
-	resource "ovh_cloud_project_network_private" "network" {
-		service_name = ovh_vrack_cloudproject.attach.project_id
-		vlan_id		= 1
-		name		= "terraform_testacc_private_net"
-		regions		= slice(sort(tolist(data.ovh_cloud_project_regions.regions.names)), 0, 3)
-	}
-`
-	attachVrack := fmt.Sprintf(
-		testAccCloudProjectNetworkPrivateSubnetV2Config_attachVrack,
-		os.Getenv("OVH_VRACK_SERVICE_TEST"),
-		os.Getenv("OVH_CLOUD_PROJECT_SERVICE_TEST"),
-	)
-
-	var testAccCloudProjectNetworkPrivateSubnetV2Config_noAttachVrack = `
-	data "ovh_cloud_project_regions" "regions" {
-		service_name = "%s"
-		has_services_up = ["network"]
-	}
-
-	resource "ovh_cloud_project_network_private" "network" {
-		service_name = data.ovh_cloud_project_regions.regions.service_name
-		vlan_id	= 1
-		name	= "terraform_testacc_private_net"
-		regions	= slice(sort(tolist(data.ovh_cloud_project_regions.regions.names)), 0, 3)
-	}
-`
-	noAttachVrack := fmt.Sprintf(
-		testAccCloudProjectNetworkPrivateSubnetV2Config_noAttachVrack,
-		os.Getenv("OVH_CLOUD_PROJECT_SERVICE_TEST"),
-	)
-
-	if os.Getenv("OVH_ATTACH_VRACK") == "0" {
-		return fmt.Sprintf(
-			config,
-			noAttachVrack,
-		)
-	}
-
-	return fmt.Sprintf(
-		config,
-		attachVrack,
-	)
+	cloudProject := os.Getenv("OVH_CLOUD_PROJECT_SERVICE_TEST")
+	region := os.Getenv("OVH_CLOUD_PROJECT_REGION_TEST")
+	var testAccCloudProjectNetworkPrivateSubnetV2Config_basic = fmt.Sprintf(`
+resource "ovh_cloud_project_network_private" "network" {
+  service_name = "%s"
+  vlan_id    = 0
+  name       = "terraform_testacc_private_net"
+  regions    = ["%s"]
 }
 
-var testAccCloudProjectNetworkPrivateSubnetV2Config_basic = `
-%s
-
-resource "ovh_cloud_project_network_private_subnet_v2" "subnet" {
+  resource "ovh_cloud_project_network_private_subnet_v2" "subnet" {
   service_name = ovh_cloud_project_network_private.network.service_name
 
-  # whatever region, for test purpose
   network_id        = element(tolist(ovh_cloud_project_network_private.network.regions_attributes), 0).openstackid
-  region            = element(tolist(ovh_cloud_project_network_private.network.regions), 0)
+  region     = element(tolist(sort(ovh_cloud_project_network_private.network.regions)), 0)
   name              = "my_new_subnet"
   cidr              = "192.168.169.0/24"
   dns_nameservers   = ["1.1.1.1"]
@@ -87,10 +39,10 @@ resource "ovh_cloud_project_network_private_subnet_v2" "subnet" {
   dhcp              = true
   gateway_ip        = "192.168.169.253"
   enable_gateway_ip = true
+  use_default_public_dns_resolver = false
 }
-`
+`, cloudProject, region)
 
-func TestAccCloudProjectNetworkPrivateSubnetV2_basic(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheckCloud(t)
@@ -100,7 +52,7 @@ func TestAccCloudProjectNetworkPrivateSubnetV2_basic(t *testing.T) {
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCloudProjectNetworkPrivateV2SubnetConfig(testAccCloudProjectNetworkPrivateSubnetV2Config_basic),
+				Config: testAccCloudProjectNetworkPrivateSubnetV2Config_basic,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet("ovh_cloud_project_network_private_subnet_v2.subnet", "service_name"),
 					resource.TestCheckResourceAttrSet("ovh_cloud_project_network_private_subnet_v2.subnet", "network_id"),
@@ -114,6 +66,71 @@ func TestAccCloudProjectNetworkPrivateSubnetV2_basic(t *testing.T) {
 					resource.TestCheckResourceAttr("ovh_cloud_project_network_private_subnet_v2.subnet", "dhcp", "true"),
 					resource.TestCheckResourceAttr("ovh_cloud_project_network_private_subnet_v2.subnet", "enable_gateway_ip", "true"),
 					resource.TestCheckResourceAttr("ovh_cloud_project_network_private_subnet_v2.subnet", "cidr", "192.168.169.0/24"),
+					resource.TestCheckResourceAttr("ovh_cloud_project_network_private_subnet_v2.subnet", "use_default_public_dns_resolver", "false"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccCloudProjectNetworkPrivateSubnetV2DefaultDns_basic(t *testing.T) {
+
+	cloudProject := os.Getenv("OVH_CLOUD_PROJECT_SERVICE_TEST")
+	region := os.Getenv("OVH_CLOUD_PROJECT_REGION_TEST")
+	var testAccCloudProjectNetworkPrivateSubnetV2Config_basic = fmt.Sprintf(`
+resource "ovh_cloud_project_network_private" "network" {
+  service_name = "%s"
+  vlan_id    = 0
+  name       = "terraform_testacc_private_net"
+  regions    = ["%s"]
+}
+
+  resource "ovh_cloud_project_network_private_subnet_v2" "subnet" {
+  service_name = ovh_cloud_project_network_private.network.service_name
+
+  network_id        = element(tolist(ovh_cloud_project_network_private.network.regions_attributes), 0).openstackid
+  region     = element(tolist(sort(ovh_cloud_project_network_private.network.regions)), 0)
+  name              = "my_new_subnet"
+  cidr              = "192.168.169.0/24"
+  host_route {
+    destination = "192.168.169.0/24" 
+    nexthop = "192.168.169.254"
+  }
+  allocation_pool {
+    start = "192.168.169.100"
+    end = "192.168.169.200"
+  }
+  dhcp              = true
+  gateway_ip        = "192.168.169.253"
+  enable_gateway_ip = true
+  use_default_public_dns_resolver = true
+}
+`, cloudProject, region)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheckCloud(t)
+			testAccCheckCloudProjectExists(t)
+			testAccPreCheckVRack(t)
+		},
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCloudProjectNetworkPrivateSubnetV2Config_basic,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("ovh_cloud_project_network_private_subnet_v2.subnet", "service_name"),
+					resource.TestCheckResourceAttrSet("ovh_cloud_project_network_private_subnet_v2.subnet", "network_id"),
+					resource.TestCheckResourceAttrSet("ovh_cloud_project_network_private_subnet_v2.subnet", "region"),
+					resource.TestCheckResourceAttr("ovh_cloud_project_network_private_subnet_v2.subnet", "gateway_ip", "192.168.169.253"),
+					resource.TestCheckResourceAttr("ovh_cloud_project_network_private_subnet_v2.subnet", "allocation_pool.0.start", "192.168.169.100"),
+					resource.TestCheckResourceAttr("ovh_cloud_project_network_private_subnet_v2.subnet", "allocation_pool.0.end", "192.168.169.200"),
+					resource.TestCheckResourceAttr("ovh_cloud_project_network_private_subnet_v2.subnet", "host_route.0.destination", "192.168.169.0/24"),
+					resource.TestCheckResourceAttr("ovh_cloud_project_network_private_subnet_v2.subnet", "host_route.0.nexthop", "192.168.169.254"),
+					resource.TestCheckResourceAttr("ovh_cloud_project_network_private_subnet_v2.subnet", "dns_nameservers.0", "213.186.33.99"),
+					resource.TestCheckResourceAttr("ovh_cloud_project_network_private_subnet_v2.subnet", "dhcp", "true"),
+					resource.TestCheckResourceAttr("ovh_cloud_project_network_private_subnet_v2.subnet", "enable_gateway_ip", "true"),
+					resource.TestCheckResourceAttr("ovh_cloud_project_network_private_subnet_v2.subnet", "cidr", "192.168.169.0/24"),
+					resource.TestCheckResourceAttr("ovh_cloud_project_network_private_subnet_v2.subnet", "use_default_public_dns_resolver", "true"),
 				),
 			},
 		},

--- a/ovh/types_cloud.go
+++ b/ovh/types_cloud.go
@@ -109,11 +109,6 @@ type CloudProjectNetworkPrivateV2CreateOpts struct {
 	UseDefaultPublicDNSResolver *bool            `json:"useDefaultPublicDNSResolver"`
 }
 
-func (p *CloudProjectNetworkPrivateV2CreateOpts) String() string {
-	return fmt.Sprintf("PCPNSCreateOpts[name: %s, cidr:%s, ipVersion: %d, allocationPools: %+v, dnsNameServers: %s, hostRoutes: %+v, enableDHCP: %t, gatewayIP: %v, enableGatewayIP: %t, useDefaultPublicDNSResolver: %t]",
-		p.Name, p.Cidr, p.IpVersion, p.AllocationPools, p.DnsNameServers, p.HostRoutes, p.EnableDHCP, p.GatewayIp, p.EnableGatewayIP, *p.UseDefaultPublicDNSResolver)
-}
-
 type HostRoute struct {
 	Destination string `json:"destination"`
 	Nexthop     string `json:"nextHop"`

--- a/ovh/types_cloud.go
+++ b/ovh/types_cloud.go
@@ -97,20 +97,21 @@ func (p *CloudProjectNetworkPrivatesCreateOpts) String() string {
 }
 
 type CloudProjectNetworkPrivateV2CreateOpts struct {
-	Name            string           `json:"name"`
-	Cidr            string           `json:"cidr"`
-	IpVersion       int              `json:"ipVersion"`
-	AllocationPools []AllocationPool `json:"allocationPools"`
-	DnsNameServers  []string         `json:"dnsNameServers"`
-	HostRoutes      []HostRoute      `json:"hostRoutes"`
-	EnableDHCP      bool             `json:"enableDhcp"`
-	GatewayIp       string           `json:"gatewayIp,omitempty"`
-	EnableGatewayIP bool             `json:"enableGatewayIp"`
+	Name                        string           `json:"name"`
+	Cidr                        string           `json:"cidr"`
+	IpVersion                   int              `json:"ipVersion"`
+	AllocationPools             []AllocationPool `json:"allocationPools"`
+	DnsNameServers              []string         `json:"dnsNameServers"`
+	HostRoutes                  []HostRoute      `json:"hostRoutes"`
+	EnableDHCP                  bool             `json:"enableDhcp"`
+	GatewayIp                   string           `json:"gatewayIp,omitempty"`
+	EnableGatewayIP             bool             `json:"enableGatewayIp"`
+	UseDefaultPublicDNSResolver *bool            `json:"useDefaultPublicDNSResolver"`
 }
 
 func (p *CloudProjectNetworkPrivateV2CreateOpts) String() string {
-	return fmt.Sprintf("PCPNSCreateOpts[name: %s, cidr:%s, ipVersion: %d, allocationPools: %+v, dnsNameServers: %s, hostRoutes: %+v, enableDHCP: %t, gatewayIP: %v, enableGatewayIP: %t]",
-		p.Name, p.Cidr, p.IpVersion, p.AllocationPools, p.DnsNameServers, p.HostRoutes, p.EnableDHCP, p.GatewayIp, p.EnableGatewayIP)
+	return fmt.Sprintf("PCPNSCreateOpts[name: %s, cidr:%s, ipVersion: %d, allocationPools: %+v, dnsNameServers: %s, hostRoutes: %+v, enableDHCP: %t, gatewayIP: %v, enableGatewayIP: %t, useDefaultPublicDNSResolver: %t]",
+		p.Name, p.Cidr, p.IpVersion, p.AllocationPools, p.DnsNameServers, p.HostRoutes, p.EnableDHCP, p.GatewayIp, p.EnableGatewayIP, *p.UseDefaultPublicDNSResolver)
 }
 
 type HostRoute struct {

--- a/website/docs/r/cloud_project_network_private_subnet_v2.html.markdown
+++ b/website/docs/r/cloud_project_network_private_subnet_v2.html.markdown
@@ -18,6 +18,7 @@ resource "ovh_cloud_project_network_private_subnet_v2" "subnet" {
   cidr              = "192.168.168.0/24"
   dhcp              = true
   enable_gateway_ip = true
+  use_default_public_dns_resolver = false
 }
 ```
 
@@ -55,6 +56,8 @@ The following arguments are supported:
 * `allocation_pools` - List of IP allocation pools
    Changing this value recreates the resource.
 
+* `use_default_public_dns_resolver` - Set to false if you want to use your DNS resolver.
+   Changing this value recreates the resource.
 ## Attributes Reference
 
 The following attributes are exported:


### PR DESCRIPTION
# Description

Add use_default_public_dns_resolver in subnetv2

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (improve existing resource(s) or datasource(s))
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

**Test Configuration**:
* Terraform version: `terraform version`: Terraform vx.y.z
* Existing HCL configuration you used: 
```hcl
resource "ovh_cloud_project_network_private_subnet_v2" "subnet" {
  network_id        = "aaa-vvv-bbb-ccc"
  name              = "my_private_subnet"
  region            = "BHS5"
  dns_nameservers   = ["1.1.1.1"]
  cidr              = "192.168.168.0/24"
  dhcp              = true
  enable_gateway_ip = true
  use_default_public_dns_resolver = false
}
```
```
 # ovh_cloud_project_network_private_subnet_v2.subnet will be created
  + resource "ovh_cloud_project_network_private_subnet_v2" "subnet" {
      + cidr                            = "192.168.168.0/24"
      + dhcp                            = true
      + dns_nameservers                 = [
          + "1.1.1.1",
        ]
      + enable_gateway_ip               = true
      + gateway_ip                      = (known after apply)
      + id                              = (known after apply)
      + name                            = "my_private_subnet"
      + network_id                      = "aaa-vvv-bbb-ccc"
      + region                          = "BHS5"
      + service_name                    = "xxx"
      + use_default_public_dns_resolver = false
    }
  ```
