### PR TITLE
feat(saving-plans): add default service_name using OVH_CLOUD_PROJECT_SERVICE

### DIFF
--- a/docs/resources/savings_plan.md
+++ b/docs/resources/savings_plan.md
@@ -23,7 +23,7 @@ resource "ovh_savings_plan" "plan" {
 
 The following arguments are supported:
 
-* `service_name` - (Required) ID of the public cloud project
+* `service_name` - (Required) ID of the public cloud project. If omitted, the `OVH_CLOUD_PROJECT_SERVICE` environment variable is used.
 * `flavor` - (Required) Savings Plan flavor. The list of available flavors can be retrieved in the [next section](#available-flavors).
 * `period` - (Required) Periodicity of the Savings Plan
 * `size` - (Required) Size of the Savings Plan

--- a/ovh/resource_savings_plan.go
+++ b/ovh/resource_savings_plan.go
@@ -33,6 +33,7 @@ func resourceSavingsPlan() *schema.Resource {
 				Description: "ID of the public cloud project",
 				ForceNew:    true,
 				Required:    true,
+				DefaultFunc: schema.EnvDefaultFunc("OVH_CLOUD_PROJECT_SERVICE", nil),
 			},
 			"flavor": {
 				Type:        schema.TypeString,

--- a/templates/resources/savings_plan.md.tmpl
+++ b/templates/resources/savings_plan.md.tmpl
@@ -18,7 +18,7 @@ Create and manage an OVHcloud Savings Plan
 
 The following arguments are supported:
 
-* `service_name` - (Required) ID of the public cloud project
+* `service_name` - (Required) ID of the public cloud project. If omitted, the `OVH_CLOUD_PROJECT_SERVICE` environment variable is used.
 * `flavor` - (Required) Savings Plan flavor. The list of available flavors can be retrieved in the [next section](#available-flavors).
 * `period` - (Required) Periodicity of the Savings Plan
 * `size` - (Required) Size of the Savings Plan


### PR DESCRIPTION
# Description

This PR add a default to the `service_name` argument for the savings_plan resource.
It's using the `OVH_CLOUD_PROJECT_SERVICE`, similar to what other resources do (see [data_cloud_project_vrack.go](https://github.com/ovh/terraform-provider-ovh/blob/master/ovh/data_cloud_project_vrack.go#L21C5-L21C74))


## Type of change

Please delete options that are not relevant.

- [x] Improvement (improve existing resource(s) or datasource(s))

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or issues
- [ ] I have added acceptance tests that prove my fix is effective or that my feature works
- [ ] New and existing acceptance tests pass locally with my changes
- [ ] I ran succesfully `go mod vendor` if I added or modify `go.mod` file
