### PR TITLE
fix: Send the correct floatingIp information when creating an instance

### DIFF
--- a/ovh/provider_test.go
+++ b/ovh/provider_test.go
@@ -481,6 +481,14 @@ func testAccPreCheckOkmsCredential(t *testing.T) {
 	checkEnvOrSkip(t, "OVH_OKMS_CREDENTIAL")
 }
 
+func testAccPreCheckCloudInstance(t *testing.T) {
+	testAccPreCheckCredentials(t)
+	checkEnvOrSkip(t, "OVH_CLOUD_PROJECT_NETWORK_PRIVATE_TEST")
+	checkEnvOrSkip(t, "OVH_CLOUD_PROJECT_NETWORK_PRIVATE_SUBNET_TEST")
+	checkEnvOrSkip(t, "OVH_CLOUD_PROJECT_FLOATING_IP_ID")
+	checkEnvOrSkip(t, "OVH_CLOUD_PROJECT_GATEWAY_ID")
+}
+
 func testAccCheckVRackExists(t *testing.T) {
 	type vrackResponse struct {
 		Name        string `json:"name"`

--- a/ovh/resource_cloud_project_instance_test.go
+++ b/ovh/resource_cloud_project_instance_test.go
@@ -300,7 +300,7 @@ func TestAccCloudProjectInstance_privateNetworkCreate(t *testing.T) {
 	})
 }
 
-func TestAccCloudProjectInstance_privateNetworkAlreadyExisting(t *testing.T) {
+func TestAccCloudProjectInstance_privateNetworkAlreadyExists(t *testing.T) {
 	serviceName := os.Getenv("OVH_CLOUD_PROJECT_SERVICE_TEST")
 	region := os.Getenv("OVH_CLOUD_PROJECT_REGION_TEST")
 	flavor, image, err := getFlavorAndImage(serviceName, region)

--- a/ovh/types_cloud_project_instance.go
+++ b/ovh/types_cloud_project_instance.go
@@ -45,7 +45,7 @@ type Network struct {
 }
 
 type PrivateNetwork struct {
-	FloatingIP       *PrivateNetworkFloatingIP        `json:"floating_ip,omitempty"`
+	FloatingIP       *PrivateNetworkFloatingIP        `json:"floatingIp,omitempty"`
 	FloatingIPCreate *PrivateNetworkFloatingIPCreate  `json:"floatingIpCreate,omitempty"`
 	Gateway          *PrivateNetworkGateway           `json:"gateway,omitempty"`
 	GatewayCreate    *PrivateNetworkGatewayCreate     `json:"gatewayCreate,omitempty"`


### PR DESCRIPTION
# Description

Fixes #983 (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] Test A: `make testacc TESTARGS="-run TestAccCloudProjectInstance_privateNetworkAlreadyExisting"`

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or issues
- [x] I have added acceptance tests that prove my fix is effective or that my feature works
- [x] New and existing acceptance tests pass locally with my changes
- [x] I ran succesfully `go mod vendor` if I added or modify `go.mod` file
