### PR TITLE
feat(vps-reinstall): new resource to be able to reinstall VPS server

### DIFF
--- a/docs/resources/vps.md
+++ b/docs/resources/vps.md
@@ -31,6 +31,8 @@ data "ovh_order_cart_product_plan" "vps" {
 resource "ovh_vps" "my_vps" {
   display_name = "dev_vps"
 
+  image_id = "45b2f222-ab10-44ed-863f-720942762b6f"
+
   ovh_subsidiary = data.ovh_order_cart.mycart.ovh_subsidiary
   plan = [
     {
@@ -50,6 +52,8 @@ resource "ovh_vps" "my_vps" {
       ]
     }
   ]
+
+  public_ssh_key = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDSD76EaLUzJjf70W8W2uU9FzEyl68di67Bd20qtYfBLJpFJuX/RJC9StI1y1RnXXqC1Lf/Yo+yJzvNx0iqLxCX1G7g0XYex74HkgC6a2QeNhp9M56ANZtA3TKKAbkZ1xobfhOPWpq3lEFp7dgJctcILBPL3l6OjKf6NIxHo5yF67Vy4D0nWl5utumNdWhhlX7MtVQooszLyIwPlNO+DzD3ZnJFCt2Z1jdRkhm/Oobtx17CZ+5SN23tgHXS6pLOgM6w30M11zkI510z95IAIHhRT7MbiXICkvG/0qHuSftz1j/CcHFbttNB27dH86vByumfSEgRKaoRkCqrn64IWrSsFr3Smsf7gZWLBlYLliGPyn8Tsr9bT5pRul6yTvVbfZ31RREBr1I0Lp4q++d+fIpa3LtMGRaMb9huJYy8cwW/Vfzbxsqfz9xzjIOFNcYl7J9l4cvz3hgSlai2Jgngw5ShNVlxcIKUdiynZWm09nQudlYNHgor9ID+JACzCfPkUZ8"
 }
 
 output "vps_display_name" {
@@ -62,6 +66,7 @@ output "vps_display_name" {
 The following arguments are supported:
 
 * `display_name` - Custom display name
+* `image_id` - (String) Id of the image to install on the VPS
 * `netboot_mode` - VPS netboot mode (local┃rescue)
 * `ovh_subsidiary` - (Required) OVHcloud Subsidiary. Country of OVHcloud legal entity you'll be billed by. List of supported subsidiaries available on API at [/1.0/me.json](https://eu.api.ovh.com/console-preview/?section=%2Fme&branch=v1#get-/me)
 * `plan` - (Required) Product Plan to order
@@ -78,6 +83,7 @@ The following arguments are supported:
   * `configuration` - (Optional) Representation of a configuration item for personalizing product
     * `label` - (Required) Identifier of the resource
     * `value` - (Required) Path to the resource in api.ovh.com
+* `public_ssh_key` - (String) Public SSH key to pre-install on your VPS - if set, then `image_id` must also be set
 
 ## Attributes Reference
 

--- a/examples/resources/vps/example_1.tf
+++ b/examples/resources/vps/example_1.tf
@@ -14,6 +14,8 @@ data "ovh_order_cart_product_plan" "vps" {
 resource "ovh_vps" "my_vps" {
   display_name = "dev_vps"
 
+  image_id = "45b2f222-ab10-44ed-863f-720942762b6f"
+
   ovh_subsidiary = data.ovh_order_cart.mycart.ovh_subsidiary
   plan = [
     {
@@ -33,6 +35,8 @@ resource "ovh_vps" "my_vps" {
       ]
     }
   ]
+
+  public_ssh_key = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDSD76EaLUzJjf70W8W2uU9FzEyl68di67Bd20qtYfBLJpFJuX/RJC9StI1y1RnXXqC1Lf/Yo+yJzvNx0iqLxCX1G7g0XYex74HkgC6a2QeNhp9M56ANZtA3TKKAbkZ1xobfhOPWpq3lEFp7dgJctcILBPL3l6OjKf6NIxHo5yF67Vy4D0nWl5utumNdWhhlX7MtVQooszLyIwPlNO+DzD3ZnJFCt2Z1jdRkhm/Oobtx17CZ+5SN23tgHXS6pLOgM6w30M11zkI510z95IAIHhRT7MbiXICkvG/0qHuSftz1j/CcHFbttNB27dH86vByumfSEgRKaoRkCqrn64IWrSsFr3Smsf7gZWLBlYLliGPyn8Tsr9bT5pRul6yTvVbfZ31RREBr1I0Lp4q++d+fIpa3LtMGRaMb9huJYy8cwW/Vfzbxsqfz9xzjIOFNcYl7J9l4cvz3hgSlai2Jgngw5ShNVlxcIKUdiynZWm09nQudlYNHgor9ID+JACzCfPkUZ8"
 }
 
 output "vps_display_name" {

--- a/ovh/provider_test.go
+++ b/ovh/provider_test.go
@@ -475,6 +475,7 @@ func testAccPreCheckOrderDedicatedServer(t *testing.T) {
 func testAccPreCheckVPS(t *testing.T) {
 	testAccPreCheckCredentials(t)
 	checkEnvOrSkip(t, "OVH_VPS")
+	checkEnvOrSkip(t, "OVH_VPS_IMAGE_ID")
 }
 
 func testAccPreCheckOkms(t *testing.T) {

--- a/ovh/resource_vps_test.go
+++ b/ovh/resource_vps_test.go
@@ -2,6 +2,7 @@ package ovh
 
 import (
 	"fmt"
+	"os"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
@@ -25,6 +26,51 @@ data "ovh_order_cart_product_plan" "vps" {
 resource "ovh_vps" "myvps" {
   display_name = "%s"
   netboot_mode = "rescue"
+
+  image_id = "45b2f222-ab10-44ed-863f-720942762b6f"
+  public_ssh_key = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDSD76EaLUzJjf70W8W2uU9FzEyl68di67Bd20qtYfBLJpFJuX/RJC9StI1y1RnXXqC1Lf/Yo+yJzvNx0iqLxCX1G7g0XYex74HkgC6a2QeNhp9M56ANZtA3TKKAbkZ1xobfhOPWpq3lEFp7dgJctcILBPL3l6OjKf6NIxHo5yF67Vy4D0nWl5utumNdWhhlX7MtVQooszLyIwPlNO+DzD3ZnJFCt2Z1jdRkhm/Oobtx17CZ+5SN23tgHXS6pLOgM6w30M11zkI510z95IAIHhRT7MbiXICkvG/0qHuSftz1j/CcHFbttNB27dH86vByumfSEgRKaoRkCqrn64IWrSsFr3Smsf7gZWLBlYLliGPyn8Tsr9bT5pRul6yTvVbfZ31RREBr1I0Lp4q++d+fIpa3LtMGRaMb9huJYy8cwW/Vfzbxsqfz9xzjIOFNcYl7J9l4cvz3hgSlai2Jgngw5ShNVlxcIKUdiynZWm09nQudlYNHgor9ID+JACzCfPkUZ8"
+
+  ovh_subsidiary = data.ovh_order_cart.mycart.ovh_subsidiary
+  plan = [
+    {
+      duration     = "P1M"
+      plan_code    = data.ovh_order_cart_product_plan.vps.plan_code
+      pricing_mode = "default"
+
+      configuration = [
+        {
+          label = "vps_datacenter"
+          value = "WAW"
+        },
+        {
+          label = "vps_os"
+          value = "Debian 10"
+        }
+      ]
+    }
+  ]
+}
+`
+
+const testAccVpsReinstallImageOnly = `
+data "ovh_me" "myaccount" {}
+
+data "ovh_order_cart" "mycart" {
+  ovh_subsidiary = data.ovh_me.myaccount.ovh_subsidiary
+}
+
+data "ovh_order_cart_product_plan" "vps" {
+  cart_id        = data.ovh_order_cart.mycart.id
+  price_capacity = "renew"
+  product        = "vps"
+  plan_code      = "vps-le-2-2-40"
+}
+
+resource "ovh_vps" "myvps" {
+  display_name = "%s"
+  netboot_mode = "rescue"
+
+  image_id = "45b2f222-ab10-44ed-863f-720942762b6f"
 
   ovh_subsidiary = data.ovh_order_cart.mycart.ovh_subsidiary
   plan = [
@@ -66,6 +112,36 @@ func TestAccResourceVps_basic(t *testing.T) {
 						"ovh_vps.myvps", "netboot_mode", "rescue"),
 					resource.TestCheckResourceAttr(
 						"ovh_vps.myvps", "display_name", displayName),
+					resource.TestCheckResourceAttr(
+						"ovh_vps.myvps", "public_ssh_key", "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDSD76EaLUzJjf70W8W2uU9FzEyl68di67Bd20qtYfBLJpFJuX/RJC9StI1y1RnXXqC1Lf/Yo+yJzvNx0iqLxCX1G7g0XYex74HkgC6a2QeNhp9M56ANZtA3TKKAbkZ1xobfhOPWpq3lEFp7dgJctcILBPL3l6OjKf6NIxHo5yF67Vy4D0nWl5utumNdWhhlX7MtVQooszLyIwPlNO+DzD3ZnJFCt2Z1jdRkhm/Oobtx17CZ+5SN23tgHXS6pLOgM6w30M11zkI510z95IAIHhRT7MbiXICkvG/0qHuSftz1j/CcHFbttNB27dH86vByumfSEgRKaoRkCqrn64IWrSsFr3Smsf7gZWLBlYLliGPyn8Tsr9bT5pRul6yTvVbfZ31RREBr1I0Lp4q++d+fIpa3LtMGRaMb9huJYy8cwW/Vfzbxsqfz9xzjIOFNcYl7J9l4cvz3hgSlai2Jgngw5ShNVlxcIKUdiynZWm09nQudlYNHgor9ID+JACzCfPkUZ8"),
+					resource.TestCheckResourceAttr(
+						"ovh_vps.myvps", "image_id", os.Getenv("OVH_VPS_IMAGE_ID")),
+				),
+			},
+		},
+	})
+}
+
+func TestAccResourceVps_reinstallImageOnly(t *testing.T) {
+	displayName := acctest.RandomWithPrefix(test_prefix)
+	config := fmt.Sprintf(
+		testAccVpsReinstallImageOnly,
+		displayName,
+	)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheckOrderVPS(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(
+						"ovh_vps.myvps", "netboot_mode", "rescue"),
+					resource.TestCheckResourceAttr(
+						"ovh_vps.myvps", "display_name", displayName),
+					resource.TestCheckResourceAttr(
+						"ovh_vps.myvps", "image_id", "45b2f222-ab10-44ed-863f-720942762b6f"),
 				),
 			},
 		},

--- a/templates/resources/vps.md.tmpl
+++ b/templates/resources/vps.md.tmpl
@@ -25,6 +25,7 @@ Creates an OVHcloud Virtual Private Server (VPS).
 The following arguments are supported:
 
 * `display_name` - Custom display name
+* `image_id` - (String) Id of the image to install on the VPS
 * `netboot_mode` - VPS netboot mode (local┃rescue)
 * `ovh_subsidiary` - (Required) OVHcloud Subsidiary. Country of OVHcloud legal entity you'll be billed by. List of supported subsidiaries available on API at [/1.0/me.json](https://eu.api.ovh.com/console-preview/?section=%2Fme&branch=v1#get-/me)
 * `plan` - (Required) Product Plan to order
@@ -41,6 +42,7 @@ The following arguments are supported:
   * `configuration` - (Optional) Representation of a configuration item for personalizing product
     * `label` - (Required) Identifier of the resource
     * `value` - (Required) Path to the resource in api.ovh.com
+* `public_ssh_key` - (String) Public SSH key to pre-install on your VPS - if set, then `image_id` must also be set
 
 ## Attributes Reference
 


### PR DESCRIPTION
# Description

Introducing new attributes `public_ssh_key` and `image_id` on `vps` resource allowing to call the `/rebuild` API endpoint on an existing VPS server, especially useful to update the default SSH key configured on that server.

Fixes #943 (issue)

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Test A: `make testacc TESTARGS="-run TestAccResourceVps_basic"

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or issues
- [x] I have added acceptance tests that prove my fix is effective or that my feature works
- [x] New and existing acceptance tests pass locally with my changes
- [x] I ran succesfully `go mod vendor` if I added or modify `go.mod` file
