### PR TITLE
fix(dedicated_server{,_reinstall_task}): move properties to customizations.config_drive_metadata

### DIFF
--- a/docs/guides/dedicated_server_migration.md
+++ b/docs/guides/dedicated_server_migration.md
@@ -92,7 +92,7 @@ resource "ovh_dedicated_server" "srv" {
   #
 
   lifecycle {
-    ignore_changes = [os, customizations, properties, storage]
+    ignore_changes = [os, customizations, storage]
   }
 }
 ```

--- a/docs/resources/dedicated_server.md
+++ b/docs/resources/dedicated_server.md
@@ -141,7 +141,6 @@ resource "ovh_dedicated_server" "server" {
       * `raid_level` - Software raid type
       * `size` - Partition size in MiB
     * `scheme_name` - Partitioning scheme (if applicable with selected operating system)
-* `properties` - Attribute 'properties' is deprecated and has no effect
 
 ### Arguments used to control the lifecycle of a dedicated server
 

--- a/docs/resources/dedicated_server_reinstall_task.md
+++ b/docs/resources/dedicated_server_reinstall_task.md
@@ -239,8 +239,6 @@ The following arguments are supported:
 
 ~> **WARNING** Some customizations may be required on some Operating Systems. [Check how to list the available and required customization(s) for your operating system](https://help.ovhcloud.com/csm/en-dedicated-servers-api-os-installation?id=kb_article_view&sysparm_article=KB0061951#os-inputs) (do not forget to adapt camel case customization name to snake case parameter).
 
-* `properties` - Attribute 'properties' is deprecated and has no effect.
-
 * `storage`: OS reinstallation storage configurations. [More details about disks, hardware/software RAID and partitioning configuration](https://help.ovhcloud.com/csm/en-dedicated-servers-api-partitioning?id=kb_article_view&sysparm_article=KB0043882) (do not forget to adapt camel case parameters to snake case parameters).
   * `disk_group_id`: Disk group id to install the OS to (default is 0, meaning automatic).
   * `hardware_raid`: Hardware Raid configurations (if not specified, all disks of the chosen disk group id will be configured in JBOD mode).

--- a/examples/resources/dedicated_server_reinstall_task/example_4.tf
+++ b/examples/resources/dedicated_server_reinstall_task/example_4.tf
@@ -19,6 +19,6 @@ resource "ovh_dedicated_server_reinstall_task" "server_install" {
     http_headers = {
       Authorization = "Basic bG9naW46cGFzc3dvcmQ="
     }
-    image_url           = "https://github.com/ashmonger/akution_test/releases/download/0.5-compress/deb11k6.qcow2"
+    image_url              = "https://github.com/ashmonger/akution_test/releases/latest/download/deb11k6.qcow2"
   }
 }

--- a/ovh/resource_dedicated_server.go
+++ b/ovh/resource_dedicated_server.go
@@ -312,10 +312,9 @@ func (r *dedicatedServerResource) Update(ctx context.Context, req resource.Updat
 	responseData.MergeWith(&stateData)
 	responseData.ID = responseData.ServiceName
 
-	// Explicitely set Customizations/Properties/Storage to what was defined in the plan
+	// Explicitely set Customizations/Storage to what was defined in the plan
 	// as we can't determine the right thing to do in MergeWith function
 	responseData.Customizations = planData.Customizations
-	responseData.Properties = planData.Properties
 	responseData.Storage = planData.Storage
 
 	// Same thing for the flags to control reinstallation, set the plan value explicitly
@@ -474,8 +473,7 @@ func (r *dedicatedServerResource) reinstallDedicatedServer(ctx context.Context, 
 		if planData.Os.ValueString() != "" &&
 			stateData.Os.ValueString() != planData.Os.ValueString() ||
 			!stateData.Customizations.Equal(planData.Customizations) ||
-			!stateData.Storage.Equal(planData.Storage) ||
-			!stateData.Properties.Equal(planData.Properties) {
+			!stateData.Storage.Equal(planData.Storage) {
 			shouldReinstall = true
 		}
 	}

--- a/ovh/resource_dedicated_server_gen.go
+++ b/ovh/resource_dedicated_server_gen.go
@@ -350,13 +350,6 @@ func DedicatedServerResourceSchema(ctx context.Context) schema.Schema {
 				boolplanmodifier.UseStateForUnknown(),
 			},
 		},
-		"properties": schema.MapAttribute{
-			CustomType:          ovhtypes.NewTfMapNestedType[ovhtypes.TfStringValue](ctx),
-			Optional:            true,
-			Description:         "Arbitrary properties to pass to cloud-init's config drive datasource",
-			MarkdownDescription: "Arbitrary properties to pass to cloud-init's config drive datasource",
-			DeprecationMessage:  "Attribute 'properties' is deprecated and has no effect",
-		},
 		"rack": schema.StringAttribute{
 			CustomType: ovhtypes.TfStringType{},
 			Computed:   true,
@@ -727,7 +720,6 @@ type DedicatedServerModel struct {
 	Os                      ovhtypes.TfStringValue                             `tfsdk:"os" json:"os"`
 	PowerState              ovhtypes.TfStringValue                             `tfsdk:"power_state" json:"powerState"`
 	ProfessionalUse         ovhtypes.TfBoolValue                               `tfsdk:"professional_use" json:"professionalUse"`
-	Properties              ovhtypes.TfMapNestedValue[ovhtypes.TfStringValue]  `tfsdk:"properties" json:"properties"`
 	Rack                    ovhtypes.TfStringValue                             `tfsdk:"rack" json:"rack"`
 	PreventInstallOnCreate  ovhtypes.TfBoolValue                               `tfsdk:"prevent_install_on_create" json:"-"`
 	PreventInstallOnImport  ovhtypes.TfBoolValue                               `tfsdk:"prevent_install_on_import" json:"-"`
@@ -823,20 +815,12 @@ func (v *DedicatedServerModel) MergeWith(other *DedicatedServerModel) {
 		v.Os = other.Os
 	}
 
-	if (v.Properties.IsUnknown() || v.Properties.IsNull()) && !other.Properties.IsUnknown() {
-		v.Properties = other.Properties
-	}
-
 	if (v.PowerState.IsUnknown() || v.PowerState.IsNull()) && !other.PowerState.IsUnknown() {
 		v.PowerState = other.PowerState
 	}
 
 	if (v.ProfessionalUse.IsUnknown() || v.ProfessionalUse.IsNull()) && !other.ProfessionalUse.IsUnknown() {
 		v.ProfessionalUse = other.ProfessionalUse
-	}
-
-	if (v.Properties.IsUnknown() || v.Properties.IsNull()) && !other.Properties.IsUnknown() {
-		v.Properties = other.Properties
 	}
 
 	if (v.Rack.IsUnknown() || v.Rack.IsNull()) && !other.Rack.IsUnknown() {
@@ -949,19 +933,18 @@ func (v *DedicatedServerModel) ToOrder() *OrderModel {
 }
 
 type DedicatedServerWritableModel struct {
-	BootId            *ovhtypes.TfInt64Value                             `tfsdk:"boot_id" json:"bootId,omitempty"`
-	BootScript        *ovhtypes.TfStringValue                            `tfsdk:"boot_script" json:"bootScript,omitempty"`
-	Customizations    *CustomizationsWritableValue                       `tfsdk:"customizations" json:"customizations,omitempty"`
-	EfiBootloaderPath *ovhtypes.TfStringValue                            `tfsdk:"efi_bootloader_path" json:"efiBootloaderPath,omitempty"`
-	Monitoring        *ovhtypes.TfBoolValue                              `tfsdk:"monitoring" json:"monitoring,omitempty"`
-	NoIntervention    *ovhtypes.TfBoolValue                              `tfsdk:"no_intervention" json:"noIntervention,omitempty"`
-	Properties        *ovhtypes.TfMapNestedValue[ovhtypes.TfStringValue] `tfsdk:"properties" json:"properties,omitempty"`
-	RescueMail        *ovhtypes.TfStringValue                            `tfsdk:"rescue_mail" json:"rescueMail,omitempty"`
-	RescueSshKey      *ovhtypes.TfStringValue                            `tfsdk:"rescue_ssh_key" json:"rescueSshKey,omitempty"`
-	RootDevice        *ovhtypes.TfStringValue                            `tfsdk:"root_device" json:"rootDevice,omitempty"`
-	State             *ovhtypes.TfStringValue                            `tfsdk:"state" json:"state,omitempty"`
-	Storage           []*StorageWritableValue                            `tfsdk:"storage" json:"storage,omitempty"`
-	Os                *ovhtypes.TfStringValue                            `tfsdk:"os" json:"operatingSystem,omitempty"`
+	BootId            *ovhtypes.TfInt64Value       `tfsdk:"boot_id" json:"bootId,omitempty"`
+	BootScript        *ovhtypes.TfStringValue      `tfsdk:"boot_script" json:"bootScript,omitempty"`
+	Customizations    *CustomizationsWritableValue `tfsdk:"customizations" json:"customizations,omitempty"`
+	EfiBootloaderPath *ovhtypes.TfStringValue      `tfsdk:"efi_bootloader_path" json:"efiBootloaderPath,omitempty"`
+	Monitoring        *ovhtypes.TfBoolValue        `tfsdk:"monitoring" json:"monitoring,omitempty"`
+	NoIntervention    *ovhtypes.TfBoolValue        `tfsdk:"no_intervention" json:"noIntervention,omitempty"`
+	RescueMail        *ovhtypes.TfStringValue      `tfsdk:"rescue_mail" json:"rescueMail,omitempty"`
+	RescueSshKey      *ovhtypes.TfStringValue      `tfsdk:"rescue_ssh_key" json:"rescueSshKey,omitempty"`
+	RootDevice        *ovhtypes.TfStringValue      `tfsdk:"root_device" json:"rootDevice,omitempty"`
+	State             *ovhtypes.TfStringValue      `tfsdk:"state" json:"state,omitempty"`
+	Storage           []*StorageWritableValue      `tfsdk:"storage" json:"storage,omitempty"`
+	Os                *ovhtypes.TfStringValue      `tfsdk:"os" json:"operatingSystem,omitempty"`
 }
 
 func (v DedicatedServerModel) ToCreate() *DedicatedServerWritableModel {
@@ -1022,10 +1005,6 @@ func (v DedicatedServerModel) ToReinstall(onlyOS bool) *DedicatedServerWritableM
 			for _, elem := range v.Storage.Elements() {
 				res.Storage = append(res.Storage, elem.(StorageValue).ToCreate())
 			}
-		}
-
-		if !v.Properties.IsUnknown() && !v.Properties.IsNull() {
-			res.Properties = &v.Properties
 		}
 	}
 

--- a/ovh/resource_dedicated_server_reinstall_task.go
+++ b/ovh/resource_dedicated_server_reinstall_task.go
@@ -135,15 +135,6 @@ func resourceDedicatedServerReinstallTask() *schema.Resource {
 					},
 				},
 			},
-			"properties": {
-				Type:        schema.TypeMap,
-				Optional:    true,
-				ForceNew:    true,
-				Description: "Attribute 'properties' is deprecated and has no effect",
-				Elem: &schema.Schema{
-					Type: schema.TypeString,
-				},
-			},
 			"storage": {
 				Type:        schema.TypeList,
 				Optional:    true,

--- a/ovh/resource_dedicated_server_reinstall_task_test.go
+++ b/ovh/resource_dedicated_server_reinstall_task_test.go
@@ -292,7 +292,7 @@ resource "ovh_dedicated_server_reinstall_task" "server_reinstall" {
   os = "byolinux_64"
   customizations {
     hostname = "mon-tux"
-    image_url = "https://github.com/ashmonger/akution_test/releases/download/0.6-fixCache/deb11k6.qcow2"
+    image_url = "https://github.com/ashmonger/akution_test/releases/latest/download/deb11k6.qcow2"
 	efi_bootloader_path = "\\efi\\debian\\grubx64.efi"
 	ssh_key = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIIrODOo0SvY5f0TlQNvGHIRKzr4bHPa+D5bYF18RiOgP email@example.com"
 	config_drive_user_data = "c3NoX2F1dGhvcml6ZWRfa2V5czoKICAtIHNzaC1yc2EgQUFBQUI4ZGpZaXc9PSBteXNlbGZAbXlkb21haW4ubmV0Cgp1c2VyczoKICAtIG5hbWU6IHBhdGllbnQwCiAgICBzdWRvOiBBTEw9KEFMTCkgTk9QQVNTV0Q6QUxMCiAgICBncm91cHM6IHVzZXJzLCBzdWRvCiAgICBzaGVsbDogL2Jpbi9iYXNoCiAgICBsb2NrX3Bhc3N3ZDogZmFsc2UKICAgIHNzaF9hdXRob3JpemVkX2tleXM6CiAgICAgIC0gc3NoLXJzYSBBQUFBQjhkallpdz09IG15c2VsZkBteWRvbWFpbi5uZXQKZGlzYWJsZV9yb290OiBmYWxzZQpwYWNrYWdlczoKICAtIHZpbQogIC0gdHJlZQpmaW5hbF9tZXNzYWdlOiBUaGUgc3lzdGVtIGlzIGZpbmFsbHkgdXAsIGFmdGVyICRVUFRJTUUgc2Vjb25kcw=="

--- a/ovh/types_dedicated_server.go
+++ b/ovh/types_dedicated_server.go
@@ -119,7 +119,6 @@ type DedicatedServerTask struct {
 type DedicatedServerReinstallTaskCreateOpts struct {
 	Os             string                                      `json:"operatingSystem"`
 	Customizations *DedicatedServerReinstallTaskCustomizations `json:"customizations,omitempty"`
-	Properties     map[string]interface{}                      `json:"properties,omitempty"`
 	Storage        []DedicatedServerReinstallTaskStorage       `json:"storage,omitempty"`
 }
 
@@ -129,11 +128,6 @@ func (opts *DedicatedServerReinstallTaskCreateOpts) FromResource(d *schema.Resou
 	Customizations := d.Get("customizations").([]interface{})
 	if len(Customizations) == 1 {
 		opts.Customizations = (&DedicatedServerReinstallTaskCustomizations{}).FromResource(d, "customizations.0")
-	}
-
-	Properties := d.Get("properties").(map[string]interface{})
-	if len(Properties) >= 1 {
-		opts.Properties = d.Get("properties").(map[string]interface{})
 	}
 
 	Storage := d.Get("storage").([]interface{})

--- a/templates/guides/dedicated_server_migration.md
+++ b/templates/guides/dedicated_server_migration.md
@@ -92,7 +92,7 @@ resource "ovh_dedicated_server" "srv" {
   #
 
   lifecycle {
-    ignore_changes = [os, customizations, properties, storage]
+    ignore_changes = [os, customizations, storage]
   }
 }
 ```

--- a/templates/resources/dedicated_server.md.tmpl
+++ b/templates/resources/dedicated_server.md.tmpl
@@ -88,7 +88,6 @@ Use this resource to order and manage a dedicated server.
       * `raid_level` - Software raid type
       * `size` - Partition size in MiB
     * `scheme_name` - Partitioning scheme (if applicable with selected operating system)
-* `properties` - Attribute 'properties' is deprecated and has no effect
 
 ### Arguments used to control the lifecycle of a dedicated server
 

--- a/templates/resources/dedicated_server_reinstall_task.md.tmpl
+++ b/templates/resources/dedicated_server_reinstall_task.md.tmpl
@@ -85,8 +85,6 @@ The following arguments are supported:
 
 ~> **WARNING** Some customizations may be required on some Operating Systems. [Check how to list the available and required customization(s) for your operating system](https://help.ovhcloud.com/csm/en-dedicated-servers-api-os-installation?id=kb_article_view&sysparm_article=KB0061951#os-inputs) (do not forget to adapt camel case customization name to snake case parameter).
 
-* `properties` - Attribute 'properties' is deprecated and has no effect.
-
 * `storage`: OS reinstallation storage configurations. [More details about disks, hardware/software RAID and partitioning configuration](https://help.ovhcloud.com/csm/en-dedicated-servers-api-partitioning?id=kb_article_view&sysparm_article=KB0043882) (do not forget to adapt camel case parameters to snake case parameters).
   * `disk_group_id`: Disk group id to install the OS to (default is 0, meaning automatic).
   * `hardware_raid`: Hardware Raid configurations (if not specified, all disks of the chosen disk group id will be configured in JBOD mode).


### PR DESCRIPTION
# Description

Issue in API call `POST /dedicated/server/{serviceName}/reinstall`, `properties` attribute is not taken into account in OS installation.
Since custom config drive (cloud init datasource) metadata doesn't make sense for some OSes such as Windows, it has been decided to move those custom config drive metadata under customizations attribute in `customizations.configDriveMetadata`, since it's an OS-dependent configuration.
This PR is reflecting this upcoming API change to the Terraform Provider: removing this useless already deprecated `properties` attribute

Fixes #PUBM-43183

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Test A: `make testacc --debug TESTARGS="-run TestAccDedicatedServerReinstall_byolinux"`
```none
GNU Make 4.3
Built for x86_64-pc-linux-gnu
Copyright (C) 1988-2020 Free Software Foundation, Inc.
License GPLv3+: GNU GPL version 3 or later <http://gnu.org/licenses/gpl.html>
This is free software: you are free to change and redistribute it.
There is NO WARRANTY, to the extent permitted by law.
Reading makefiles...
Updating makefiles....
Updating goal targets....
 File 'testacc' does not exist.
   File 'fmtcheck' does not exist.
  Must remake target 'fmtcheck'.
==> Checking that code complies with gofmt requirements...
  Successfully remade target file 'fmtcheck'.
Must remake target 'testacc'.
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -run TestAccDedicatedServerReinstall_byolinux -timeout 600m -p 10
?   	github.com/ovh/terraform-provider-ovh/v2	[no test files]
=== RUN   TestAccDedicatedServerReinstall_byolinux
--- PASS: TestAccDedicatedServerReinstall_byolinux (444.47s)
PASS
ok  	github.com/ovh/terraform-provider-ovh/v2/ovh	444.486s
?   	github.com/ovh/terraform-provider-ovh/v2/ovh/datasources/cloud_project_rancher	[no test files]
?   	github.com/ovh/terraform-provider-ovh/v2/ovh/helpers	[no test files]
testing: warning: no tests to run
PASS
ok  	github.com/ovh/terraform-provider-ovh/v2/ovh/helpers/hashcode	(cached) [no tests to run]
?   	github.com/ovh/terraform-provider-ovh/v2/ovh/ovhwrap	[no test files]
?   	github.com/ovh/terraform-provider-ovh/v2/ovh/resources/cloud_project_rancher	[no test files]
?   	github.com/ovh/terraform-provider-ovh/v2/ovh/types	[no test files]
Successfully remade target file 'testacc'.
```
```none
echo $?
0
```
Installation task 497608994 was performed successfully

- [x] Test B: `make testacc --debug TESTARGS="-run TestAccDedicatedServerReinstall_basic"`

```none
GNU Make 4.3
Built for x86_64-pc-linux-gnu
Copyright (C) 1988-2020 Free Software Foundation, Inc.
License GPLv3+: GNU GPL version 3 or later <http://gnu.org/licenses/gpl.html>
This is free software: you are free to change and redistribute it.
There is NO WARRANTY, to the extent permitted by law.
Reading makefiles...
Updating makefiles....
Updating goal targets....
 File 'testacc' does not exist.
   File 'fmtcheck' does not exist.
  Must remake target 'fmtcheck'.
==> Checking that code complies with gofmt requirements...
  Successfully remade target file 'fmtcheck'.
Must remake target 'testacc'.
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -run TestAccDedicatedServerReinstall_basic -timeout 600m -p 10
?   	github.com/ovh/terraform-provider-ovh/v2	[no test files]

=== RUN   TestAccDedicatedServerReinstall_basic
--- PASS: TestAccDedicatedServerReinstall_basic (931.52s)
PASS
ok  	github.com/ovh/terraform-provider-ovh/v2/ovh	931.534s
?   	github.com/ovh/terraform-provider-ovh/v2/ovh/datasources/cloud_project_rancher	[no test files]
?   	github.com/ovh/terraform-provider-ovh/v2/ovh/helpers	[no test files]
testing: warning: no tests to run
PASS
ok  	github.com/ovh/terraform-provider-ovh/v2/ovh/helpers/hashcode	(cached) [no tests to run]
?   	github.com/ovh/terraform-provider-ovh/v2/ovh/ovhwrap	[no test files]
?   	github.com/ovh/terraform-provider-ovh/v2/ovh/resources/cloud_project_rancher	[no test files]
?   	github.com/ovh/terraform-provider-ovh/v2/ovh/types	[no test files]
Successfully remade target file 'testacc'.
```
```none
echo $?
0
```
Installation task 497609244 was performed successfully

**Test Configuration**:
* Terraform version: `terraform version`: Terraform v1.12.2

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or issues
~I have added acceptance tests that prove my fix is effective or that my feature works~
- [x] New and existing acceptance tests pass locally with my changes
- [x] I ran successfully `go mod vendor` if I added or modify `go.mod` file
