### PR TITLE
feat: add vrack data source

### DIFF
--- a/ovh/data_vrack.go
+++ b/ovh/data_vrack.go
@@ -1,0 +1,61 @@
+package ovh
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func dataSourceVrack() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceVrackRead,
+		Schema: map[string]*schema.Schema{
+			"service_name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			// Here come all the computed items
+			"name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"description": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"iam": {
+				Type: schema.TypeMap,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+				Computed: true,
+			},
+		},
+	}
+}
+
+func dataSourceVrackRead(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+	serviceName := d.Get("service_name").(string)
+	vrack := &Vrack{}
+	err := config.OVHClient.Get(
+		fmt.Sprintf(
+			"/vrack/%s",
+			serviceName,
+		),
+		&vrack,
+	)
+
+	if err != nil {
+		return fmt.Errorf("Error calling /vrack/%s:\n\t %q", serviceName, err)
+	}
+
+	d.SetId(serviceName)
+	d.Set("name", vrack.Name)
+	d.Set("description", vrack.Description)
+	iam := make(map[string]string)
+	iam["id"] = vrack.IamResourceDetails.Id
+	iam["urn"] = vrack.IamResourceDetails.URN
+	d.Set("iam", iam)
+	return nil
+}

--- a/ovh/data_vrack_test.go
+++ b/ovh/data_vrack_test.go
@@ -1,0 +1,42 @@
+package ovh
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+func TestAccVrackDataSource_basic(t *testing.T) {
+	vrack := os.Getenv("OVH_VRACK_SERVICE_TEST")
+	config := fmt.Sprintf(testAccVrackDatasourceConfig_Basic, vrack)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheckVrack(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(
+						"data.ovh_vrack.vrack", "id", vrack),
+					resource.TestCheckResourceAttr(
+						"data.ovh_vrack.vrack", "service_name", vrack),
+					resource.TestCheckResourceAttrSet(
+						"data.ovh_vrack.vrack", "iam"),
+					resource.TestCheckResourceAttrSet(
+						"data.ovh_vrack.vrack", "name"),
+					resource.TestCheckResourceAttrSet(
+						"data.ovh_vrack.vrack", "description"),
+				),
+			},
+		},
+	})
+}
+
+const testAccVrackDatasourceConfig_Basic = `
+data "ovh_vrack" "vrack" {
+  service_name  = "%s"
+}
+`

--- a/ovh/provider.go
+++ b/ovh/provider.go
@@ -184,6 +184,7 @@ func Provider() *schema.Provider {
 			"ovh_vps":                                                        dataSourceVPS(),
 			"ovh_vpss":                                                       dataSourceVPSs(),
 			"ovh_vracks":                                                     dataSourceVracks(),
+			"ovh_vrack":                                                      dataSourceVrack(),
 		},
 
 		ResourcesMap: map[string]*schema.Resource{

--- a/ovh/provider_test.go
+++ b/ovh/provider_test.go
@@ -396,6 +396,11 @@ func testAccPreCheckOkmsCredential(t *testing.T) {
 	checkEnvOrSkip(t, "OVH_OKMS_CREDENTIAL")
 }
 
+func testAccPreCheckVrack(t *testing.T) {
+	testAccPreCheckCredentials(t)
+	checkEnvOrSkip(t, "OVH_VRACK_SERVICE_TEST")
+}
+
 func testAccCheckVRackExists(t *testing.T) {
 	type vrackResponse struct {
 		Name        string `json:"name"`


### PR DESCRIPTION
# Description

Adding single vRack retrieval data source support

There is currently no raised issue that needs this functionality, however I have noticed it is missing and I need it for a project.

## Type of change

Please delete options that are not relevant.

- [ ] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Simple unit test like implemented for VPS retrieval.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings or issues
- [ ] I have added acceptance tests that prove my fix is effective or that my feature works
- [ ] New and existing acceptance tests pass locally with my changes
- [ ] I ran succesfully `go mod vendor` if I added or modify `go.mod` file
