### PR TITLE
feat: Add support for password rotation in cloud project user resource

### DIFF
--- a/docs/resources/cloud_project_user.md
+++ b/docs/resources/cloud_project_user.md
@@ -14,6 +14,17 @@ resource "ovh_cloud_project_user" "user1" {
 }
 ```
 
+## User with rotating password support
+```terraform
+resource "ovh_cloud_project_user" "user_with_rotation" {
+  service_name = "XXX"
+  description  = "Service User created by Terraform with password rotation"
+  rotate_when_changed = {
+    last_rotation = "2025-04-30"
+  }
+}
+```
+
 ## Argument Reference
 
 The following arguments are supported:

--- a/docs/resources/cloud_project_user.md
+++ b/docs/resources/cloud_project_user.md
@@ -14,17 +14,18 @@ resource "ovh_cloud_project_user" "user1" {
 }
 ```
 
-## User with rotating password support
 ```terraform
+# Change password_reset with the datetime each time you want to reset the password to trigger an update
 resource "ovh_cloud_project_user" "user_with_rotation" {
-  service_name = "XXX"
-  description  = "Service User created by Terraform with password rotation"
-  rotate_when_changed = {
-    last_rotation = "2025-04-30"
-  }
+  service_name   = "XXX"
+  description    = "Service User created by Terraform with password rotation"
+  password_reset = "2025-04-30"
 }
 ```
 
+-> **NOTE** To reset password of the user previously created, update the `password_reset` attribute. Use the `terraform refresh` command after executing `terraform apply` to update the output with the new password. This attribute can be an arbitrary string but we recommend 2 formats:
+- a datetime to keep a trace of the last reset
+- a md5 of other variables to automatically trigger it based on this variable update
 ## Argument Reference
 
 The following arguments are supported:
@@ -49,6 +50,8 @@ The following arguments are supported:
   - objectstore_operator
   - volume_operator
 
+* `password_reset` - (Optional) Arbitrary string to change to trigger a password update. Use the `terraform refresh` command after executing `terraform apply` to update the output with the new password.
+
 ## Attributes Reference
 
 The following attributes are exported:
@@ -57,6 +60,7 @@ The following attributes are exported:
 * `description` - See Argument Reference above.
 * `openstack_rc` - a convenient map representing an openstack_rc file. Note: no password nor sensitive token is set in this map.
 * `password` - (Sensitive) the password generated for the user. The password can be used with the Openstack API. This attribute is sensitive and will only be retrieve once during creation.
+* `password_reset` - See Argument Reference above.
 * `roles` - A list of roles associated with the user.
   * `description` - description of the role
   * `id` - id of the role

--- a/examples/resources/cloud_project_user/example_2.tf
+++ b/examples/resources/cloud_project_user/example_2.tf
@@ -1,0 +1,8 @@
+resource "ovh_cloud_project_user" "user_with_rotation" {
+  service_name = "XXX"
+  description  = "Service User created by Terraform with password rotation"
+  rotate_when_changed = {
+    last_rotation = "2025-04-30"
+  }
+}
+

--- a/examples/resources/cloud_project_user/example_2.tf
+++ b/examples/resources/cloud_project_user/example_2.tf
@@ -1,8 +1,7 @@
+# Change password_reset with the datetime each time you want to reset the password to trigger an update
 resource "ovh_cloud_project_user" "user_with_rotation" {
-  service_name = "XXX"
-  description  = "Service User created by Terraform with password rotation"
-  rotate_when_changed = {
-    last_rotation = "2025-04-30"
-  }
+  service_name   = "XXX"
+  description    = "Service User created by Terraform with password rotation"
+  password_reset = "2025-04-30"
 }
 

--- a/ovh/resource_cloud_project_user.go
+++ b/ovh/resource_cloud_project_user.go
@@ -185,7 +185,7 @@ func resourceCloudProjectUserUpdate(d *schema.ResourceData, meta interface{}) er
 		// Wait for user to be ok after password regeneration
 		log.Printf("[DEBUG] Waiting for User %s to be ok after password regeneration:", userId)
 		stateConf := &resource.StateChangeConf{
-			Pending:    []string{"updating", "regenerating"}, // Add any potential intermediate states
+			Pending:    []string{"creating", "deleted", "deleting"},
 			Target:     []string{"ok"},
 			Refresh:    waitForCloudProjectUser(config.OVHClient, serviceName, userId),
 			Timeout:    5 * time.Minute, // Adjust timeout as needed

--- a/ovh/types_cloud.go
+++ b/ovh/types_cloud.go
@@ -194,17 +194,19 @@ func (p *CloudProjectNetworkPrivatesResponse) String() string {
 
 // Opts
 type CloudProjectUserCreateOpts struct {
-	Description *string  `json:"description,omitempty"`
-	Role        *string  `json:"role,omitempty"`
-	Roles       []string `json:"roles"`
+	Description       *string           `json:"description,omitempty"`
+	Role              *string           `json:"role,omitempty"`
+	Roles             []string          `json:"roles"`
+	RotateWhenChanged map[string]string `json:"-"` // This is only used for triggering recreation, not sent to the API
 }
 
 func (p *CloudProjectUserCreateOpts) String() string {
 	return fmt.Sprintf(
-		"CloudProjectUserCreateOpts[description:%v, role:%v, roles:%s]",
+		"CloudProjectUserCreateOpts[description:%v, role:%v, roles:%s, rotateWhenChanged:%v]",
 		p.Description,
 		p.Role,
 		p.Roles,
+		p.RotateWhenChanged,
 	)
 }
 
@@ -212,6 +214,15 @@ func (opts *CloudProjectUserCreateOpts) FromResource(d *schema.ResourceData) *Cl
 	opts.Description = helpers.GetNilStringPointerFromData(d, "description")
 	opts.Role = helpers.GetNilStringPointerFromData(d, "role_name")
 	opts.Roles, _ = helpers.StringsFromSchema(d, "role_names")
+
+	// Extract the rotate_when_changed map if present
+	if rotateMap, ok := d.GetOk("rotate_when_changed"); ok {
+		opts.RotateWhenChanged = make(map[string]string)
+		for k, v := range rotateMap.(map[string]interface{}) {
+			opts.RotateWhenChanged[k] = v.(string)
+		}
+	}
+
 	return opts
 }
 
@@ -342,4 +353,15 @@ type CloudServiceStatusResponse struct {
 
 func (s *CloudServiceStatusResponse) String() string {
 	return fmt.Sprintf("%s: %s", s.Name, s.Status)
+}
+
+type CloudProjectUserRegenerate struct {
+	CreationDate string                  `json:"creationDate"`
+	Description  string                  `json:"description"`
+	Id           int                     `json:"id"`
+	OpenstackId  string                  `json:"openstackId"`
+	Password     string                  `json:"password"`
+	Roles        []*CloudProjectUserRole `json:"roles"`
+	Status       string                  `json:"status"`
+	Username     string                  `json:"username"`
 }

--- a/ovh/types_cloud.go
+++ b/ovh/types_cloud.go
@@ -194,19 +194,19 @@ func (p *CloudProjectNetworkPrivatesResponse) String() string {
 
 // Opts
 type CloudProjectUserCreateOpts struct {
-	Description       *string           `json:"description,omitempty"`
-	Role              *string           `json:"role,omitempty"`
-	Roles             []string          `json:"roles"`
-	RotateWhenChanged map[string]string `json:"-"` // This is only used for triggering recreation, not sent to the API
+	Description   *string  `json:"description,omitempty"`
+	Role          *string  `json:"role,omitempty"`
+	Roles         []string `json:"roles"`
+	PasswordReset string   `json:"-"` // This is only used for triggering recreation, not sent to the API
 }
 
 func (p *CloudProjectUserCreateOpts) String() string {
 	return fmt.Sprintf(
-		"CloudProjectUserCreateOpts[description:%v, role:%v, roles:%s, rotateWhenChanged:%v]",
+		"CloudProjectUserCreateOpts[description:%v, role:%v, roles:%s, passwordReset:%s]",
 		p.Description,
 		p.Role,
 		p.Roles,
-		p.RotateWhenChanged,
+		p.PasswordReset,
 	)
 }
 
@@ -214,14 +214,7 @@ func (opts *CloudProjectUserCreateOpts) FromResource(d *schema.ResourceData) *Cl
 	opts.Description = helpers.GetNilStringPointerFromData(d, "description")
 	opts.Role = helpers.GetNilStringPointerFromData(d, "role_name")
 	opts.Roles, _ = helpers.StringsFromSchema(d, "role_names")
-
-	// Extract the rotate_when_changed map if present
-	if rotateMap, ok := d.GetOk("rotate_when_changed"); ok {
-		opts.RotateWhenChanged = make(map[string]string)
-		for k, v := range rotateMap.(map[string]interface{}) {
-			opts.RotateWhenChanged[k] = v.(string)
-		}
-	}
+	opts.PasswordReset = d.Get("password_reset").(string)
 
 	return opts
 }

--- a/templates/resources/cloud_project_user.md.tmpl
+++ b/templates/resources/cloud_project_user.md.tmpl
@@ -14,9 +14,11 @@ Creates a user in a public cloud project.
 
 {{tffile "examples/resources/cloud_project_user/example_1.tf"}}
 
-## User with rotating password support
 {{tffile "examples/resources/cloud_project_user/example_2.tf"}}
 
+-> **NOTE** To reset password of the user previously created, update the `password_reset` attribute. Use the `terraform refresh` command after executing `terraform apply` to update the output with the new password. This attribute can be an arbitrary string but we recommend 2 formats:
+- a datetime to keep a trace of the last reset
+- a md5 of other variables to automatically trigger it based on this variable update
 ## Argument Reference
 
 The following arguments are supported:
@@ -41,6 +43,8 @@ The following arguments are supported:
   - objectstore_operator
   - volume_operator
 
+* `password_reset` - (Optional) Arbitrary string to change to trigger a password update. Use the `terraform refresh` command after executing `terraform apply` to update the output with the new password.
+
 ## Attributes Reference
 
 The following attributes are exported:
@@ -49,6 +53,7 @@ The following attributes are exported:
 * `description` - See Argument Reference above.
 * `openstack_rc` - a convenient map representing an openstack_rc file. Note: no password nor sensitive token is set in this map.
 * `password` - (Sensitive) the password generated for the user. The password can be used with the Openstack API. This attribute is sensitive and will only be retrieve once during creation.
+* `password_reset` - See Argument Reference above.
 * `roles` - A list of roles associated with the user.
   * `description` - description of the role
   * `id` - id of the role

--- a/templates/resources/cloud_project_user.md.tmpl
+++ b/templates/resources/cloud_project_user.md.tmpl
@@ -14,6 +14,9 @@ Creates a user in a public cloud project.
 
 {{tffile "examples/resources/cloud_project_user/example_1.tf"}}
 
+## User with rotating password support
+{{tffile "examples/resources/cloud_project_user/example_2.tf"}}
+
 ## Argument Reference
 
 The following arguments are supported:


### PR DESCRIPTION
# Description

This PR introduces a password rotation mechanism for the ovh_cloud_project_user resource. A new optional attribute rotate_when_changed has been added. When any key/value pair within this map changes, the provider will trigger the OVHcloud API to regenerate the user's password without recreating the user resource itself.

This allows for scheduled or event-driven password rotation. The new password is stored in the Terraform state, making it available for use by other resources (e.g., storing it securely).

Fixes #962 

## Type of change
- [x] Improvement (improve existing resource(s) or datasource(s))
- [x] Documentation update

# How Has This Been Tested?

go test -v ./ovh -run '^TestAccCloudProjectUser_.*$' -timeout 30m

```
=== RUN   TestAccCloudProjectUser_basic
    provider_test.go:506: Read Cloud Project /cloud/project/aa2425907763475a89a4bf4e9f9e22fb -> status: 'ok', desc: 'itsc-test-rollout'
--- PASS: TestAccCloudProjectUser_basic (26.24s)
=== RUN   TestAccCloudProjectUser_withRole
    provider_test.go:506: Read Cloud Project /cloud/project/aa2425907763475a89a4bf4e9f9e22fb -> status: 'ok', desc: 'itsc-test-rollout'
--- PASS: TestAccCloudProjectUser_withRole (25.86s)
=== RUN   TestAccCloudProjectUser_withRoles
    provider_test.go:506: Read Cloud Project /cloud/project/aa2425907763475a89a4bf4e9f9e22fb -> status: 'ok', desc: 'itsc-test-rollout'
--- PASS: TestAccCloudProjectUser_withRoles (51.42s)
=== RUN   TestAccCloudProjectUser_withRotate
    provider_test.go:506: Read Cloud Project /cloud/project/aa2425907763475a89a4bf4e9f9e22fb -> status: 'ok', desc: 'itsc-test-rollout'
--- PASS: TestAccCloudProjectUser_withRotate (33.95s)
PASS
ok      github.com/ovh/terraform-provider-ovh/v2/ovh    137.777s
```
Additionally, I have tested the provider in a standard Terraform environment, where all functionality worked as expected. I also verified the migration from provider version 2.2.0 and observed no issues or unexpected behavior.

**Test Configuration**:
* Terraform version: `terraform version`: Terraform v1.11.3
* Existing HCL configuration you used: 
```hcl
resource "ovh_cloud_project_user" "test_user" {
  service_name = var.project_id
  description  = "Test user for password rotation"
  role_name    = "administrator"
  rotate_when_changed = {
    "last_rotated" = "2025-04-30"
  }
}
```

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or issues
- [x] I have added acceptance tests that prove my fix is effective or that my feature works
- [x] New and existing acceptance tests pass locally with my changes
- [x] I ran succesfully `go mod vendor` if I added or modify `go.mod` file
