### PR TITLE
[Docs] Move s3 docs to object storage category

### DIFF
--- a/docs/data-sources/cloud_project_user_s3_credential.md
+++ b/docs/data-sources/cloud_project_user_s3_credential.md
@@ -1,5 +1,5 @@
 ---
-subcategory : "Cloud Project"
+subcategory : "Object Storage"
 ---
 
 # ovh_cloud_project_user_s3_credential (Data Source)

--- a/docs/data-sources/cloud_project_user_s3_credentials.md
+++ b/docs/data-sources/cloud_project_user_s3_credentials.md
@@ -1,5 +1,5 @@
 ---
-subcategory : "Cloud Project"
+subcategory : "Object Storage"
 ---
 
 # ovh_cloud_project_user_s3_credentials (Data Source)

--- a/docs/data-sources/cloud_project_user_s3_policy.md
+++ b/docs/data-sources/cloud_project_user_s3_policy.md
@@ -1,5 +1,5 @@
 ---
-subcategory : "Cloud Project"
+subcategory : "Object Storage"
 ---
 
 # ovh_cloud_project_user_s3_policy

--- a/docs/resources/cloud_project_user_s3_credential.md
+++ b/docs/resources/cloud_project_user_s3_credential.md
@@ -1,5 +1,5 @@
 ---
-subcategory : "Cloud Project"
+subcategory : "Object Storage"
 ---
 
 # ovh_cloud_project_user_s3_credential

--- a/docs/resources/cloud_project_user_s3_policy.md
+++ b/docs/resources/cloud_project_user_s3_policy.md
@@ -1,5 +1,5 @@
 ---
-subcategory : "Cloud Project"
+subcategory : "Object Storage"
 ---
 
 # ovh_cloud_project_user_s3_policy

--- a/templates/data-sources/cloud_project_user_s3_credential.md.tmpl
+++ b/templates/data-sources/cloud_project_user_s3_credential.md.tmpl
@@ -1,5 +1,5 @@
 ---
-subcategory : "Cloud Project"
+subcategory : "Object Storage"
 ---
 
 {{/* This template serves as a starting point for documentation generation, and can be customized with hardcoded values and/or doc gen templates.

--- a/templates/data-sources/cloud_project_user_s3_credentials.md.tmpl
+++ b/templates/data-sources/cloud_project_user_s3_credentials.md.tmpl
@@ -1,5 +1,5 @@
 ---
-subcategory : "Cloud Project"
+subcategory : "Object Storage"
 ---
 
 {{/* This template serves as a starting point for documentation generation, and can be customized with hardcoded values and/or doc gen templates.

--- a/templates/data-sources/cloud_project_user_s3_policy.md.tmpl
+++ b/templates/data-sources/cloud_project_user_s3_policy.md.tmpl
@@ -1,5 +1,5 @@
 ---
-subcategory : "Cloud Project"
+subcategory : "Object Storage"
 ---
 
 {{/* This template serves as a starting point for documentation generation, and can be customized with hardcoded values and/or doc gen templates.

--- a/templates/resources/cloud_project_user_s3_credential.md.tmpl
+++ b/templates/resources/cloud_project_user_s3_credential.md.tmpl
@@ -1,5 +1,5 @@
 ---
-subcategory : "Cloud Project"
+subcategory : "Object Storage"
 ---
 
 {{/* This template serves as a starting point for documentation generation, and can be customized with hardcoded values and/or doc gen templates.

--- a/templates/resources/cloud_project_user_s3_policy.md.tmpl
+++ b/templates/resources/cloud_project_user_s3_policy.md.tmpl
@@ -1,5 +1,5 @@
 ---
-subcategory : "Cloud Project"
+subcategory : "Object Storage"
 ---
 
 {{/* This template serves as a starting point for documentation generation, and can be customized with hardcoded values and/or doc gen templates.


### PR DESCRIPTION
# Description

Move guides about S3 to Object Storage subcategory (it's not easy to find them now).

## Type of change

- [x] Documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
