### PR TITLE
fix: Add missing Equal methods on types TfInt64Value and TfNumberValue

### DIFF
--- a/ovh/types/int64.go
+++ b/ovh/types/int64.go
@@ -86,6 +86,16 @@ func (t *TfInt64Value) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (t TfInt64Value) Equal(o attr.Value) bool {
+	other, ok := o.(TfInt64Value)
+
+	if !ok {
+		return false
+	}
+
+	return t.Int64Value.Equal(other.Int64Value)
+}
+
 func (t TfInt64Value) MarshalJSON() ([]byte, error) {
 	if t.IsNull() || t.IsUnknown() {
 		return []byte("null"), nil

--- a/ovh/types/number.go
+++ b/ovh/types/number.go
@@ -85,6 +85,16 @@ func (t *TfNumberValue) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (t TfNumberValue) Equal(o attr.Value) bool {
+	other, ok := o.(TfNumberValue)
+
+	if !ok {
+		return false
+	}
+
+	return t.NumberValue.Equal(other.NumberValue)
+}
+
 func (t TfNumberValue) MarshalJSON() ([]byte, error) {
 	if t.IsNull() || t.IsUnknown() {
 		return []byte("null"), nil


### PR DESCRIPTION
# Description

Function `Equal` was missing on custom types `TfInt64Value` and `TfNumberValue`, which caused invalid diff between state and plan when used.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (improve existing resource(s) or datasource(s))
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or issues
- [x] I have added acceptance tests that prove my fix is effective or that my feature works
- [x] New and existing acceptance tests pass locally with my changes
- [x] I ran succesfully `go mod vendor` if I added or modify `go.mod` file
