### PR TITLE
feat: Allow creating an instance on a private network

### DIFF
--- a/docs/data-sources/cloud_project_instance.md
+++ b/docs/data-sources/cloud_project_instance.md
@@ -43,3 +43,4 @@ The following attributes are exported:
 * `image_id` - Image id
 * `task_state` - Instance task state
 * `ssh_key` - SSH Keypair
+* `status` - Instance status

--- a/docs/data-sources/cloud_project_instances.md
+++ b/docs/data-sources/cloud_project_instances.md
@@ -43,3 +43,4 @@ The following attributes are exported:
   * `image_id` - Image id
   * `task_state` - Instance task state
   * `ssh_key` - SSH Keypair
+  * `status` - Instance status

--- a/docs/resources/cloud_project_instance.md
+++ b/docs/resources/cloud_project_instance.md
@@ -39,7 +39,28 @@ The following arguments are supported:
 * `region` - (Required, Forces new resource) Instance region
 * `billing_period` - (Required, Forces new resource) Billing period - hourly or monthly
 * `network` - (Required, Forces new resource) Create network interfaces
-  * `public` - (Optional, Forces new resource) Set the new instance as public boolean
+  * `public` - (Optional, Forces new resource) Set the new instance as public
+  * `private` - (Optional, Forces new resource) Private network information
+    * `floating_ip` - (Optional, Forces new resource) Existing floating IP
+      * `id` - (Optional, Forces new resource) Floating IP ID
+    * `floating_ip_create` - (Optional, Forces new resource) Information to create a new floating IP
+      * `description` - (Optional, Forces new resource) Floating IP description
+    * `gateway` - (Optional, Forces new resource) Existing gateway
+      * `id` - (Optional, Forces new resource) Gateway ID
+    * `gateway_create` - (Optional, Forces new resource) Information to create a new gateway
+      * `model` - (Optional, Forces new resource) Gateway model (s | m | l)
+      * `name` - (Optional, Forces new resource) Gateway name
+    * `ip` - (Optional, Forces new resource) Instance IP in the private network
+    * `network` - (Optional, Forces new resource) Existing private network
+      * `id` - (Optional, Forces new resource) Network ID
+      * `subnet_id` - (Optional, Forces new resource) Existing subnet ID
+    * network_create - (Optional, Forces new resource) Information to create a new private network
+      * `name` - (Optional, Forces new resource) Network name
+      * `vlan_id` - (Optional, Forces new resource) Network vlan ID
+      * `subnet` - (Optional, Forces new resource) New subnet information
+        * `cidr` - (Optional, Forces new resource) Subnet range in CIDR notation
+        * `enable_dhcp` - (Optional, Forces new resource) Whether to enable DHCP
+        * `ip_version` - (Optional, Forces new resource) IP version
 * `flavor` - (Required, Forces new resource) Flavor information
   * `flavor_id` - (Required, Forces new resource) Flavor ID. Flavors can be retrieved using `GET /cloud/project/{serviceName}/flavor`
 * `boot_from` - (Required, Forces new resource) Boot the instance from an image or a volume
@@ -74,3 +95,4 @@ The following attributes are exported:
 * `name` - Instance name
 * `image_id` - Image id
 * `task_state` - Instance task state
+* `status` - Instance status

--- a/ovh/data_cloud_project_instance.go
+++ b/ovh/data_cloud_project_instance.go
@@ -98,6 +98,11 @@ func dataSourceCloudProjectInstance() *schema.Resource {
 				Description: "Instance task state",
 				Computed:    true,
 			},
+			"status": {
+				Type:        schema.TypeString,
+				Description: "Instance status",
+				Computed:    true,
+			},
 		},
 	}
 }
@@ -146,6 +151,7 @@ func dataSourceCloudProjectInstanceRead(d *schema.ResourceData, meta interface{}
 	d.Set("availability_zone", res.AvailabilityZone)
 	d.Set("task_state", res.TaskState)
 	d.Set("attached_volumes", attachedVolumes)
+	d.Set("status", res.Status)
 
 	return nil
 }

--- a/ovh/data_cloud_project_instances.go
+++ b/ovh/data_cloud_project_instances.go
@@ -101,6 +101,11 @@ func dataSourceCloudProjectInstances() *schema.Resource {
 							Description: "SSH Key pair name",
 							Computed:    true,
 						},
+						"status": {
+							Type:        schema.TypeString,
+							Description: "Instance status",
+							Computed:    true,
+						},
 						"task_state": {
 							Type:        schema.TypeString,
 							Description: "Instance task state",

--- a/ovh/types_cloud.go
+++ b/ovh/types_cloud.go
@@ -75,7 +75,7 @@ type CloudProjectSubOperation struct {
 func waitForCloudProjectOperation(ctx context.Context, c *ovh.Client, serviceName, operationId, actionType string) (string, error) {
 	endpoint := fmt.Sprintf("/cloud/project/%s/operation/%s", url.PathEscape(serviceName), url.PathEscape(operationId))
 	resourceID := ""
-	err := retry.RetryContext(ctx, 10*time.Minute, func() *retry.RetryError {
+	err := retry.RetryContext(ctx, 60*time.Minute, func() *retry.RetryError {
 		ro := &CloudProjectOperationResponse{}
 		if err := c.GetWithContext(ctx, endpoint, ro); err != nil {
 			return retry.NonRetryableError(err)

--- a/templates/data-sources/cloud_project_instance.md.tmpl
+++ b/templates/data-sources/cloud_project_instance.md.tmpl
@@ -41,3 +41,4 @@ The following attributes are exported:
 * `image_id` - Image id
 * `task_state` - Instance task state
 * `ssh_key` - SSH Keypair
+* `status` - Instance status

--- a/templates/data-sources/cloud_project_instances.md.tmpl
+++ b/templates/data-sources/cloud_project_instances.md.tmpl
@@ -42,3 +42,4 @@ The following attributes are exported:
   * `image_id` - Image id
   * `task_state` - Instance task state
   * `ssh_key` - SSH Keypair
+  * `status` - Instance status

--- a/templates/resources/cloud_project_instance.md.tmpl
+++ b/templates/resources/cloud_project_instance.md.tmpl
@@ -24,7 +24,28 @@ The following arguments are supported:
 * `region` - (Required, Forces new resource) Instance region
 * `billing_period` - (Required, Forces new resource) Billing period - hourly or monthly
 * `network` - (Required, Forces new resource) Create network interfaces
-  * `public` - (Optional, Forces new resource) Set the new instance as public boolean
+  * `public` - (Optional, Forces new resource) Set the new instance as public
+  * `private` - (Optional, Forces new resource) Private network information
+    * `floating_ip` - (Optional, Forces new resource) Existing floating IP
+      * `id` - (Optional, Forces new resource) Floating IP ID
+    * `floating_ip_create` - (Optional, Forces new resource) Information to create a new floating IP
+      * `description` - (Optional, Forces new resource) Floating IP description
+    * `gateway` - (Optional, Forces new resource) Existing gateway
+      * `id` - (Optional, Forces new resource) Gateway ID
+    * `gateway_create` - (Optional, Forces new resource) Information to create a new gateway
+      * `model` - (Optional, Forces new resource) Gateway model (s | m | l)
+      * `name` - (Optional, Forces new resource) Gateway name
+    * `ip` - (Optional, Forces new resource) Instance IP in the private network
+    * `network` - (Optional, Forces new resource) Existing private network
+      * `id` - (Optional, Forces new resource) Network ID
+      * `subnet_id` - (Optional, Forces new resource) Existing subnet ID
+    * network_create - (Optional, Forces new resource) Information to create a new private network
+      * `name` - (Optional, Forces new resource) Network name
+      * `vlan_id` - (Optional, Forces new resource) Network vlan ID
+      * `subnet` - (Optional, Forces new resource) New subnet information
+        * `cidr` - (Optional, Forces new resource) Subnet range in CIDR notation
+        * `enable_dhcp` - (Optional, Forces new resource) Whether to enable DHCP
+        * `ip_version` - (Optional, Forces new resource) IP version
 * `flavor` - (Required, Forces new resource) Flavor information
   * `flavor_id` - (Required, Forces new resource) Flavor ID. Flavors can be retrieved using `GET /cloud/project/{serviceName}/flavor`
 * `boot_from` - (Required, Forces new resource) Boot the instance from an image or a volume
@@ -59,3 +80,4 @@ The following attributes are exported:
 * `name` - Instance name
 * `image_id` - Image id
 * `task_state` - Instance task state
+* `status` - Instance status


### PR DESCRIPTION
# Description

Allow creating a `ovh_cloud_project_instance` on a private network, and wait for it to be ready after creation.

Fixes #915 (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Improvement (improve existing resource(s) or datasource(s))

# How Has This Been Tested?

- [x] Test A: `make testacc TESTARGS="-run TestAccCloudProjectInstance_privateNetwork"`

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or issues
- [x] I have added acceptance tests that prove my fix is effective or that my feature works
- [x] New and existing acceptance tests pass locally with my changes
- [x] I ran succesfully `go mod vendor` if I added or modify `go.mod` file
