### PR TITLE
feat: Add import capability to ovh_dbaas_logs_token

### DIFF
--- a/docs/resources/dbaas_logs_token.md
+++ b/docs/resources/dbaas_logs_token.md
@@ -32,3 +32,25 @@ The following arguments are supported:
 * `value` - Token value
 * `created_at` - Token creation date
 * `updated_at` - Token last update date
+
+## Import
+
+A token can be imported using the `service_name` and `token_id` fields.
+
+Using the following configuration:
+
+```terraform
+import {
+  to = ovh_dbaas_logs_token.token
+  id = "<service_name>/<token_id"
+}
+```
+
+You can then run:
+
+```bash
+$ terraform plan -generate-config-out=token.tf
+$ terraform apply
+```
+
+The file `token.tf` will then contain the imported resource's configuration, that can be copied next to the `import` block above. See https://developer.hashicorp.com/terraform/language/import/generating-configuration for more details.

--- a/examples/resources/dbaas_logs_token/example_2.tf
+++ b/examples/resources/dbaas_logs_token/example_2.tf
@@ -1,0 +1,4 @@
+import {
+  to = ovh_dbaas_logs_token.token
+  id = "<service_name>/<token_id"
+}

--- a/ovh/resource_dbaas_logs_token.go
+++ b/ovh/resource_dbaas_logs_token.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"fmt"
 	"net/url"
+	"strings"
 
+	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 )
 
@@ -41,6 +43,20 @@ func (d *dbaasLogsTokenResource) Configure(_ context.Context, req resource.Confi
 
 func (d *dbaasLogsTokenResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
 	resp.Schema = DbaasLogsTokenResourceSchema(ctx)
+}
+
+func (r *dbaasLogsTokenResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	parts := strings.Split(req.ID, "/")
+	if len(parts) != 2 {
+		resp.Diagnostics.AddError(
+			"Invalid Import ID",
+			fmt.Sprintf("Expected import ID in the format 'serviceName/tokenId', got: %s", req.ID),
+		)
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("service_name"), parts[0])...)
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("token_id"), parts[1])...)
 }
 
 func (r *dbaasLogsTokenResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {

--- a/templates/resources/dbaas_logs_token.md.tmpl
+++ b/templates/resources/dbaas_logs_token.md.tmpl
@@ -31,3 +31,20 @@ The following arguments are supported:
 * `value` - Token value
 * `created_at` - Token creation date
 * `updated_at` - Token last update date
+
+## Import
+
+A token can be imported using the `service_name` and `token_id` fields.
+
+Using the following configuration:
+
+{{tffile "examples/resources/dbaas_logs_token/example_2.tf"}}
+
+You can then run:
+
+```bash
+$ terraform plan -generate-config-out=token.tf
+$ terraform apply
+```
+
+The file `token.tf` will then contain the imported resource's configuration, that can be copied next to the `import` block above. See https://developer.hashicorp.com/terraform/language/import/generating-configuration for more details.


### PR DESCRIPTION
# Description

Add ability to import resource `ovh_dbaas_logs_token`.

Fixes #1025 (issue)

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or issues
- [x] New and existing acceptance tests pass locally with my changes
- [x] I ran succesfully `go mod vendor` if I added or modify `go.mod` file
