### PR TITLE
feat: Add customizable creation timeout for ovh_cloud_project_instance

### DIFF
--- a/docs/resources/cloud_project_instance.md
+++ b/docs/resources/cloud_project_instance.md
@@ -96,3 +96,17 @@ The following attributes are exported:
 * `image_id` - Image id
 * `task_state` - Instance task state
 * `status` - Instance status
+
+## Timeouts
+
+```terraform
+resource "ovh_cloud_project_instance" "instance" {
+  # ...
+
+  timeouts {
+    create = "10min"
+  }
+}
+```
+
+* `create` - (Default 60m)

--- a/examples/resources/cloud_project_instance/timeout.tf
+++ b/examples/resources/cloud_project_instance/timeout.tf
@@ -1,0 +1,7 @@
+resource "ovh_cloud_project_instance" "instance" {
+  # ...
+
+  timeouts {
+    create = "10min"
+  }
+}

--- a/ovh/resource_cloud_project_instance.go
+++ b/ovh/resource_cloud_project_instance.go
@@ -17,6 +17,11 @@ func resourceCloudProjectInstance() *schema.Resource {
 		ReadContext:   resourceCloudProjectInstanceRead,
 		DeleteContext: resourceCloudProjectInstanceDelete,
 
+		Timeouts: &schema.ResourceTimeout{
+			Create:  schema.DefaultTimeout(defaultCloudOperationTimeout),
+			Default: schema.DefaultTimeout(defaultCloudOperationTimeout),
+		},
+
 		Schema: map[string]*schema.Schema{
 			"service_name": {
 				Type:        schema.TypeString,
@@ -438,14 +443,14 @@ func resourceCloudProjectInstanceCreate(ctx context.Context, d *schema.ResourceD
 		return diag.Errorf("calling %s with params %v:\n\t %q", endpoint, params, err)
 	}
 
-	instanceID, err := waitForCloudProjectOperation(ctx, config.OVHClient, serviceName, r.Id, "instance#create")
+	instanceID, err := waitForCloudProjectOperation(ctx, config.OVHClient, serviceName, r.Id, "instance#create", d.Timeout(schema.TimeoutCreate))
 	if err != nil {
 		return diag.Errorf("timeout instance creation: %s", err)
 	}
 
 	d.SetId(instanceID)
 
-	if err := waitForCloudProjectInstance(ctx, config.OVHClient, serviceName, region, instanceID); err != nil {
+	if err := waitForCloudProjectInstance(ctx, config.OVHClient, serviceName, region, instanceID, d.Timeout(schema.TimeoutCreate)); err != nil {
 		return diag.Errorf("error waiting for instance to be ready: %s", err)
 	}
 

--- a/ovh/resource_cloud_project_loadbalancer.go
+++ b/ovh/resource_cloud_project_loadbalancer.go
@@ -97,7 +97,7 @@ func (r *cloudProjectLoadbalancerResource) Create(ctx context.Context, req resou
 	}
 
 	// Wait for operation to be completed
-	resourceID, err := waitForCloudProjectOperation(ctx, r.config.OVHClient, data.ServiceName.ValueString(), operation.Id, "")
+	resourceID, err := waitForCloudProjectOperation(ctx, r.config.OVHClient, data.ServiceName.ValueString(), operation.Id, "", defaultCloudOperationTimeout)
 	if err != nil {
 		resp.Diagnostics.AddError("error waiting for operation", err.Error())
 	}

--- a/ovh/resource_cloud_project_region_network.go
+++ b/ovh/resource_cloud_project_region_network.go
@@ -83,7 +83,7 @@ func (r *cloudProjectRegionNetworkResource) Create(ctx context.Context, req reso
 	}
 
 	// Wait for operation to complete
-	networkID, err := waitForCloudProjectOperation(ctx, r.config.OVHClient, data.ServiceName.ValueString(), operation.Id, "")
+	networkID, err := waitForCloudProjectOperation(ctx, r.config.OVHClient, data.ServiceName.ValueString(), operation.Id, "", defaultCloudOperationTimeout)
 	if err != nil {
 		resp.Diagnostics.AddError(fmt.Sprintf("error waiting for operation %s", operation.Id), err.Error())
 		return

--- a/ovh/types_cloud.go
+++ b/ovh/types_cloud.go
@@ -12,6 +12,8 @@ import (
 	"github.com/ovh/terraform-provider-ovh/v2/ovh/helpers"
 )
 
+const defaultCloudOperationTimeout = 60 * time.Minute
+
 // Opts
 type CloudProjectGatewayCreateOpts struct {
 	Name  string `json:"name"`
@@ -72,10 +74,10 @@ type CloudProjectSubOperation struct {
 	Action     string  `json:"action"`
 }
 
-func waitForCloudProjectOperation(ctx context.Context, c *ovh.Client, serviceName, operationId, actionType string) (string, error) {
+func waitForCloudProjectOperation(ctx context.Context, c *ovh.Client, serviceName, operationId, actionType string, timeout time.Duration) (string, error) {
 	endpoint := fmt.Sprintf("/cloud/project/%s/operation/%s", url.PathEscape(serviceName), url.PathEscape(operationId))
 	resourceID := ""
-	err := retry.RetryContext(ctx, 60*time.Minute, func() *retry.RetryError {
+	err := retry.RetryContext(ctx, timeout, func() *retry.RetryError {
 		ro := &CloudProjectOperationResponse{}
 		if err := c.GetWithContext(ctx, endpoint, ro); err != nil {
 			return retry.NonRetryableError(err)

--- a/ovh/types_cloud_project_instance.go
+++ b/ovh/types_cloud_project_instance.go
@@ -391,10 +391,10 @@ func (cpir *CloudProjectInstanceCreateOpts) FromResource(d *schema.ResourceData)
 	cpir.UserData = helpers.GetNilStringPointerFromData(d, "user_data")
 }
 
-func waitForCloudProjectInstance(ctx context.Context, c *ovh.Client, serviceName, region, instance string) error {
+func waitForCloudProjectInstance(ctx context.Context, c *ovh.Client, serviceName, region, instance string, timeout time.Duration) error {
 	endpoint := fmt.Sprintf("/cloud/project/%s/region/%s/instance/%s", url.PathEscape(serviceName), url.PathEscape(region), url.PathEscape(instance))
 
-	err := retry.RetryContext(ctx, 60*time.Minute, func() *retry.RetryError {
+	err := retry.RetryContext(ctx, timeout, func() *retry.RetryError {
 
 		ro := &CloudProjectInstanceResponse{}
 		if err := c.GetWithContext(ctx, endpoint, ro); err != nil {

--- a/templates/resources/cloud_project_instance.md.tmpl
+++ b/templates/resources/cloud_project_instance.md.tmpl
@@ -81,3 +81,9 @@ The following attributes are exported:
 * `image_id` - Image id
 * `task_state` - Instance task state
 * `status` - Instance status
+
+## Timeouts
+
+{{tffile "examples/resources/cloud_project_instance/timeout.tf"}}
+
+* `create` - (Default 60m)


### PR DESCRIPTION
# Description

This PR adds the ability to customize the timeout for `ovh_cloud_project_instance` resource creation.

Fixes #956 (issue)

## Type of change

- [x] Improvement (improve existing resource(s) or datasource(s))

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or issues
- [x] I have added acceptance tests that prove my fix is effective or that my feature works
- [x] New and existing acceptance tests pass locally with my changes
- [x] I ran succesfully `go mod vendor` if I added or modify `go.mod` file
