### PR TITLE
fix(okms): require replacement of credential on identity_urn change

### DIFF
--- a/ovh/resource_okms_credential_gen.go
+++ b/ovh/resource_okms_credential_gen.go
@@ -8,6 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/boolplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/listplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 )
@@ -111,6 +112,9 @@ func OkmsCredentialResourceSchema(ctx context.Context) schema.Schema {
 			Required:            true,
 			Description:         "List of identity URNs associated with the credential (max 25)",
 			MarkdownDescription: "List of identity URNs associated with the credential (max 25)",
+			PlanModifiers: []planmodifier.List{
+				listplanmodifier.RequiresReplace(),
+			},
 		},
 		"name": schema.StringAttribute{
 			CustomType:          ovhtypes.TfStringType{},


### PR DESCRIPTION
# Description

In the okms API the `identity_urns` field of a credential cannot be updated, however I forgot the `RequiresReplace` plan modifier on the corresponding `ovh_okms_credential` resource, which causes apply to fail when this field changes.

## Type of change

Please delete options that are not relevant.

- [x ] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Test A: `make testacc TESTARGS="-run TestAccOkmsCred"`

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or issues
- [x] I have added acceptance tests that prove my fix is effective or that my feature works
- [x] New and existing acceptance tests pass locally with my changes
- [x] I ran succesfully `go mod vendor` if I added or modify `go.mod` file
