### PR TITLE
feat: Set resource ovh_cloud_project_region_storage_presign up to date

### DIFF
--- a/ovh/types_presigned_url.go
+++ b/ovh/types_presigned_url.go
@@ -5,19 +5,22 @@ import (
 )
 
 type PresignedURL struct {
-	Method string `json:"method"`
-	URL    string `json:"url"`
+	Method        string            `json:"method"`
+	URL           string            `json:"url"`
+	SignedHeaders map[string]string `json:"signedHeaders"`
 }
 
 type PresignedURLInput struct {
-	Expire int    `json:"expire"`
-	Method string `json:"method"`
-	Object string `json:"object"`
+	Expire    int    `json:"expire"`
+	Method    string `json:"method"`
+	Object    string `json:"object"`
+	VersionId string `json:"versionId,omitempty"`
 }
 
 func (opts *PresignedURLInput) FromResource(d *schema.ResourceData) *PresignedURLInput {
 	opts.Expire = d.Get("expire").(int)
 	opts.Method = d.Get("method").(string)
 	opts.Object = d.Get("object").(string)
+	opts.VersionId = d.Get("version_id").(string)
 	return opts
 }

--- a/website/docs/r/cloud_project_region_storage_presign.html.markdown
+++ b/website/docs/r/cloud_project_region_storage_presign.html.markdown
@@ -37,6 +37,7 @@ The following arguments are supported:
 - `method` - (Required) The method you want to use to interact with your
   object. Can be either 'GET' or 'PUT'.
 - `object` - (Required) The name of the object in your S3 bucket.
+- `version_id` - Version ID of the object to download or delete
 
 
 ## Attributes Reference
@@ -50,3 +51,4 @@ The following attributes are exported:
 * `method` - See Argument Reference above.
 * `object` - See Argument Reference above.
 * `url` - Computed URL result.
+* `signed_headers` - Map of signed headers.


### PR DESCRIPTION
# Description

Add the new API fields in resource `ovh_cloud_project_region_storage_presign`.

## Type of change

- [x] Improvement (improve existing resource(s) or datasource(s))

# How Has This Been Tested?

- [x] Test A: `make testacc TESTARGS="-run TestCloudProjectRegionStoragePresign"`

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or issues
- [x] I have added acceptance tests that prove my fix is effective or that my feature works
- [x] New and existing acceptance tests pass locally with my changes
- [x] I ran succesfully `go mod vendor` if I added or modify `go.mod` file
