### PR TITLE
fix: Send the right raid_level in dedicated reinstall task

### DIFF
--- a/ovh/resource_dedicated_server_reinstall_task.go
+++ b/ovh/resource_dedicated_server_reinstall_task.go
@@ -257,6 +257,7 @@ func resourceDedicatedServerReinstallTask() *schema.Resource {
 												},
 												"raid_level": {
 													Type:        schema.TypeInt,
+													Default:     1,
 													Optional:    true,
 													ForceNew:    true,
 													Description: "Software raid type (default is 1)",

--- a/ovh/types_dedicated_server.go
+++ b/ovh/types_dedicated_server.go
@@ -169,7 +169,7 @@ type Partitioning struct {
 type Layout struct {
 	FileSystem string `json:"fileSystem,omitempty"`
 	MountPoint string `json:"mountPoint,omitempty"`
-	RaidLevel  int    `json:"raidLevel,omitempty"`
+	RaidLevel  int    `json:"raidLevel"`
 	Size       int    `json:"size,omitempty"`
 	Extras     Extras `json:"extras,omitempty"`
 }


### PR DESCRIPTION
# Description

Fixes software raid type that was not sent to the API calls when the value is `0`.

Fixes #906 (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)