### PR TITLE
fix: Use go-1.23 worker model in CI

### DIFF
--- a/.cds/terraform-provider-ovh-check.pip.yml
+++ b/.cds/terraform-provider-ovh-check.pip.yml
@@ -15,4 +15,4 @@ jobs:
       make test
       make vet
   requirements:
-  - model: shared.infra/Go-official-1.22-bookworm
+  - model: shared.infra/Go-official-1.23-bookworm

--- a/.cds/terraform-provider-ovh-run-sweepers.pip.yml
+++ b/.cds/terraform-provider-ovh-run-sweepers.pip.yml
@@ -24,4 +24,4 @@ jobs:
       TF_ACC=1 go test ./ovh/ -v -sweep=1
 
   requirements:
-  - model: shared.infra/Go-official-1.22-bookworm
+  - model: shared.infra/Go-official-1.23-bookworm

--- a/.cds/terraform-provider-ovh-testacc.pip.yml
+++ b/.cds/terraform-provider-ovh-testacc.pip.yml
@@ -37,4 +37,4 @@ jobs:
       make testacc TESTARGS="-parallel=1 ${CDS_PIP_TESTARGS}"
 
   requirements:
-  - model: shared.infra/Go-official-1.22-bookworm
+  - model: shared.infra/Go-official-1.23-bookworm


### PR DESCRIPTION
# Description

Use Go 1.23 in worker models to run tests in CI.