### PR TITLE
feat(vrack): add region argument to post block

### DIFF
--- a/docs/resources/vrack_ip.md
+++ b/docs/resources/vrack_ip.md
@@ -69,6 +69,7 @@ The following arguments are supported:
 
 * `service_name` - (Required) The internal name of your vrack
 * `block` - (Required) Your IP block.
+* `region` - (Optional) The region (e.g: eu-west-gra) where want to route your block to.
 
 ## Attributes Reference
 
@@ -77,3 +78,4 @@ The following attributes are exported:
 * `gateway` - Your gateway
 * `ip` - Your IP block
 * `zone` - Where you want your block announced on the network
+* `region` - See Argument Reference above.

--- a/docs/resources/vrack_ipv6.md
+++ b/docs/resources/vrack_ipv6.md
@@ -34,7 +34,8 @@ The following arguments are supported:
 
 ## Attributes Reference
 
-No additional attribute is exported.
+* `region` - The region in which the block is routed.
+* `ipv6` - The IPv6 block.
 
 ## Import
 

--- a/ovh/provider_test.go
+++ b/ovh/provider_test.go
@@ -439,6 +439,15 @@ func testAccPreCheckVRack(t *testing.T) {
 	checkEnvOrSkip(t, "OVH_VRACK_SERVICE_TEST")
 }
 
+// Checks that the environment variables needed for the /vrack/{serviceName}/ip acceptance tests
+// are set, and variable used for block with region.
+func testAccPreCheckVRackIpWithRegion(t *testing.T) {
+	testAccPreCheckCredentials(t)
+	checkEnvOrSkip(t, "OVH_VRACK_SERVICE_TEST")
+	checkEnvOrSkip(t, "OVH_VRACK_IP_BLOCK")
+	checkEnvOrSkip(t, "OVH_VRACK_IP_REGION")
+}
+
 // Checks that the environment variables needed for the /me/paymentMean acceptance tests
 // are set.
 func testAccPreCheckMePaymentMean(t *testing.T) {

--- a/ovh/resource_vrack_ip.go
+++ b/ovh/resource_vrack_ip.go
@@ -31,6 +31,12 @@ func resourceVrackIp() *schema.Resource {
 				ForceNew:    true,
 				Description: "Your IP block.",
 			},
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: "Where you want your block announced on the network",
+			},
 
 			// computed
 			"gateway": {

--- a/ovh/resource_vrack_ip_test.go
+++ b/ovh/resource_vrack_ip_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"log"
 	"net/url"
+	"os"
 	"strings"
 	"testing"
 
@@ -178,6 +179,35 @@ func TestAccVrackIp_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet("ovh_vrack_ip.vrackblock", "service_name"),
 					resource.TestCheckResourceAttrSet("ovh_vrack_ip.vrackblock", "block"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccVrackIpWithRegion_basic(t *testing.T) {
+	serviceName := os.Getenv("OVH_VRACK_SERVICE_TEST")
+	block := os.Getenv("OVH_VRACK_IP_BLOCK")
+	region := os.Getenv("OVH_VRACK_IP_REGION")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheckVRackIpWithRegion(t)
+		},
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(`
+				resource "ovh_vrack_ip" "vrackblock" {
+				  service_name      = "%s"
+				  block 	= "%s"
+				  region 	= "%s"
+				}
+				`, serviceName, block, region),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("ovh_vrack_ip.vrackblock", "service_name", serviceName),
+					resource.TestCheckResourceAttr("ovh_vrack_ip.vrackblock", "block", block),
+					resource.TestCheckResourceAttr("ovh_vrack_ip.vrackblock", "region", region),
 				),
 			},
 		},

--- a/ovh/resource_vrack_ipv6.go
+++ b/ovh/resource_vrack_ipv6.go
@@ -67,6 +67,17 @@ func resourceVrackIpV6() *schema.Resource {
 					},
 				},
 			},
+			// computed
+			"region": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Where your block announced on the network",
+			},
+			"ipv6": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The IPv6 block announced on the network",
+			},
 		},
 	}
 }
@@ -96,7 +107,7 @@ func resourceVrackIpv6Create(d *schema.ResourceData, meta interface{}) error {
 
 	serviceName := d.Get("service_name").(string)
 
-	opts := (&VrackIpCreateOpts{}).FromResource(d)
+	opts := (&VrackIpV6CreateOpts{}).FromResource(d)
 	task := VrackTask{}
 
 	endpoint := fmt.Sprintf("/vrack/%s/ipv6", url.PathEscape(serviceName))
@@ -196,8 +207,14 @@ func resourceVrackIpv6Read(d *schema.ResourceData, meta interface{}) error {
 		url.PathEscape(block),
 	)
 
-	if err := config.OVHClient.Get(endpoint, nil); err != nil {
+	ipv6 := &VrackIpV6{}
+	if err := config.OVHClient.Get(endpoint, ipv6); err != nil {
 		return fmt.Errorf("failed to get vrack-ipv6 link: %w", err)
+	}
+
+	// set resource attributes
+	for k, v := range ipv6.ToMap() {
+		d.Set(k, v)
 	}
 
 	return setBridgedSubrangeState(d, meta, serviceName, block)

--- a/ovh/resource_vrack_ipv6_test.go
+++ b/ovh/resource_vrack_ipv6_test.go
@@ -88,6 +88,8 @@ func TestAccVrackIPv6_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("ovh_vrack_ipv6.test-vrack-ipv6-basic", "service_name", serviceName),
 					resource.TestCheckResourceAttr("ovh_vrack_ipv6.test-vrack-ipv6-basic", "block", ipBlock),
+					resource.TestCheckResourceAttrSet("ovh_vrack_ipv6.test-vrack-ipv6-basic", "region"),
+					resource.TestCheckResourceAttrSet("ovh_vrack_ipv6.test-vrack-ipv6-basic", "ipv6"),
 					resource.TestCheckResourceAttrSet("ovh_vrack_ipv6.test-vrack-ipv6-basic", "bridged_subrange.0.subrange"),
 					resource.TestCheckResourceAttrSet("ovh_vrack_ipv6.test-vrack-ipv6-basic", "bridged_subrange.0.gateway"),
 					resource.TestCheckResourceAttr("ovh_vrack_ipv6.test-vrack-ipv6-basic", "bridged_subrange.0.slaac", "enabled"),
@@ -99,6 +101,8 @@ func TestAccVrackIPv6_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("ovh_vrack_ipv6.test-vrack-ipv6-basic", "service_name", serviceName),
 					resource.TestCheckResourceAttr("ovh_vrack_ipv6.test-vrack-ipv6-basic", "block", ipBlock),
+					resource.TestCheckResourceAttrSet("ovh_vrack_ipv6.test-vrack-ipv6-basic", "region"),
+					resource.TestCheckResourceAttrSet("ovh_vrack_ipv6.test-vrack-ipv6-basic", "ipv6"),
 					resource.TestCheckResourceAttrSet("ovh_vrack_ipv6.test-vrack-ipv6-basic", "bridged_subrange.0.subrange"),
 					resource.TestCheckResourceAttrSet("ovh_vrack_ipv6.test-vrack-ipv6-basic", "bridged_subrange.0.gateway"),
 					resource.TestCheckResourceAttr("ovh_vrack_ipv6.test-vrack-ipv6-basic", "bridged_subrange.0.slaac", "disabled"),

--- a/ovh/types_vrack.go
+++ b/ovh/types_vrack.go
@@ -45,6 +45,7 @@ type VrackIp struct {
 	Gateway string `json:"gateway"`
 	Ip      string `json:"ip"`
 	Zone    string `json:"zone"`
+	Region  string `json:"region"`
 }
 
 func (v VrackIp) ToMap() map[string]interface{} {
@@ -53,15 +54,41 @@ func (v VrackIp) ToMap() map[string]interface{} {
 	obj["gateway"] = v.Gateway
 	obj["ip"] = v.Ip
 	obj["zone"] = v.Zone
+	obj["region"] = v.Region
 
 	return obj
 }
 
+// IPv4 Block Payload
 type VrackIpCreateOpts struct {
-	Block string `json:"block"`
+	Block  string  `json:"block"`
+	Region *string `json:"region,omitempty"`
 }
 
 func (opts *VrackIpCreateOpts) FromResource(d *schema.ResourceData) *VrackIpCreateOpts {
+	opts.Block = d.Get("block").(string)
+	opts.Region = helpers.GetNilStringPointerFromData(d, "region")
+	return opts
+}
+
+type VrackIpV6 struct {
+	Region string `json:"region"`
+	IPv6   string `json:"ipv6"`
+}
+
+func (v VrackIpV6) ToMap() map[string]interface{} {
+	obj := make(map[string]interface{})
+	obj["region"] = v.Region
+	obj["ipv6"] = v.IPv6
+	return obj
+}
+
+// IPv6 Block Payload
+type VrackIpV6CreateOpts struct {
+	Block string `json:"block"`
+}
+
+func (opts *VrackIpV6CreateOpts) FromResource(d *schema.ResourceData) *VrackIpV6CreateOpts {
 	opts.Block = d.Get("block").(string)
 	return opts
 }

--- a/templates/resources/vrack_ip.md.tmpl
+++ b/templates/resources/vrack_ip.md.tmpl
@@ -20,6 +20,7 @@ The following arguments are supported:
 
 * `service_name` - (Required) The internal name of your vrack
 * `block` - (Required) Your IP block.
+* `region` - (Optional) The region (e.g: eu-west-gra) where want to route your block to.
 
 ## Attributes Reference
 
@@ -28,3 +29,4 @@ The following attributes are exported:
 * `gateway` - Your gateway
 * `ip` - Your IP block
 * `zone` - Where you want your block announced on the network
+* `region` - See Argument Reference above.

--- a/templates/resources/vrack_ipv6.md.tmpl
+++ b/templates/resources/vrack_ipv6.md.tmpl
@@ -25,7 +25,8 @@ The following arguments are supported:
 
 ## Attributes Reference
 
-No additional attribute is exported.
+* `region` - The region in which the block is routed.
+* `ipv6` - The IPv6 block.
 
 ## Import
 


### PR DESCRIPTION
# Description

Add region argument for POST /vrack/{serviceName}/ip

Region will also be added in IPv6 as a returned value for  GET /vrack/{serviceName}/ipv6/{ipv6}

## Type of change

Please delete options that are not relevant.

- [x] Improvement (improve existing resource(s) or datasource(s))
- [x] Documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Test A: `make testacc TESTARGS="-run TestAccVrackIpWithRegion_basic"`
- [x] Test B: `make testacc TESTARGS="-run TestAccVrackIp_basic"` 
- [x] Test C: `make testacc TESTARGS="-run TestAccVrackIPv6_basic"`

**Test Configuration**:
* Terraform version: `terraform version`: Terraform v1.11.1
* Existing HCL configuration you used: 
```hcl
resource "ovh_vrack_ip" "vrack_block" {
  service_name = {vRack}
  block        =  {Blockv4}
  region       = {region}
}
```

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or issues
- [x] I have added acceptance tests that prove my fix is effective or that my feature works
- [x] New and existing acceptance tests pass locally with my changes
- [ ] I ran succesfully `go mod vendor` if I added or modify `go.mod` file
