### PR TITLE
doc: fix dbaas_logs input example

### DIFF
--- a/docs/resources/dbaas_logs_input.md
+++ b/docs/resources/dbaas_logs_input.md
@@ -36,7 +36,7 @@ resource "ovh_dbaas_logs_input" "input" {
       input_section = <<EOF
   beats {
     port => 6514
-    ssl => true
+    ssl_enabled => true
     ssl_certificate => "/etc/ssl/private/server.crt"
     ssl_key => "/etc/ssl/private/server.key"
   }

--- a/examples/resources/dbaas_logs_input/example_1.tf
+++ b/examples/resources/dbaas_logs_input/example_1.tf
@@ -25,7 +25,7 @@ resource "ovh_dbaas_logs_input" "input" {
       input_section = <<EOF
   beats {
     port => 6514
-    ssl => true
+    ssl_enabled => true
     ssl_certificate => "/etc/ssl/private/server.crt"
     ssl_key => "/etc/ssl/private/server.key"
   }


### PR DESCRIPTION
# Description

The example configuration (`ssl` vs `ssl_enabled`) is misaligned with the example's logstash version (`9.x`)


## Type of change

Please delete options that are not relevant.

- [x] Documentation update

# How Has This Been Tested?

Nope

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings or issues
- [ ] I have added acceptance tests that prove my fix is effective or that my feature works
- [ ] New and existing acceptance tests pass locally with my changes
- [ ] I ran succesfully `go mod vendor` if I added or modify `go.mod` file
