### PR TITLE
fix: match exact product code

### DIFF
--- a/ovh/resource_savings_plan.go
+++ b/ovh/resource_savings_plan.go
@@ -151,7 +151,7 @@ func resourceSavingsPlanCreate(d *schema.ResourceData, meta interface{}) error {
 
 	// Get subscribables savings plans
 	log.Print("[DEBUG] Will fetch subscribables savings plans")
-	endpoint := fmt.Sprintf("/services/%d/savingsPlans/subscribable?productCode=%s", serviceId, url.QueryEscape(flavor))
+	endpoint := fmt.Sprintf("/services/%d/savingsPlans/subscribable?productCode=%q", serviceId, url.QueryEscape(flavor))
 	subscribables := []savingsPlansSubscribable{}
 	if err := config.OVHClient.Get(endpoint, &subscribables); err != nil {
 		return fmt.Errorf("error calling GET %s:\n\t %q", endpoint, err)


### PR DESCRIPTION
# Description

Currently API route will return any match, for instance B3-64 search will match B3-64 and B3-640

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (improve existing resource(s) or datasource(s))
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

* Existing HCL configuration you used: 
```hcl
resource "ovh_savings_plan" "plan" {
    service_name = "xxx"
    flavor = "B3-64"
    period = "P1M"
    size = 1
    display_name = "xxx"
    auto_renewal = false
}
```

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or issues
- [ ] I have added acceptance tests that prove my fix is effective or that my feature works
- [ ] New and existing acceptance tests pass locally with my changes
- [x] I ran succesfully `go mod vendor` if I added or modify `go.mod` file
