### PR TITLE
fix: ovh_cloud_project_rancher: avoid loosing bootstrap_password

### DIFF
--- a/ovh/resource_cloud_project_rancher.go
+++ b/ovh/resource_cloud_project_rancher.go
@@ -74,6 +74,10 @@ func (r *cloudProjectRancherResource) Create(ctx context.Context, req resource.C
 		return
 	}
 
+	// The password is only returned in response of the initial POST, so
+	// we save it to set it in the state in the end
+	savedBootstrapPassword := responseData.CurrentState.BootstrapPassword
+
 	// Wait for service to be ready
 	endpoint = "/v2/publicCloud/project/" + url.PathEscape(data.ProjectId.ValueString()) + "/rancher/" + url.PathEscape(responseData.Id.ValueString())
 	if err := helpers.WaitForAPIv2ResourceStatusReady(ctx, r.config.OVHClient, endpoint); err != nil {
@@ -88,6 +92,7 @@ func (r *cloudProjectRancherResource) Create(ctx context.Context, req resource.C
 	}
 
 	responseData.MergeWith(&data)
+	responseData.CurrentState.BootstrapPassword = savedBootstrapPassword
 
 	// Save data into Terraform state
 	resp.Diagnostics.Append(resp.State.Set(ctx, &responseData)...)
@@ -155,6 +160,7 @@ func (r *cloudProjectRancherResource) Update(ctx context.Context, req resource.U
 	}
 
 	responseData.MergeWith(&planData)
+	responseData.MergeWith(&data)
 
 	// Save updated data into Terraform state
 	resp.Diagnostics.Append(resp.State.Set(ctx, &responseData)...)

--- a/ovh/resource_cloud_project_rancher_test.go
+++ b/ovh/resource_cloud_project_rancher_test.go
@@ -33,6 +33,7 @@ func TestAccCloudProjectRancher_basic(t *testing.T) {
 					resource.TestCheckResourceAttrSet("ovh_cloud_project_rancher.ranch", "current_state.version"),
 					resource.TestCheckResourceAttrSet("ovh_cloud_project_rancher.ranch", "current_state.region"),
 					resource.TestCheckResourceAttrSet("ovh_cloud_project_rancher.ranch", "current_state.url"),
+					resource.TestCheckResourceAttrSet("ovh_cloud_project_rancher.ranch", "current_state.bootstrap_password"),
 				),
 			},
 			{
@@ -53,6 +54,7 @@ func TestAccCloudProjectRancher_basic(t *testing.T) {
 					resource.TestCheckResourceAttrSet("ovh_cloud_project_rancher.ranch", "current_state.version"),
 					resource.TestCheckResourceAttrSet("ovh_cloud_project_rancher.ranch", "current_state.region"),
 					resource.TestCheckResourceAttrSet("ovh_cloud_project_rancher.ranch", "current_state.url"),
+					resource.TestCheckResourceAttrSet("ovh_cloud_project_rancher.ranch", "current_state.bootstrap_password"),
 				),
 			},
 		},


### PR DESCRIPTION
# Description

`bootstrap_password` is only returned when creating the Rancher service and was never saved in the state.
This PR makes sure the password is saved.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] Test A: `make testacc TESTARGS="-run TestAccCloudProjectRancher_basic"`

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or issues
- [x] I have added acceptance tests that prove my fix is effective or that my feature works
- [x] New and existing acceptance tests pass locally with my changes
- [x] I ran succesfully `go mod vendor` if I added or modify `go.mod` file
