### PR TITLE
fix ovh_cloud_project_instance 3AZ test

### DIFF
--- a/ovh/resource_cloud_project_instance_test.go
+++ b/ovh/resource_cloud_project_instance_test.go
@@ -108,8 +108,8 @@ func TestAccCloudProjectInstance_basic(t *testing.T) {
 
 func TestAccCloudProjectInstance3AZ_basic(t *testing.T) {
 	serviceName := os.Getenv("OVH_CLOUD_PROJECT_SERVICE_TEST")
-	region := os.Getenv("OVH_CLOUD_PROJECT_REGION_TEST")
-	az := os.Getenv("OVH_CLOUD_PROJECT_3AZ_REGION_TEST")
+	region := os.Getenv("OVH_CLOUD_PROJECT_3AZ_REGION_TEST")
+	az := os.Getenv("OVH_CLOUD_PROJECT_AVAILABILITY_ZONE_TEST")
 	flavor, image, err := getFlavorAndImage(serviceName, region)
 	if err != nil {
 		t.Fatalf("failed to retrieve a flavor and an image: %s", err)


### PR DESCRIPTION
# Description

Test was using a bad set of input variables.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [ ] Test A: `make testacc TESTARGS="-run TestAccCloudProjectInstance3AZ_basic"`