### PR TITLE
fix(ovh_cloud_project_database): Don't error when backup_time is only set in state for an engine that doesn't handle the parameter

### DIFF
--- a/ovh/types_cloud_project_database.go
+++ b/ovh/types_cloud_project_database.go
@@ -317,11 +317,12 @@ func (opts *CloudProjectDatabaseUpdateOpts) fromResource(d *schema.ResourceData)
 	if err != nil {
 		return nil, err
 	}
-	time := d.Get("backup_time").(string)
-	if time != "" && slices.Contains(enginesWithoutBackupTime, engine) {
+
+	if d.HasChange("backup_time") && slices.Contains(enginesWithoutBackupTime, engine) {
 		return nil, fmt.Errorf("backup_time is not customizable for engine %q", engine)
 	}
 
+	time := d.Get("backup_time").(string)
 	if engine != "kafka" && (len(regions) != 0 || time != "") {
 		opts.Backups = &CloudProjectDatabaseBackups{
 			Regions: regions,


### PR DESCRIPTION
# Description

When updating a cloud database, an error is returned if `backup_time` is set for an engine for which this parameter cannot be configured. This error is returned even when the field is only set in the state but not configured by the user.
This PR modifies this behavior to error only when the user has manually updated the value.

Fixes #935 (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] Test A: `make testacc TESTARGS="-run TestAccCloudProjectDatabase_invalidBackupTimeUpdate"`

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or issues
- [x] I have added acceptance tests that prove my fix is effective or that my feature works
- [x] New and existing acceptance tests pass locally with my changes
- [x] I ran succesfully `go mod vendor` if I added or modify `go.mod` file
