### PR TITLE
feat: Add reboot_rescue option in ovh_dedicated_server pre-destroy available actions

### DIFF
--- a/docs/resources/cloud_project_database_log_subscription.md
+++ b/docs/resources/cloud_project_database_log_subscription.md
@@ -17,9 +17,9 @@ data "ovh_dbaas_logs_output_graylog_stream" "stream" {
 }
 
 data "ovh_cloud_project_database" "db" {
-  service_name  = "XXX"
-  engine        = "YYY"
-  id            = "ZZZ"
+  service_name = "XXX"
+  engine       = "YYY"
+  id           = "ZZZ"
 }
 
 resource "ovh_cloud_project_database_log_subscription" "subscription" {

--- a/docs/resources/dedicated_server.md
+++ b/docs/resources/dedicated_server.md
@@ -142,7 +142,9 @@ resource "ovh_dedicated_server" "server" {
 ### Arguments used to control the lifecycle of a dedicated server
 
 * `keep_service_after_destroy` - Avoid termination of the service when deleting the resource (when using this parameter, make sure to apply your configuration before running the destroy so that the value is set in the state)
-* `run_actions_before_destroy` - (Set of strings) Actions to perform before destroying the server. Right now the only available action is "reinstall_only_os", that will reinstall the dedicated server with the operating system defined in the `os` field. When using this parameter, make sure to apply your configuration before running the destroy so that the value is set in the state
+* `run_actions_before_destroy` - (Set of strings) Actions to perform before destroying the server. When using this parameter, make sure to apply your configuration before running the destroy so that the value is set in the state. The following actions are available:
+  * "reinstall_only_os": Will reinstall the dedicated server with the operating system defined in the `os` field.
+  * "reboot_rescue": Will reboot your server in rescue mode before destroying the resource.
 * `prevent_install_on_create`  - Prevent server installation after it has been delivered
 * `prevent_install_on_import`  - Defines whether a reinstallation of the server is allowed after importing it if there is a modification on the installation parameters
 

--- a/ovh/resource_dedicated_server_gen.go
+++ b/ovh/resource_dedicated_server_gen.go
@@ -262,7 +262,7 @@ func DedicatedServerResourceSchema(ctx context.Context) schema.Schema {
 			Optional:    true,
 			Description: "Actions to run before destroying the resource",
 			Validators: []validator.Set{
-				setvalidator.ValueStringsAre(stringvalidator.OneOf("reinstall_only_os")),
+				setvalidator.ValueStringsAre(stringvalidator.OneOf("reinstall_only_os", "reboot_rescue")),
 			},
 		},
 		"link_speed": schema.Int64Attribute{

--- a/templates/resources/dedicated_server.md.tmpl
+++ b/templates/resources/dedicated_server.md.tmpl
@@ -89,7 +89,9 @@ Use this resource to order and manage a dedicated server.
 ### Arguments used to control the lifecycle of a dedicated server
 
 * `keep_service_after_destroy` - Avoid termination of the service when deleting the resource (when using this parameter, make sure to apply your configuration before running the destroy so that the value is set in the state)
-* `run_actions_before_destroy` - (Set of strings) Actions to perform before destroying the server. Right now the only available action is "reinstall_only_os", that will reinstall the dedicated server with the operating system defined in the `os` field. When using this parameter, make sure to apply your configuration before running the destroy so that the value is set in the state
+* `run_actions_before_destroy` - (Set of strings) Actions to perform before destroying the server. When using this parameter, make sure to apply your configuration before running the destroy so that the value is set in the state. The following actions are available:
+  * "reinstall_only_os": Will reinstall the dedicated server with the operating system defined in the `os` field.
+  * "reboot_rescue": Will reboot your server in rescue mode before destroying the resource.
 * `prevent_install_on_create`  - Prevent server installation after it has been delivered
 * `prevent_install_on_import`  - Defines whether a reinstallation of the server is allowed after importing it if there is a modification on the installation parameters
 


### PR DESCRIPTION
# Description

Add `reboot_rescue` option in `ovh_dedicated_server` pre-destroy available actions.

## Type of change

- [x] Improvement (improve existing resource(s) or datasource(s))

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or issues
- [x] I have added acceptance tests that prove my fix is effective or that my feature works
- [x] New and existing acceptance tests pass locally with my changes
- [x] I ran succesfully `go mod vendor` if I added or modify `go.mod` file
