### PR TITLE
Fix links to open issues to include correct template parameter

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,4 +30,4 @@ The contributions should be submitted through new GitHub Pull Requests.
 
 ## Submiting an Issue:
 
-In addition to contributions, we welcome [bug reports](https://github.com/ovh/terraform-provider-ovh/issues/new?assignees=&labels=&template=Bug_Report.md) and [feature requests](https://github.com/ovh/terraform-provider-ovh/issues/new?assignees=&labels=enhancement&template=Feature_Request.md).
+In addition to contributions, we welcome [bug reports](https://github.com/ovh/terraform-provider-ovh/issues/new?template=report-a-bug.md), [resource or datasource requests](https://github.com/ovh/terraform-provider-ovh/issues/new?template=request-a-new-resource-and-or-datasource.md), [documentation errors reports](https://github.com/ovh/terraform-provider-ovh/issues/new?template=report-a-documentation-error.md) and [feature requests](https://github.com/ovh/terraform-provider-ovh/issues/new?template=request-a-feature.md).


### PR DESCRIPTION
# Description

I noticed the links didn't match the templates anymore and also added links to all templates

## Type of change

- [x] Documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] click preview in Github web editor to see if markdown renders OK

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings or issues
- [ ] I have added acceptance tests that prove my fix is effective or that my feature works
- [ ] New and existing acceptance tests pass locally with my changes
- [ ] I ran succesfully `go mod vendor` if I added or modify `go.mod` file
