### PR TITLE
fix: Add missing ForceNew on serviceName on resources ovh_dedicated_server and ovh_dedicated_server_update

### DIFF
--- a/docs/resources/dedicated_server.md
+++ b/docs/resources/dedicated_server.md
@@ -90,7 +90,7 @@ resource "ovh_dedicated_server" "server" {
   * `configuration` - Representation of a configuration item to personalize product
     * `label` - (Required) Identifier of the resource
     * `value` - (Required) Path to the resource in API.OVH.COM
-* `service_name` - (Optional) The service_name of your dedicated server. This field can be used to avoid ordering a dedicated server at creation and just create the resource using an already existing service
+* `service_name` - (Optional, Forces replacement) The service_name of your dedicated server. This field can be used to avoid ordering a dedicated server at creation and just create the resource using an already existing service
 
 ### Editable fields of a dedicated server
 

--- a/docs/resources/dedicated_server_update.md
+++ b/docs/resources/dedicated_server_update.md
@@ -30,7 +30,7 @@ resource "ovh_dedicated_server_update" "server" {
 
 The following arguments are supported:
 
-* `service_name` - (Required) The service_name of your dedicated server.
+* `service_name` - (Required, Forces replacement) The service_name of your dedicated server.
 * `boot_id` - boot id of the server
 * `boot_script` - boot script of the server
 * `efi_bootloader_path` - path of the EFI bootloader

--- a/ovh/resource_dedicated_server_gen.go
+++ b/ovh/resource_dedicated_server_gen.go
@@ -425,6 +425,7 @@ func DedicatedServerResourceSchema(ctx context.Context) schema.Schema {
 			MarkdownDescription: "The internal name of your dedicated server",
 			PlanModifiers: []planmodifier.String{
 				stringplanmodifier.UseStateForUnknown(),
+				stringplanmodifier.RequiresReplace(),
 			},
 		},
 		"state": schema.StringAttribute{

--- a/ovh/resource_dedicated_server_update.go
+++ b/ovh/resource_dedicated_server_update.go
@@ -22,6 +22,7 @@ func resourceDedicatedServerUpdate() *schema.Resource {
 				Type:        schema.TypeString,
 				Description: "The internal name of your dedicated server.",
 				Required:    true,
+				ForceNew:    true,
 			},
 			"boot_id": {
 				Type:        schema.TypeInt,

--- a/templates/resources/dedicated_server.md.tmpl
+++ b/templates/resources/dedicated_server.md.tmpl
@@ -37,7 +37,7 @@ Use this resource to order and manage a dedicated server.
   * `configuration` - Representation of a configuration item to personalize product
     * `label` - (Required) Identifier of the resource
     * `value` - (Required) Path to the resource in API.OVH.COM
-* `service_name` - (Optional) The service_name of your dedicated server. This field can be used to avoid ordering a dedicated server at creation and just create the resource using an already existing service
+* `service_name` - (Optional, Forces replacement) The service_name of your dedicated server. This field can be used to avoid ordering a dedicated server at creation and just create the resource using an already existing service
 
 ### Editable fields of a dedicated server
 

--- a/templates/resources/dedicated_server_update.md.tmpl
+++ b/templates/resources/dedicated_server_update.md.tmpl
@@ -20,7 +20,7 @@ Update various properties of your Dedicated Server.
 
 The following arguments are supported:
 
-* `service_name` - (Required) The service_name of your dedicated server.
+* `service_name` - (Required, Forces replacement) The service_name of your dedicated server.
 * `boot_id` - boot id of the server
 * `boot_script` - boot script of the server
 * `efi_bootloader_path` - path of the EFI bootloader


### PR DESCRIPTION
# Description

When updating `serviceName` field on resources `ovh_dedicated_server` and `ovh_dedicated_server_update`, they should be recreated.

Fixes #1030 (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or issues
- [x] I have added acceptance tests that prove my fix is effective or that my feature works
- [x] New and existing acceptance tests pass locally with my changes
- [x] I ran succesfully `go mod vendor` if I added or modify `go.mod` file
