### PR TITLE
feat: Allow smooth migration for ovh_dedicated_server resource

### DIFF
--- a/docs/guides/dedicated_server_migration.md
+++ b/docs/guides/dedicated_server_migration.md
@@ -1,0 +1,105 @@
+---
+page_title: "Migrating dedicated servers from previous versions to v2.0.0"
+---
+
+Version v2.0.0 of OVHcloud Terraform provider introduced a breaking change on the resources related to dedicated servers, mainly:
+- Deletion of resource `ovh_dedicated_server_install_task` that has been replaced by a new resource `ovh_dedicated_server_reinstall_task`
+- The parameters of resource `ovh_dedicated_server` have been updated to reflect the changes on parameters needed to reinstall a dedicated server
+
+The complete changelog can be found [here](https://github.com/ovh/terraform-provider-ovh/releases/tag/v2.0.0).
+
+This guide explains how to migrate your existing configuration relying on resource `ovh_dedicated_server_install_task` to a new configuration compatible with version v2.0.0 of the provider without triggering a reinstallation of your dedicated servers.
+
+!> This documentation presents a direct migration path between v1.6.0 and v2.0.0. To make this transition easier, we released a version v1.7.0 of the provider that includes both deprecated resources and the new ones. The migration steps are the same, but this version allows a more gradual shift towards v2.0.0.
+
+## First step: import your dedicated servers in the state
+
+From version v2.0.0 and later, the preferred way to manage dedicated servers installation details is through usage of resource `ovh_dedicated_server`. As a result, if you don't already have your dedicated servers declared in your Terraform configuration, you must import them.
+
+You can use an `import` block like the following:
+
+```terraform
+import {
+  id = "nsxxxxxxx.ip-xx-xx-xx.eu"
+  to = ovh_dedicated_server.srv
+}
+
+resource "ovh_dedicated_server" "srv" {}
+```
+
+-> If you are doing a first migration to v1.7.0, you should add the following parameter `prevent_install_on_import = true` to the dedicated server resource. This guarantees you that the server won't be reinstalled after import, even if you have a diff on the reinstall-related parameters.
+
+To finish importing the resource into your Terraform state, you should run:
+
+```sh
+terraform apply
+```
+
+## Second step: backport your previous task details into the imported resource
+
+This step is manual and requires you to convert the previous installation details from resource `ovh_dedicated_server_install_task` to the new fields of resource `ovh_dedicated_server`: `os`, `customizations`, `properties` and `storage`.
+
+Let's take an example: if you previously used the following configuration:
+
+```terraform
+resource "ovh_dedicated_server_install_task" "server_install" {
+  service_name      = "nsxxxxxxx.ip-xx-xx-xx.eu"
+  template_name     = "debian12_64"
+  details {
+      custom_hostname = "mytest"
+  }
+  user_metadata {
+    key = "sshKey"
+    value = "ssh-ed25519 AAAAC3..."
+  }
+  user_metadata {
+    key = "postInstallationScript"
+    value = <<-EOF
+        #!/bin/bash
+          echo "coucou postInstallationScript" > /opt/coucou
+          cat /etc/machine-id  >> /opt/coucou
+          date "+%Y-%m-%d %H:%M:%S" --utc >> /opt/coucou
+        EOF
+  }
+}
+```
+
+You can replace it by the following one:
+
+```terraform
+resource "ovh_dedicated_server" "srv" {
+  customizations = {
+    hostname                 = "mytest"
+    post_installation_script = "IyEvYmluL2Jhc2gKZWNobyAiY291Y291IHBvc3RJbnN0YWxsYXRpb25TY3JpcHQiID4gL29wdC9jb3Vjb3UKY2F0IC9ldGMvbWFjaGluZS1pZCAgPj4gL29wdC9jb3Vjb3UKZGF0ZSAiKyVZLSVtLSVkICVIOiVNOiVTIiAtLXV0YyA+PiAvb3B0L2NvdWNvdQo="
+    ssh_key                  = "ssh-ed25519 AAAAC3..."
+  }
+  os         = "debian12_64"
+  properties = null
+  storage    = null
+}
+```
+
+You can check the documentation of resource `ovh_dedicated_server` to see what inputs are available for the reinstallation-related fields.
+The documentation of resource `ovh_dedicated_server_reinstall_task` also includes several examples of configuration.
+
+## Third step: make sure your server is not reinstalled unintentionally
+
+You should add the following piece of configuration in the declaration of your dedicated server resource in order to avoid a reinstallation on the next `terraform apply`:
+
+```terraform
+resource "ovh_dedicated_server" "srv" {
+  #
+  # ... resource fields
+  #
+
+  lifecycle {
+    ignore_changes = [os, customizations, properties, storage]
+  }
+}
+```
+
+This is needed because there is no API endpoint that returns the previous installation parameters of a dedicated server. The goal here is to migrate your old configuration to the new format without triggering a reinstallation.
+
+## Fourth step: remove the lifecycle block
+
+After a while, whenever you need to trigger a reinstallation of your dedicated server, you can just remove the `lifecycle` field from your configuration and run `terraform apply`.

--- a/go.sum
+++ b/go.sum
@@ -134,8 +134,6 @@ github.com/mitchellh/reflectwalk v1.0.2 h1:G2LzWKi524PWgd3mLHV8Y5k7s6XUvT0Gef6zx
 github.com/mitchellh/reflectwalk v1.0.2/go.mod h1:mSTlrgnPZtwu0c4WaC2kGObEpuNDbx0jmZXqmk4esnw=
 github.com/oklog/run v1.0.0 h1:Ru7dDtJNOyC66gQ5dQmaCa0qIsAUFY3sFpK1Xk8igrw=
 github.com/oklog/run v1.0.0/go.mod h1:dlhp/R75TPv97u0XWUtDeV/lRKWPKSdTuV0TZvrmrQA=
-github.com/ovh/go-ovh v1.6.0 h1:ixLOwxQdzYDx296sXcgS35TOPEahJkpjMGtzPadCjQI=
-github.com/ovh/go-ovh v1.6.0/go.mod h1:cTVDnl94z4tl8pP1uZ/8jlVxntjSIf09bNcQ5TJSC7c=
 github.com/ovh/go-ovh v1.7.0 h1:V14nF7FwDjQrZt9g7jzcvAAQ3HN6DNShRFRMC3jLoPw=
 github.com/ovh/go-ovh v1.7.0/go.mod h1:cTVDnl94z4tl8pP1uZ/8jlVxntjSIf09bNcQ5TJSC7c=
 github.com/pjbgf/sha1cd v0.3.0 h1:4D5XXmUUBUl/xQ6IjCkEAbqXskkq/4O7LmGn0AqMDs4=

--- a/ovh/order_resource_gen.go
+++ b/ovh/order_resource_gen.go
@@ -169,7 +169,6 @@ func OrderResourceSchema(ctx context.Context) schema.Schema {
 				},
 				CustomType: ovhtypes.NewTfListNestedType[PlanValue](ctx),
 				Optional:   true,
-				Computed:   true,
 				PlanModifiers: []planmodifier.List{
 					listplanmodifier.RequiresReplaceIfConfigured(),
 				},
@@ -235,7 +234,6 @@ func OrderResourceSchema(ctx context.Context) schema.Schema {
 				},
 				CustomType: ovhtypes.NewTfListNestedType[PlanOptionValue](ctx),
 				Optional:   true,
-				Computed:   true,
 			},
 		},
 	}

--- a/ovh/resource_dedicated_server.go
+++ b/ovh/resource_dedicated_server.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log"
 	"net/url"
+	"strconv"
 
 	"github.com/ovh/go-ovh/ovh"
 
@@ -14,6 +15,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	ovhtypes "github.com/ovh/terraform-provider-ovh/ovh/types"
 )
@@ -54,12 +56,8 @@ func (d *dedicatedServerResource) Schema(ctx context.Context, req resource.Schem
 }
 
 func (d *dedicatedServerResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
-	// Here we force the attribute "plan" to an empty array because it won't be fetched by the Read function.
-	// If we don't do this, Terraform always shows a diff on the following plans (null => []), due to the
-	// plan modifier RequiresReplace that initializes the attribute to its zero-value (an empty array).
-	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("plan"), ovhtypes.TfListNestedValue[PlanValue]{
-		ListValue: basetypes.NewListValueMust(PlanValue{}.Type(ctx), make([]attr.Value, 0)),
-	})...)
+	resp.Diagnostics.Append(resp.Private.SetKey(ctx, "is_imported", []byte("true"))...)
+	resp.Diagnostics.Append(resp.Private.SetKey(ctx, "run_count", []byte("0"))...)
 	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("service_name"), req.ID)...)
 }
 
@@ -72,41 +70,50 @@ func (r *dedicatedServerResource) Create(ctx context.Context, req resource.Creat
 		return
 	}
 
-	order := data.ToOrder()
-	if err := orderCreate(order, r.config, "baremetalServers", false); err != nil {
-		resp.Diagnostics.AddError("failed to create order", err.Error())
-		return
-	}
-	orderID := order.Order.OrderId.ValueInt64()
-	data.Order = OrderValue{
-		state:   attr.ValueStateKnown,
-		OrderId: ovhtypes.NewTfInt64Value(orderID),
-	}
-
-	// Wait for order to be completed
-	_, err := waitOrderCompletionV2(ctx, r.config, orderID)
-	if err != nil {
-		timeout := &retry.TimeoutError{}
-		if errors.As(err, &timeout) {
-			// Delivery took too long, just store the order ID and leave.
-			// Resource will have to be untainted before next apply (cf: https://discuss.hashicorp.com/t/partial-resource-create-tainted-state/48905).
-			resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
-			resp.Diagnostics.AddError("still waiting for order to be completed", fmt.Sprintf("Order %d not delivered yet, saving the ID for later", orderID))
-		} else {
-			// Got a real error, return it and don't save anything in the state
-			resp.Diagnostics.AddError("error waiting for order", err.Error())
+	// If service_name is not provided, it means dedicated server has to be ordered
+	if data.ServiceName.IsNull() || data.ServiceName.IsUnknown() {
+		order := data.ToOrder()
+		if err := orderCreate(order, r.config, "baremetalServers", false); err != nil {
+			resp.Diagnostics.AddError("failed to create order", err.Error())
+			return
 		}
-		return
+		orderID := order.Order.OrderId.ValueInt64()
+		data.Order = OrderValue{
+			state:   attr.ValueStateKnown,
+			OrderId: ovhtypes.NewTfInt64Value(orderID),
+		}
+
+		// Wait for order to be completed
+		_, err := waitOrderCompletionV2(ctx, r.config, orderID)
+		if err != nil {
+			timeout := &retry.TimeoutError{}
+			if errors.As(err, &timeout) {
+				// Delivery took too long, just store the order ID and leave.
+				// Resource will have to be untainted before next apply (cf: https://discuss.hashicorp.com/t/partial-resource-create-tainted-state/48905).
+				resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+				resp.Diagnostics.AddError("still waiting for order to be completed", fmt.Sprintf("Order %d not delivered yet, saving the ID for later", orderID))
+			} else {
+				// Got a real error, return it and don't save anything in the state
+				resp.Diagnostics.AddError("error waiting for order", err.Error())
+			}
+			return
+		}
+
+		// Find service name from order
+		r.getServiceName(ctx, &data, orderID, resp.Diagnostics)
+		if resp.Diagnostics.HasError() {
+			return
+		}
 	}
 
-	// Find service name from order
-	r.getServiceName(ctx, &data, orderID, resp.Diagnostics)
-	if resp.Diagnostics.HasError() {
+	// Reinstall server if not blocked by configuration
+	if err := r.reinstallDedicatedServer(ctx, data.PreventInstallOnCreate.ValueBool(), nil, &data); err != nil {
+		resp.Diagnostics.AddError("failed to reinstall server", err.Error())
 		return
 	}
 
 	// Update resource
-	r.updateDedicatedServerResource(ctx, nil, &data, &responseData, resp.Diagnostics)
+	r.updateDedicatedServerResource(ctx, nil, &data, &responseData, &resp.Diagnostics)
 	if resp.Diagnostics.HasError() {
 		// TODO: not sure we should return here, maybe save the state instead
 		return
@@ -166,10 +173,35 @@ func (r *dedicatedServerResource) Read(ctx context.Context, req resource.ReadReq
 		return
 	}
 
-	data.MergeWith(&responseData)
+	responseData.MergeWith(&data)
+
+	// Check if resource has just been imported. If it is the case, increase
+	// the run counter each time we go through this function. The run counter
+	// value is used in the Update function to decide if the server should be
+	// reinstalled or not.
+	isImported, privDiags := req.Private.GetKey(ctx, "is_imported")
+	if privDiags.HasError() {
+		resp.Diagnostics.Append(privDiags...)
+		return
+	}
+
+	if isImported != nil && string(isImported) == "true" {
+		runCounter, privDiags := req.Private.GetKey(ctx, "run_count")
+		if privDiags.HasError() {
+			resp.Diagnostics.Append(privDiags...)
+			return
+		}
+		count, err := strconv.Atoi(string(runCounter))
+		if err != nil {
+			resp.Diagnostics.AddError("failed to read run_count from private state", err.Error())
+			return
+		}
+
+		resp.Private.SetKey(ctx, "run_count", []byte(strconv.Itoa(count+1)))
+	}
 
 	// Save updated data into Terraform state
-	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+	resp.Diagnostics.Append(resp.State.Set(ctx, &responseData)...)
 }
 
 func (r *dedicatedServerResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
@@ -216,8 +248,48 @@ func (r *dedicatedServerResource) Update(ctx context.Context, req resource.Updat
 		}
 	}
 
+	// Check if resource has just been imported, and remove key from private state.
+	// We need this information to know if a reinstall should be forced at this point.
+	isImported, privDiags := req.Private.GetKey(ctx, "is_imported")
+	if privDiags.HasError() {
+		resp.Diagnostics.Append(privDiags...)
+		return
+	}
+	resp.Private.SetKey(ctx, "is_imported", nil)
+
+	// Decide if server installation should be blocked. This happens when resource has
+	// just been imported and the parameter "prevent_install_on_import" is true.
+	var preventReinstall bool
+	if isImported != nil && string(isImported) == "true" {
+		runCounter, privDiags := req.Private.GetKey(ctx, "run_count")
+		if privDiags.HasError() {
+			resp.Diagnostics.Append(privDiags...)
+			return
+		}
+		resp.Private.SetKey(ctx, "run_count", nil)
+
+		count, err := strconv.Atoi(string(runCounter))
+		if err != nil {
+			resp.Diagnostics.AddError("failed to read run_count from private state", err.Error())
+			return
+		}
+
+		// When "is_imported" is true, check parameter "prevent_install_on_import" to decide
+		// if we should allow a server reinstallation.
+		// If "run_count" is > 1, it means that Update was not called at import time, so we just
+		// ignore this parameter: changing the value of "prevent_install_on_import" after import
+		// should not have any effect.
+		preventReinstall = count == 1 && planData.PreventInstallOnImport.ValueBool()
+	}
+
+	// Reinstall server (if needed and not blocked)
+	if err := r.reinstallDedicatedServer(ctx, preventReinstall, &stateData, &planData); err != nil {
+		resp.Diagnostics.AddError("failed to reinstall server", err.Error())
+		return
+	}
+
 	// Update resource
-	r.updateDedicatedServerResource(ctx, &stateData, &planData, &responseData, resp.Diagnostics)
+	r.updateDedicatedServerResource(ctx, &stateData, &planData, &responseData, &resp.Diagnostics)
 	if resp.Diagnostics.HasError() {
 		// TODO: not sure we should return here, maybe save the state instead
 		return
@@ -226,9 +298,17 @@ func (r *dedicatedServerResource) Update(ctx context.Context, req resource.Updat
 	responseData.MergeWith(&planData)
 	responseData.MergeWith(&stateData)
 
-	// Explicitely set UserMetadata to what was defined in the plan
+	// Explicitly set installation config to what was defined in the plan
 	// as we can't determine the right thing to do in MergeWith function
 	responseData.UserMetadata = planData.UserMetadata
+	responseData.Customizations = planData.Customizations
+	responseData.Properties = planData.Properties
+	responseData.Storage = planData.Storage
+
+	// Same thing for the flags to control reinstallation, set the plan value explicitly
+	responseData.PreventInstallOnCreate = planData.PreventInstallOnCreate
+	responseData.PreventInstallOnImport = planData.PreventInstallOnImport
+	responseData.KeepServiceAfterDestroy = planData.KeepServiceAfterDestroy
 
 	// Save updated data into Terraform state
 	resp.Diagnostics.Append(resp.State.Set(ctx, &responseData)...)
@@ -240,6 +320,11 @@ func (r *dedicatedServerResource) Delete(ctx context.Context, req resource.Delet
 	// Read Terraform prior state data into the model
 	resp.Diagnostics.Append(req.State.Get(ctx, &data)...)
 	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if data.KeepServiceAfterDestroy.ValueBool() {
+		log.Print("Will remove the resource without terminating service")
 		return
 	}
 
@@ -277,18 +362,13 @@ func (r *dedicatedServerResource) Delete(ctx context.Context, req resource.Delet
 	}
 }
 
-func (r *dedicatedServerResource) updateDedicatedServerResource(ctx context.Context, stateData, planData, responseData *DedicatedServerModel, diags diag.Diagnostics) {
-	// Check if server needs to be reinstalled
-	var shouldReinstall bool
-	if stateData != nil {
-		if stateData.TemplateName.ValueString() != planData.TemplateName.ValueString() ||
-			!stateData.UserMetadata.Equal(planData.UserMetadata) {
-			shouldReinstall = true
-		}
-	} else {
-		if planData.TemplateName.ValueString() != "" {
-			shouldReinstall = true
-		}
+func (r *dedicatedServerResource) reinstallDedicatedServer(ctx context.Context, preventReinstall bool, stateData, planData *DedicatedServerModel) error {
+	tflog.Debug(ctx, fmt.Sprintf("Prevent server reinstallation: %t", preventReinstall))
+	tflog.Debug(ctx, fmt.Sprintf("State data is nil: %t", stateData == nil))
+
+	if preventReinstall {
+		tflog.Debug(ctx, "Prevent reinstallation of the server is true")
+		return nil
 	}
 
 	// Get service name
@@ -297,28 +377,66 @@ func (r *dedicatedServerResource) updateDedicatedServerResource(ctx context.Cont
 		serviceName = stateData.ServiceName.ValueString()
 	}
 
+	var shouldReinstallWithV1, shouldReinstallWithV2 bool
+
+	switch stateData {
+	// Check if we should install server right after it has been delivered
+	case nil:
+		if planData.TemplateName.ValueString() != "" {
+			shouldReinstallWithV1 = true
+		} else if planData.Os.ValueString() != "" {
+			shouldReinstallWithV2 = true
+		}
+
+	// Classical update when resource already exists.
+	// Checks state data against plan data to decide if a reinstall should be triggered.
+	default:
+		if stateData.TemplateName.ValueString() != planData.TemplateName.ValueString() ||
+			!stateData.UserMetadata.Equal(planData.UserMetadata) {
+			shouldReinstallWithV1 = true
+		} else if stateData.Os.ValueString() != planData.Os.ValueString() ||
+			!stateData.Customizations.Equal(planData.Customizations) ||
+			!stateData.Storage.Equal(planData.Storage) ||
+			!stateData.Properties.Equal(planData.Properties) {
+			shouldReinstallWithV2 = true
+		}
+	}
+
 	// Trigger server reinstallation
-	endpoint := "/dedicated/server/" + url.PathEscape(serviceName) + "/install/start"
-	if shouldReinstall {
+	if shouldReinstallWithV1 || shouldReinstallWithV2 {
 		log.Print("Triggering server reinstallation")
+
 		task := DedicatedServerTask{}
-		if err := r.config.OVHClient.Post(endpoint, planData.ToReinstall(), &task); err != nil {
-			diags.AddError(
-				fmt.Sprintf("Error calling Post %s", endpoint),
-				err.Error(),
-			)
-			return
+		if shouldReinstallWithV1 {
+			endpoint := "/dedicated/server/" + url.PathEscape(serviceName) + "/install/start"
+			if err := r.config.OVHClient.Post(endpoint, planData.ToReinstall(), &task); err != nil {
+				return fmt.Errorf("error calling Post %s", endpoint)
+			}
+		} else {
+			endpoint := "/dedicated/server/" + url.PathEscape(serviceName) + "/reinstall"
+			if err := r.config.OVHClient.Post(endpoint, planData.ToReinstallV2(), &task); err != nil {
+				return fmt.Errorf("error calling Post %s", endpoint)
+			}
 		}
 
 		// Wait for reinstallation completion
 		if err := waitForDedicatedServerTask(serviceName, &task, r.config.OVHClient); err != nil {
-			diags.AddError("Error during server reinstallation", err.Error())
-			return
+			return fmt.Errorf("error during server reinstallation: %s", err.Error())
 		}
 	}
 
+	return nil
+}
+
+func (r *dedicatedServerResource) updateDedicatedServerResource(ctx context.Context, stateData, planData, responseData *DedicatedServerModel, diags *diag.Diagnostics) {
+	// Get service name
+	serviceName := planData.ServiceName.ValueString()
+	if stateData != nil {
+		serviceName = stateData.ServiceName.ValueString()
+	}
+
 	// PUT the resource
-	endpoint = "/dedicated/server/" + url.PathEscape(serviceName)
+	endpoint := "/dedicated/server/" + url.PathEscape(serviceName)
 	if err := r.config.OVHClient.Put(endpoint, planData.ToUpdate(), nil); err != nil {
 		diags.AddError(
 			fmt.Sprintf("Error calling Put %s", endpoint),

--- a/website/docs/r/dedicated_server.html.markdown
+++ b/website/docs/r/dedicated_server.html.markdown
@@ -91,6 +91,7 @@ resource "ovh_dedicated_server" "server" {
   * `configuration` - Representation of a configuration item to personalize product
     * `label` - (Required) Identifier of the resource
     * `value` - (Required) Path to the resource in API.OVH.COM
+* `service_name` - (Optional) The service_name of your dedicated server. This field can be used to avoid ordering a dedicated server at creation and just create the resource using an already existing service
 
 ### Editable fields of a dedicated server
 
@@ -101,8 +102,49 @@ resource "ovh_dedicated_server" "server" {
 * `rescue_ssh_key` - Public SSH Key used in the rescue mode
 * `root_device` - Root device of the server
 * `state` - All states a Dedicated can in (error, hacked, hackedBlocked, ok)
+* `keep_service_after_destroy` - Avoid termination of the service when deleting the resource (when using this parameter, make sure to apply your configuration before running the destroy so that the value is set in the state)
+* `prevent_install_on_create` - Prevent server installation after it has been delivered
+* `prevent_install_on_import` - Defines whether a reinstallation of the server is allowed after importing it if there is a modification on the installation parameters
 
 ### Arguments used to reinstall a dedicated server
+
+#### New arguments
+
+* `os` - (String) Operating System to install
+* `customizations` - (Attributes) Customization of the OS configuration
+  * `config_drive_user_data` -Config Drive UserData
+  * `efi_bootloader_path` - Path of the EFI bootloader from the OS installed on the server
+  * `hostname` - Custom hostname
+  * `http_headers` - Image HTTP Headers
+  * `image_check_sum` - Image checksum
+  * `image_check_sum_type` - Checksum type
+  * `image_type` - Image Type
+  * `image_url` - Image URL
+  * `language` - Display Language
+  * `post_installation_script` - Post-Installation Script
+  * `post_installation_script_extension` - Post-Installation Script File Extension
+  * `ssh_key` - SSH Public Key
+* `storage` - (Attributes List) Storage customizations
+  * `disk_group_id` - Disk group id
+  * `hardware_raid` - Hardware Raid configurations
+    * `arrays` - Number of arrays
+    * `disks` - Total number of disks in the disk group involved in the hardware raid configuration
+    * `raid_level` - Hardware raid type
+    * `spares` - Number of disks in the disk group involved in the spare
+  * `partitioning` - Partitioning configuration
+    * `disks` - Total number of disks in the disk group involved in the partitioning configuration
+    * `layout` - Custom partitioning layout
+      * `extras` - Partition extras parameters
+        * `lv` - LVM-specific parameters
+        * `zp` - ZFS-specific parameters
+      * `file_system` - File system type
+      * `mount_point` - Mount point
+      * `raid_level` - Software raid type
+      * `size` - Partition size in MiB
+    * `scheme_name` - Partitioning scheme (if applicable with selected operating system)
+* `properties` - (Map string, string) Arbitrary properties to pass to cloud-init's config drive datasource
+
+#### Legacy arguments, will be removed in version v2.0.0
 
 * `details` - Details object when reinstalling server (see https://eu.api.ovh.com/console/?section=%2Fdedicated%2Fserver&branch=v1#post-/dedicated/server/-serviceName-/install/start)
   * `custom_hostname` - Personnal hostname to use in server reinstallation


### PR DESCRIPTION
# Description

Add the new installation parameters (first introduced in v2.0.0) in resource `ovh_dedicated_server` to allow a smooth migration from v1.6.0 to v2.0.0.
This PR also adds a migration guide.

## Type of change

- [x] Improvement (improve existing resource(s) or datasource(s))
- [x] Documentation update