### PR TITLE
feat(ip_reverse): add readiness_timeout_duration attribute

### DIFF
--- a/docs/resources/ip_reverse.md
+++ b/docs/resources/ip_reverse.md
@@ -11,9 +11,10 @@ Provides a OVHcloud IP reverse.
 ```terraform
 # Set the reverse of an IP
 resource "ovh_ip_reverse" "test" {
-  ip = "192.0.2.0/24"
-  ip_reverse = "192.0.2.1"
-  reverse = "example.com"
+  readiness_timeout_duration = "1m"
+  ip                         = "192.0.2.0/24"
+  ip_reverse                 = "192.0.2.1"
+  reverse                    = "example.com"
 }
 ```
 
@@ -24,6 +25,7 @@ The following arguments are supported:
 * `ip` - (Required) The IP block to which the IP belongs
 * `reverse` - (Required) The value of the reverse
 * `ip_reverse` - (Required) The IP to set the reverse of
+* `readiness_timeout_duration` - (Optional) The maximum duration that the provider will wait for a successful response (while retrying every 5s). If the record cannot be verified within this timeout, the operation will fail (default value: 60s)
 
 ## Attributes Reference
 

--- a/examples/resources/ip_reverse/example_1.tf
+++ b/examples/resources/ip_reverse/example_1.tf
@@ -1,6 +1,7 @@
 # Set the reverse of an IP
 resource "ovh_ip_reverse" "test" {
-  ip = "192.0.2.0/24"
-  ip_reverse = "192.0.2.1"
-  reverse = "example.com"
+  readiness_timeout_duration = "1m"
+  ip                         = "192.0.2.0/24"
+  ip_reverse                 = "192.0.2.1"
+  reverse                    = "example.com"
 }

--- a/templates/resources/ip_reverse.md.tmpl
+++ b/templates/resources/ip_reverse.md.tmpl
@@ -21,6 +21,7 @@ The following arguments are supported:
 * `ip` - (Required) The IP block to which the IP belongs
 * `reverse` - (Required) The value of the reverse
 * `ip_reverse` - (Required) The IP to set the reverse of
+* `readiness_timeout_duration` - (Optional) The maximum duration that the provider will wait for a successful response (while retrying every 5s). If the record cannot be verified within this timeout, the operation will fail (default value: 60s)
 
 ## Attributes Reference
 


### PR DESCRIPTION
# Description

Introducing new `readiness_timeout_duration`attribute on `ovh_ip_reverse` resource, in order to be able to configure a timeout before throwing an error, in the case the related record is not propagated yet.

Fixes #1020 (issue)

## Type of change

- [x] Improvement (improve existing resource(s) or datasource(s))

# How Has This Been Tested?

- [x] Test A: `make testacc TESTARGS="-run TestAccIpReverse_basic"`
- [x] Test B: `make testacc TESTARGS="-run TestAccIpReverse_invalidDuration"`

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or issues
- [x] I have added acceptance tests that prove my fix is effective or that my feature works
- [x] New and existing acceptance tests pass locally with my changes
- [x] I ran succesfully `go mod vendor` if I added or modify `go.mod` file
