### PR TITLE
fix: Add missing roles to ovh_cloud_project_user

### DIFF
--- a/docs/resources/cloud_project_user.md
+++ b/docs/resources/cloud_project_user.md
@@ -25,7 +25,8 @@ The following arguments are supported:
 * `role_name` - The name of a role. See `role_names`.
 
 * `role_names` - A list of role names. Values can be:
-  - administrator,
+  - admin
+  - administrator
   - ai_training_operator
   - ai_training_read
   - authentication
@@ -33,6 +34,9 @@ The following arguments are supported:
   - compute_operator
   - image_operator
   - infrastructure_supervisor
+  - key-manager_operator
+  - key-manager_read
+  - load-balancer_operator
   - network_operator
   - network_security_operator
   - objectstore_operator

--- a/templates/resources/cloud_project_user.md.tmpl
+++ b/templates/resources/cloud_project_user.md.tmpl
@@ -25,7 +25,8 @@ The following arguments are supported:
 * `role_name` - The name of a role. See `role_names`.
 
 * `role_names` - A list of role names. Values can be:
-  - administrator,
+  - admin
+  - administrator
   - ai_training_operator
   - ai_training_read
   - authentication
@@ -33,6 +34,9 @@ The following arguments are supported:
   - compute_operator
   - image_operator
   - infrastructure_supervisor
+  - key-manager_operator
+  - key-manager_read
+  - load-balancer_operator
   - network_operator
   - network_security_operator
   - objectstore_operator


### PR DESCRIPTION
# Description

This PR adds missing roles in the doc of resource `ovh_cloud_project_user`.

Fixes #901 (issue)

## Type of change

- [x] Documentation update