### PR TITLE
With new datasource : ovh_dedicated_nasha_partition

### DIFF
--- a/ovh/data_dedicated_nasha.go
+++ b/ovh/data_dedicated_nasha.go
@@ -65,6 +65,15 @@ func dataSourceDedicatedNasha() *schema.Resource {
 				Computed:    true,
 				Description: "the size of the HA-NAS",
 			},
+
+			"partitions_list": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Description: "List of partition names for this HA-NAS",
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+			},
 		},
 	}
 }
@@ -90,12 +99,26 @@ func dataSourceDedicatedNashaRead(c context.Context, d *schema.ResourceData, met
 		)
 	}
 
+	var partitionsList []string
+	err = config.OVHClient.Get(
+		fmt.Sprintf("/dedicated/nasha/%s/partition", url.PathEscape(serviceName)),
+		&partitionsList,
+	)
+	if err != nil {
+		return diag.Errorf(
+			"Error calling /dedicated/nasha/%s/partition: %s",
+			serviceName,
+			err,
+		)
+	}
+
 	d.SetId(ds.ServiceName)
 	d.Set("urn", ds.URN)
 	d.Set("service_name", ds.ServiceName)
 	d.Set("monitored", ds.Monitored)
 	d.Set("zpool_size", ds.ZpoolSize)
 	d.Set("zpool_capacity", ds.ZpoolCapacity)
+	d.Set("partitions_list", partitionsList)
 	d.Set("datacenter", ds.Datacenter)
 	d.Set("disk_type", ds.DiskType)
 	d.Set("can_create_partition", ds.CanCreatePartition)

--- a/ovh/data_dedicated_nasha_partition.go
+++ b/ovh/data_dedicated_nasha_partition.go
@@ -1,0 +1,85 @@
+package ovh
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func dataSourceDedicatedNashaPartition() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceDedicatedNashaPartitionRead,
+
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"service_name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+
+			// Computed
+			"description": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"protocol": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"size": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"capacity": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"used_by_snapshots": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func dataSourceDedicatedNashaPartitionRead(c context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	config := meta.(*Config)
+	serviceName := d.Get("service_name").(string)
+	partitionName := d.Get("name").(string)
+
+	ds := &DedicatedNASHAPartition{}
+	err := config.OVHClient.Get(
+		fmt.Sprintf(
+			"/dedicated/nasha/%s/partition/%s",
+			url.PathEscape(serviceName),
+			url.PathEscape(partitionName),
+		),
+		&ds,
+	)
+
+	if err != nil {
+		return diag.Errorf(
+			"Error calling /dedicated/nasha/%s/partition/%s:\n\t %q",
+			serviceName,
+			partitionName,
+			err,
+		)
+	}
+
+	d.SetId(ds.Name)
+	d.Set("name", ds.Name)
+	d.Set("description", ds.Description)
+	d.Set("protocol", ds.Protocol)
+	d.Set("size", ds.Size)
+	d.Set("capacity", ds.Capacity)
+	d.Set("used_by_snapshots", ds.UsedBySnapshots)
+
+	return nil
+}

--- a/ovh/provider.go
+++ b/ovh/provider.go
@@ -143,6 +143,7 @@ func Provider() *schema.Provider {
 			"ovh_dedicated_installation_templates":                           dataSourceDedicatedInstallationTemplates(),
 			"ovh_dedicated_installation_template":                            dataSourceDedicatedInstallationTemplate(),
 			"ovh_dedicated_nasha":                                            dataSourceDedicatedNasha(),
+			"ovh_dedicated_nasha_partition":                                  dataSourceDedicatedNashaPartition(),
 			"ovh_dedicated_server":                                           dataSourceDedicatedServer(),
 			"ovh_dedicated_server_boots":                                     dataSourceDedicatedServerBoots(),
 			"ovh_dedicated_servers":                                          dataSourceDedicatedServers(),

--- a/ovh/types_dedicated_nasha.go
+++ b/ovh/types_dedicated_nasha.go
@@ -8,6 +8,10 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 )
 
+type DedicatedNASHAPartitionsList struct {
+	PartitionName []string `json:"partitionName"`
+}
+
 type DedicatedNASHA struct {
 	ServiceName        string `json:"serviceName,omitempty"`
 	Monitored          bool   `json:"monitored,omitempty"`

--- a/website/docs/d/dedicated_nasha.html.markdown
+++ b/website/docs/d/dedicated_nasha.html.markdown
@@ -33,3 +33,4 @@ In addition, the following attributes are exported:
 * `monitored` - Send an email to customer if any issue is detected
 * `zpool_capacity` - percentage of HA-NAS space used in %
 * `zpool_size` - the size of the HA-NAS in GB
+* `partitions_list` - the list of the HA-NAS partitions name

--- a/website/docs/d/dedicated_nasha_partition.html.markdown
+++ b/website/docs/d/dedicated_nasha_partition.html.markdown
@@ -1,0 +1,33 @@
+---
+subcategory : "NAS-HA"
+---
+
+# ovh_dedicated_nasha_partition (Data Source)
+
+Use this data source to retrieve information about a dedicated HA-NAS partition.
+
+## Example Usage
+
+```hcl
+data "ovh_dedicated_nasha_partition" "my_nas_ha_partition" {
+  service_name = "zpool-12345"
+  name         = "my-zpool-partition"
+}
+```
+
+## Argument Reference
+
+* `service_name` - (Required) The service_name of your dedicated HA-NAS.
+* `name` - (Required) The name of your dedicated HA-NAS partition.
+
+## Attributes Reference
+
+`id` is set with the name of the dedicated HA-NAS partition.
+In addition, the following attributes are exported:
+
+* `size` - size of the partition in GB
+* `protocol` -  one of "NFS", "CIFS" or "NFS_CIFS"
+* `description` - A brief description of the partition
+* `capacity` - Percentage of partition space used in %
+* `used_by_snapshots` - Percentage of partition space used by snapshots in %
+


### PR DESCRIPTION
# Description

This pull request adds a new computed field partitions_list to the ovh_dedicated_nasha data source. The field is populated by calling the GET /dedicated/nasha/{serviceName}/partition endpoint, which returns an array of partition names ([]string). This change allows users to retrieve all partition names for a given NAS-HA service in their Terraform configurations.

# Motivation/Context:

    Allows Terraform users to dynamically fetch and manage partitions for a specific NAS-HA service.
    Enhances the data source by providing more detailed information about the partitions available.

# Dependencies:

    No additional dependencies are required beyond the existing OVH client library.