### PR TITLE
feat: Allow adding custom info to user-agent

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -186,6 +186,14 @@ The following arguments are supported:
 
 * `consumer_key` - (Optional) The API Consumer key. If omitted, the `OVH_CONSUMER_KEY` environment variable is used.
 
+* `client_id` - (Optional) The OAuth2 client ID. If omitted, the `OVH_CLIENT_ID` environment variable is used.
+
+* `client_id` - (Optional) The OAuth2 client secret. If omitted, the `OVH_CLIENT_SECRET` environment variable is used.
+
+* `access_token` - (Optional) The OVH API Access Token. If omitted, the `OVH_ACCESS_TOKEN` environment variable is used.
+
+* `user_agent_extra` - (Optional) Extra information to append at the end of the user-agent used when making API calls.
+
 ## Terraform State storage in an OVHcloud Object Storage (S3 compatibility)
 
 In order to store your Terraform states on a High Performance (S3) OVHcloud Object Storage, please follow the [guide](https://help.ovhcloud.com/csm/en-public-cloud-compute-terraform-high-perf-object-storage-backend-state?id=kb_article_view&sysparm_article=KB0051345).

--- a/ovh/config.go
+++ b/ovh/config.go
@@ -29,6 +29,9 @@ type Config struct {
 	ClientID     string
 	ClientSecret string
 
+	// Extra user-agent information
+	UserAgentExtra string
+
 	OVHClient     *ovh.Client
 	authenticated bool
 	authFailed    error
@@ -74,6 +77,9 @@ func clientDefault(c *Config) (*ovh.Client, error) {
 	}
 
 	client.UserAgent = "Terraform/" + providerVersion + "/" + providerCommit
+	if c.UserAgentExtra != "" {
+		client.UserAgent += " - " + c.UserAgentExtra
+	}
 
 	return client, nil
 }

--- a/ovh/provider.go
+++ b/ovh/provider.go
@@ -30,6 +30,9 @@ var (
 		// Authentication via oAuth2
 		"client_id":     "OAuth 2.0 application's ID",
 		"client_secret": "OAuth 2.0 application's secret",
+
+		// Extra info in user-agent
+		"user_agent_extra": "Extra information to append to the user-agent",
 	}
 )
 
@@ -71,6 +74,11 @@ func Provider() *schema.Provider {
 				Type:        schema.TypeString,
 				Optional:    true,
 				Description: descriptions["client_secret"],
+			},
+			"user_agent_extra": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: descriptions["user_agent_extra"],
 			},
 		},
 
@@ -313,6 +321,9 @@ func ConfigureContextFunc(context context.Context, d *schema.ResourceData) (inte
 	}
 	if v, ok := d.GetOk("client_secret"); ok {
 		config.ClientSecret = v.(string)
+	}
+	if v, ok := d.GetOk("user_agent_extra"); ok {
+		config.UserAgentExtra = v.(string)
 	}
 
 	if err := config.loadAndValidate(); err != nil {

--- a/ovh/provider_new.go
+++ b/ovh/provider_new.go
@@ -63,6 +63,10 @@ func (p *OvhProvider) Schema(_ context.Context, _ provider.SchemaRequest, resp *
 				Optional:    true,
 				Description: descriptions["client_secret"],
 			},
+			"user_agent_extra": schema.StringAttribute{
+				Optional:    true,
+				Description: descriptions["user_agent_extra"],
+			},
 		},
 	}
 }
@@ -176,6 +180,9 @@ func (p *OvhProvider) Configure(ctx context.Context, req provider.ConfigureReque
 	if !config.ClientSecret.IsNull() {
 		clientConfig.ClientSecret = config.ClientSecret.ValueString()
 	}
+	if !config.UserAgentExtra.IsNull() {
+		clientConfig.UserAgentExtra = config.UserAgentExtra.ValueString()
+	}
 
 	if err := clientConfig.loadAndValidate(); err != nil {
 		resp.Diagnostics.AddError(err.Error(), "failed to init OVH API client")
@@ -282,4 +289,5 @@ type ovhProviderModel struct {
 	ConsumerKey       types.String `tfsdk:"consumer_key"`
 	ClientID          types.String `tfsdk:"client_id"`
 	ClientSecret      types.String `tfsdk:"client_secret"`
+	UserAgentExtra    types.String `tfsdk:"user_agent_extra"`
 }

--- a/templates/index.md.tmpl
+++ b/templates/index.md.tmpl
@@ -138,6 +138,14 @@ The following arguments are supported:
 
 * `consumer_key` - (Optional) The API Consumer key. If omitted, the `OVH_CONSUMER_KEY` environment variable is used.
 
+* `client_id` - (Optional) The OAuth2 client ID. If omitted, the `OVH_CLIENT_ID` environment variable is used.
+
+* `client_id` - (Optional) The OAuth2 client secret. If omitted, the `OVH_CLIENT_SECRET` environment variable is used.
+
+* `access_token` - (Optional) The OVH API Access Token. If omitted, the `OVH_ACCESS_TOKEN` environment variable is used.
+
+* `user_agent_extra` - (Optional) Extra information to append at the end of the user-agent used when making API calls.
+
 ## Terraform State storage in an OVHcloud Object Storage (S3 compatibility)
 
 In order to store your Terraform states on a High Performance (S3) OVHcloud Object Storage, please follow the [guide](https://help.ovhcloud.com/csm/en-public-cloud-compute-terraform-high-perf-object-storage-backend-state?id=kb_article_view&sysparm_article=KB0051345).


### PR DESCRIPTION
# Description

Allow defining a `user_agent_extra` field in provider configuration to append extra information in the `user-agent` header in API calls.

Fixes #916 (issue)

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or issues
- [x] I have added acceptance tests that prove my fix is effective or that my feature works
- [x] New and existing acceptance tests pass locally with my changes
- [x] I ran succesfully `go mod vendor` if I added or modify `go.mod` file