### PR TITLE
feat: Add retention_type to datasource ovh_dbaas_logs_cluster_retention

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/hashicorp/go-cty v1.4.1-0.20200414143053-d3edf31b6320
 	github.com/hashicorp/go-version v1.7.0
 	github.com/hashicorp/terraform-plugin-framework v1.13.0
-	github.com/hashicorp/terraform-plugin-framework-validators v0.15.0
+	github.com/hashicorp/terraform-plugin-framework-validators v0.16.0
 	github.com/hashicorp/terraform-plugin-go v0.25.0
 	github.com/hashicorp/terraform-plugin-log v0.9.0
 	github.com/hashicorp/terraform-plugin-mux v0.16.0

--- a/go.sum
+++ b/go.sum
@@ -78,8 +78,8 @@ github.com/hashicorp/terraform-json v0.22.1 h1:xft84GZR0QzjPVWs4lRUwvTcPnegqlyS7
 github.com/hashicorp/terraform-json v0.22.1/go.mod h1:JbWSQCLFSXFFhg42T7l9iJwdGXBYV8fmmD6o/ML4p3A=
 github.com/hashicorp/terraform-plugin-framework v1.13.0 h1:8OTG4+oZUfKgnfTdPTJwZ532Bh2BobF4H+yBiYJ/scw=
 github.com/hashicorp/terraform-plugin-framework v1.13.0/go.mod h1:j64rwMGpgM3NYXTKuxrCnyubQb/4VKldEKlcG8cvmjU=
-github.com/hashicorp/terraform-plugin-framework-validators v0.15.0 h1:RXMmu7JgpFjnI1a5QjMCBb11usrW2OtAG+iOTIj5c9Y=
-github.com/hashicorp/terraform-plugin-framework-validators v0.15.0/go.mod h1:Bh89/hNmqsEWug4/XWKYBwtnw3tbz5BAy1L1OgvbIaY=
+github.com/hashicorp/terraform-plugin-framework-validators v0.16.0 h1:O9QqGoYDzQT7lwTXUsZEtgabeWW96zUBh47Smn2lkFA=
+github.com/hashicorp/terraform-plugin-framework-validators v0.16.0/go.mod h1:Bh89/hNmqsEWug4/XWKYBwtnw3tbz5BAy1L1OgvbIaY=
 github.com/hashicorp/terraform-plugin-go v0.25.0 h1:oi13cx7xXA6QciMcpcFi/rwA974rdTxjqEhXJjbAyks=
 github.com/hashicorp/terraform-plugin-go v0.25.0/go.mod h1:+SYagMYadJP86Kvn+TGeV+ofr/R3g4/If0O5sO96MVw=
 github.com/hashicorp/terraform-plugin-log v0.9.0 h1:i7hOA+vdAItN1/7UrfBqBwvYPQ9TFvymaRGZED3FCV0=

--- a/ovh/data_dbaas_logs_cluster_retention_gen.go
+++ b/ovh/data_dbaas_logs_cluster_retention_gen.go
@@ -5,7 +5,10 @@ package ovh
 import (
 	"context"
 
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	ovhtypes "github.com/ovh/terraform-provider-ovh/ovh/types"
 )
 
@@ -18,9 +21,12 @@ func DbaasLogsClusterRetentionDataSourceSchema(ctx context.Context) schema.Schem
 			MarkdownDescription: "Cluster ID",
 		},
 		"duration": schema.StringAttribute{
-			CustomType:          ovhtypes.TfStringType{},
-			Computed:            true,
-			Optional:            true,
+			CustomType: ovhtypes.TfStringType{},
+			Computed:   true,
+			Optional:   true,
+			Validators: []validator.String{
+				stringvalidator.ConflictsWith(path.MatchRoot("retention_id")),
+			},
 			Description:         "Indexed duration expressed in ISO-8601 format",
 			MarkdownDescription: "Indexed duration expressed in ISO-8601 format",
 		},
@@ -31,11 +37,30 @@ func DbaasLogsClusterRetentionDataSourceSchema(ctx context.Context) schema.Schem
 			MarkdownDescription: "Indicates if a new stream can use it",
 		},
 		"retention_id": schema.StringAttribute{
+			CustomType: ovhtypes.TfStringType{},
+			Computed:   true,
+			Optional:   true,
+			Validators: []validator.String{
+				stringvalidator.ConflictsWith(path.MatchRoot("duration")),
+				stringvalidator.ConflictsWith(path.MatchRoot("retention_type")),
+			},
+			Description:         "Retention ID",
+			MarkdownDescription: "Retention ID",
+		},
+		"retention_type": schema.StringAttribute{
 			CustomType:          ovhtypes.TfStringType{},
 			Computed:            true,
 			Optional:            true,
-			Description:         "Retention ID",
-			MarkdownDescription: "Retention ID",
+			Description:         "Retention type",
+			MarkdownDescription: "Retention type",
+			Validators: []validator.String{
+				stringvalidator.OneOf(
+					"LOGS_COLD_STORAGE",
+					"LOGS_INDEXING",
+					"METRICS_TENANT",
+				),
+				stringvalidator.ConflictsWith(path.MatchRoot("retention_id")),
+			},
 		},
 		"service_name": schema.StringAttribute{
 			CustomType:          ovhtypes.TfStringType{},
@@ -51,11 +76,12 @@ func DbaasLogsClusterRetentionDataSourceSchema(ctx context.Context) schema.Schem
 }
 
 type DbaasLogsClusterRetentionModel struct {
-	ClusterId   ovhtypes.TfStringValue `tfsdk:"cluster_id" json:"clusterId"`
-	Duration    ovhtypes.TfStringValue `tfsdk:"duration" json:"duration"`
-	IsSupported ovhtypes.TfBoolValue   `tfsdk:"is_supported" json:"isSupported"`
-	RetentionId ovhtypes.TfStringValue `tfsdk:"retention_id" json:"retentionId"`
-	ServiceName ovhtypes.TfStringValue `tfsdk:"service_name" json:"serviceName"`
+	ClusterId     ovhtypes.TfStringValue `tfsdk:"cluster_id" json:"clusterId"`
+	Duration      ovhtypes.TfStringValue `tfsdk:"duration" json:"duration"`
+	IsSupported   ovhtypes.TfBoolValue   `tfsdk:"is_supported" json:"isSupported"`
+	RetentionId   ovhtypes.TfStringValue `tfsdk:"retention_id" json:"retentionId"`
+	RetentionType ovhtypes.TfStringValue `tfsdk:"retention_type" json:"retentionType"`
+	ServiceName   ovhtypes.TfStringValue `tfsdk:"service_name" json:"serviceName"`
 }
 
 func (v *DbaasLogsClusterRetentionModel) MergeWith(other *DbaasLogsClusterRetentionModel) {
@@ -73,6 +99,10 @@ func (v *DbaasLogsClusterRetentionModel) MergeWith(other *DbaasLogsClusterRetent
 
 	if (v.RetentionId.IsUnknown() || v.RetentionId.IsNull()) && !other.RetentionId.IsUnknown() {
 		v.RetentionId = other.RetentionId
+	}
+
+	if (v.RetentionType.IsUnknown() || v.RetentionType.IsNull()) && !other.RetentionType.IsUnknown() {
+		v.RetentionType = other.RetentionType
 	}
 
 	if (v.ServiceName.IsUnknown() || v.ServiceName.IsNull()) && !other.ServiceName.IsUnknown() {

--- a/ovh/data_dbaas_logs_cluster_retention_test.go
+++ b/ovh/data_dbaas_logs_cluster_retention_test.go
@@ -47,6 +47,11 @@ func TestAccDataSourceDbaasLogsClusterRetention_basic(t *testing.T) {
 						"is_supported",
 						"true",
 					),
+					resource.TestCheckResourceAttr(
+						"data.ovh_dbaas_logs_cluster_retention.ret",
+						"retention_type",
+						"LOGS_INDEXING",
+					),
 				),
 			},
 		},
@@ -90,6 +95,60 @@ func TestAccDataSourceDbaasLogsClusterRetention_by_duration(t *testing.T) {
 						"is_supported",
 						"true",
 					),
+					resource.TestCheckResourceAttr(
+						"data.ovh_dbaas_logs_cluster_retention.ret",
+						"retention_type",
+						"LOGS_INDEXING",
+					),
+				),
+			},
+		},
+	})
+}
+
+func TestAccDataSourceDbaasLogsClusterRetention_by_duration_and_type(t *testing.T) {
+	serviceName := os.Getenv("OVH_DBAAS_LOGS_SERVICE_TEST")
+	clusterId := os.Getenv("OVH_DBAAS_LOGS_CLUSTER_ID")
+	retentionId := os.Getenv("OVH_DBAAS_LOGS_CLUSTER_RETENTION_ID")
+
+	config := fmt.Sprintf(`
+		data "ovh_dbaas_logs_cluster_retention" "ret" {
+			service_name   = "%s"
+			cluster_id     = "%s"
+			duration       = "P1Y"
+			retention_type = "LOGS_INDEXING"
+		}`,
+		serviceName,
+		clusterId,
+	)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheckDbaasLogsClusterRetention(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(
+						"data.ovh_dbaas_logs_cluster_retention.ret",
+						"service_name",
+						serviceName,
+					),
+					resource.TestCheckResourceAttr(
+						"data.ovh_dbaas_logs_cluster_retention.ret",
+						"retention_id",
+						retentionId,
+					),
+					resource.TestCheckResourceAttr(
+						"data.ovh_dbaas_logs_cluster_retention.ret",
+						"is_supported",
+						"true",
+					),
+					resource.TestCheckResourceAttr(
+						"data.ovh_dbaas_logs_cluster_retention.ret",
+						"retention_type",
+						"LOGS_INDEXING",
+					),
 				),
 			},
 		},
@@ -116,7 +175,34 @@ func TestAccDataSourceDbaasLogsClusterRetention_by_duration_not_found(t *testing
 		Steps: []resource.TestStep{
 			{
 				Config:      config,
-				ExpectError: regexp.MustCompile("no retention was found with duration P1000Y"),
+				ExpectError: regexp.MustCompile("no retention was found with duration P1000Y and type LOGS_INDEXING"),
+			},
+		},
+	})
+}
+
+func TestAccDataSourceDbaasLogsClusterRetention_by_duration_and_type_not_found(t *testing.T) {
+	serviceName := os.Getenv("OVH_DBAAS_LOGS_SERVICE_TEST")
+	clusterId := os.Getenv("OVH_DBAAS_LOGS_CLUSTER_ID")
+
+	config := fmt.Sprintf(`
+		data "ovh_dbaas_logs_cluster_retention" "ret" {
+			service_name   = "%s"
+			cluster_id     = "%s"
+			duration       = "P1Y"
+			retention_type = "METRICS_TENANT"
+		}`,
+		serviceName,
+		clusterId,
+	)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheckDbaasLogsClusterRetention(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config:      config,
+				ExpectError: regexp.MustCompile("no retention was found with duration P1Y and type METRICS_TENANT"),
 			},
 		},
 	})
@@ -142,6 +228,35 @@ func TestAccDataSourceDbaasLogsClusterRetention_missing_params(t *testing.T) {
 			{
 				Config:      config,
 				ExpectError: regexp.MustCompile("missing retention_id or duration"),
+			},
+		},
+	})
+}
+
+func TestAccDataSourceDbaasLogsClusterRetention_invalid_params(t *testing.T) {
+	serviceName := os.Getenv("OVH_DBAAS_LOGS_SERVICE_TEST")
+	clusterId := os.Getenv("OVH_DBAAS_LOGS_CLUSTER_ID")
+	retentionId := os.Getenv("OVH_DBAAS_LOGS_CLUSTER_RETENTION_ID")
+
+	config := fmt.Sprintf(`
+		data "ovh_dbaas_logs_cluster_retention" "ret" {
+			service_name   = "%s"
+			cluster_id     = "%s"
+			retention_id   = "%s"
+			retention_type = "LOGS_INDEXING"
+		}`,
+		serviceName,
+		clusterId,
+		retentionId,
+	)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheckDbaasLogsCluster(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config:      config,
+				ExpectError: regexp.MustCompile(`Attribute \"retention_type\" cannot be specified when \"retention_id\"`),
 			},
 		},
 	})

--- a/vendor/github.com/hashicorp/terraform-plugin-framework-validators/internal/schemavalidator/exactly_one_of.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-framework-validators/internal/schemavalidator/exactly_one_of.go
@@ -29,6 +29,7 @@ var (
 	_ validator.Object  = ExactlyOneOfValidator{}
 	_ validator.Set     = ExactlyOneOfValidator{}
 	_ validator.String  = ExactlyOneOfValidator{}
+	_ validator.Dynamic = ExactlyOneOfValidator{}
 )
 
 // ExactlyOneOfValidator is the underlying struct implementing ExactlyOneOf.
@@ -265,6 +266,20 @@ func (av ExactlyOneOfValidator) ValidateSet(ctx context.Context, req validator.S
 }
 
 func (av ExactlyOneOfValidator) ValidateString(ctx context.Context, req validator.StringRequest, resp *validator.StringResponse) {
+	validateReq := ExactlyOneOfValidatorRequest{
+		Config:         req.Config,
+		ConfigValue:    req.ConfigValue,
+		Path:           req.Path,
+		PathExpression: req.PathExpression,
+	}
+	validateResp := &ExactlyOneOfValidatorResponse{}
+
+	av.Validate(ctx, validateReq, validateResp)
+
+	resp.Diagnostics.Append(validateResp.Diagnostics...)
+}
+
+func (av ExactlyOneOfValidator) ValidateDynamic(ctx context.Context, req validator.DynamicRequest, resp *validator.DynamicResponse) {
 	validateReq := ExactlyOneOfValidatorRequest{
 		Config:         req.Config,
 		ConfigValue:    req.ConfigValue,

--- a/vendor/github.com/hashicorp/terraform-plugin-framework-validators/listvalidator/no_null_values.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-framework-validators/listvalidator/no_null_values.go
@@ -1,0 +1,78 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package listvalidator
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/function"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+)
+
+var _ validator.List = noNullValuesValidator{}
+var _ function.ListParameterValidator = noNullValuesValidator{}
+
+type noNullValuesValidator struct{}
+
+func (v noNullValuesValidator) Description(_ context.Context) string {
+	return "All values in the list must be configured"
+}
+
+func (v noNullValuesValidator) MarkdownDescription(ctx context.Context) string {
+	return v.Description(ctx)
+}
+
+func (v noNullValuesValidator) ValidateList(_ context.Context, req validator.ListRequest, resp *validator.ListResponse) {
+	if req.ConfigValue.IsNull() || req.ConfigValue.IsUnknown() {
+		return
+	}
+
+	elements := req.ConfigValue.Elements()
+
+	for _, e := range elements {
+		// Only evaluate known values for null
+		if e.IsUnknown() {
+			continue
+		}
+
+		if e.IsNull() {
+			resp.Diagnostics.AddAttributeError(
+				req.Path,
+				"Null List Value",
+				"This attribute contains a null value.",
+			)
+		}
+	}
+}
+
+func (v noNullValuesValidator) ValidateParameterList(ctx context.Context, req function.ListParameterValidatorRequest, resp *function.ListParameterValidatorResponse) {
+	if req.Value.IsNull() || req.Value.IsUnknown() {
+		return
+	}
+
+	elements := req.Value.Elements()
+
+	for _, e := range elements {
+		// Only evaluate known values for null
+		if e.IsUnknown() {
+			continue
+		}
+
+		if e.IsNull() {
+			resp.Error = function.ConcatFuncErrors(
+				resp.Error,
+				function.NewArgumentFuncError(
+					req.ArgumentPosition,
+					"Null List Value: This attribute contains a null value.",
+				),
+			)
+		}
+	}
+}
+
+// NoNullValues returns a validator which ensures that any configured list
+// only contains non-null values.
+func NoNullValues() noNullValuesValidator {
+	return noNullValuesValidator{}
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -171,7 +171,7 @@ github.com/hashicorp/terraform-plugin-framework/schema/validator
 github.com/hashicorp/terraform-plugin-framework/tfsdk
 github.com/hashicorp/terraform-plugin-framework/types
 github.com/hashicorp/terraform-plugin-framework/types/basetypes
-# github.com/hashicorp/terraform-plugin-framework-validators v0.15.0
+# github.com/hashicorp/terraform-plugin-framework-validators v0.16.0
 ## explicit; go 1.22.0
 github.com/hashicorp/terraform-plugin-framework-validators/helpers/validatordiag
 github.com/hashicorp/terraform-plugin-framework-validators/helpers/validatorfuncerr

--- a/website/docs/d/dbaas_logs_cluster_retention.html.markdown
+++ b/website/docs/d/dbaas_logs_cluster_retention.html.markdown
@@ -27,15 +27,28 @@ data "ovh_dbaas_logs_cluster_retention" "retention" {
 }
 ```
 
+Additionnaly, you can filter retentions on their type:
+
+```hcl
+data "ovh_dbaas_logs_cluster_retention" "retention" {
+  service_name   = "ldp-xx-xxxxx"
+  cluster_id     = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
+  duration       = "P14D"
+  retention_type = "LOGS_INDEXING"
+}
+```
+
 ## Argument Reference
 
 * `service_name` - (Required) The service name. It's the ID of your Logs Data Platform instance.
 * `cluster_id` - (Required) Cluster ID
-* `retention_id` - ID of the retention object
-* `duration` - Indexed duration expressed in ISO-8601 format
+* `retention_id` - ID of the retention object. Cannot be used if `duration` or `retention_type` is defined.
+* `retention_type` - Type of the retention (LOGS_INDEXING | LOGS_COLD_STORAGE | METRICS_TENANT). Cannot be used if `retention_id` is defined. Defaults to `LOGS_INDEXING` if not defined.
+* `duration` - Indexed duration expressed in ISO-8601 format. Cannot be used if `retention_id` is defined.
 
 ## Attributes Reference
 
 * `retention_id` - ID of the retention that can be used when creating a stream
 * `duration` - Indexed duration expressed in ISO-8601 format
+* `retention_type` - Type of the retention (LOGS_INDEXING | LOGS_COLD_STORAGE | METRICS_TENANT)
 * `is_supported` - Indicates if a new stream can use it


### PR DESCRIPTION
# Description

A new field has been added on API side: `retentionType`. This PR adds it in datasource `ovh_dbaas_logs_cluster_retention` to be able to filter retentions on the right type.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (improve existing resource(s) or datasource(s))
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

# How Has This Been Tested?

- [ ] Test A: `make testacc TESTARGS="-run TestAccDataSourceDbaasLogsClusterRetention"`

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or issues
- [x] I have added acceptance tests that prove my fix is effective or that my feature works
- [x] New and existing acceptance tests pass locally with my changes
- [x] I ran succesfully `go mod vendor` if I added or modify `go.mod` file
