### PR TITLE
:pencil: (resources/cloud_project_kube_nodepool.md) added missing availability_zones argument

### DIFF
--- a/docs/resources/cloud_project_kube_nodepool.md
+++ b/docs/resources/cloud_project_kube_nodepool.md
@@ -77,6 +77,7 @@ The following arguments are supported:
 * `name` - (Optional) The name of the nodepool. Warning: `_` char is not allowed! **Changing this value recreates the resource.**
 * `flavor_name` - a valid OVHcloud public cloud flavor ID in which the nodes will be started. Ex: "b2-7". You can find the list of flavor IDs: https://www.ovhcloud.com/fr/public-cloud/prices/. **Changing this value recreates the resource.**
 * `desired_nodes` - number of nodes to start.
+* `availability_zones` - (Optional) list of availability zones to associate the pool - **mandatory for multi-zone** cluster - only one zone is supported at the moment.
 * `max_nodes` - maximum number of nodes allowed in the pool. Setting `desired_nodes` over this value will raise an error.
 * `min_nodes` - minimum number of nodes allowed in the pool. Setting `desired_nodes` under this value will raise an error.
 * `monthly_billed` - (Optional) should the nodes be billed on a monthly basis. Default to `false`. **Changing this value recreates the resource.**

--- a/templates/resources/cloud_project_kube_nodepool.md.tmpl
+++ b/templates/resources/cloud_project_kube_nodepool.md.tmpl
@@ -33,6 +33,7 @@ The following arguments are supported:
 * `name` - (Optional) The name of the nodepool. Warning: `_` char is not allowed! **Changing this value recreates the resource.**
 * `flavor_name` - a valid OVHcloud public cloud flavor ID in which the nodes will be started. Ex: "b2-7". You can find the list of flavor IDs: https://www.ovhcloud.com/fr/public-cloud/prices/. **Changing this value recreates the resource.**
 * `desired_nodes` - number of nodes to start.
+* `availability_zones` - (Optional) list of availability zones to associate the pool - **mandatory for multi-zone** cluster - only one zone is supported at the moment.
 * `max_nodes` - maximum number of nodes allowed in the pool. Setting `desired_nodes` over this value will raise an error.
 * `min_nodes` - minimum number of nodes allowed in the pool. Setting `desired_nodes` under this value will raise an error.
 * `monthly_billed` - (Optional) should the nodes be billed on a monthly basis. Default to `false`. **Changing this value recreates the resource.**


### PR DESCRIPTION
Closes #968

# Description

Add missing argument reference `availability_zones` to resource `ovh_cloud_project_kube_nodepool`.

Fixes #968

## Type of change

Please delete options that are not relevant.

- [X] Documentation update

# How Has This Been Tested?

Just copy and pasted the existing documentation in the data-sources folder.

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings or issues
- [ ] I have added acceptance tests that prove my fix is effective or that my feature works
- [ ] New and existing acceptance tests pass locally with my changes
- [ ] I ran succesfully `go mod vendor` if I added or modify `go.mod` file
