### PR TITLE
chore(docs): clarifications in vps image selection

### DIFF
--- a/docs/resources/vps.md
+++ b/docs/resources/vps.md
@@ -12,6 +12,8 @@ Creates an OVHcloud Virtual Private Server (VPS).
 
 ~> **WARNING** `BANK_ACCOUNT` is not supported anymore, please update your default payment method to `SEPA_DIRECT_DEBIT`
 
+~> **NOTE** During VPS creation, the OS must be configured through the `plan.configuration` argument, using `vps_os` as key, and values from [catalog](https://eu.api.ovh.com/console/?section=%2Forder&branch=v1#get-/order/catalog/public/vps) data). The `image_id` argument should be used only when reinstalling a server.
+
 ## Example Usage
 
 ```terraform
@@ -66,7 +68,7 @@ output "vps_display_name" {
 The following arguments are supported:
 
 * `display_name` - Custom display name
-* `image_id` - (String) Id of the image to install on the VPS
+* `image_id` - (String) Id of the image to install on the VPS. This attribute is only useful to trigger a VPS reinstallation.
 * `netboot_mode` - VPS netboot mode (local┃rescue)
 * `ovh_subsidiary` - (Required) OVHcloud Subsidiary. Country of OVHcloud legal entity you'll be billed by. List of supported subsidiaries available on API at [/1.0/me.json](https://eu.api.ovh.com/console-preview/?section=%2Fme&branch=v1#get-/me)
 * `plan` - (Required) Product Plan to order
@@ -80,7 +82,7 @@ The following arguments are supported:
   * `duration` - (Required) duration
   * `plan_code` - (Required) Plan code
   * `pricing_mode` - (Required) Pricing model identifier
-  * `configuration` - (Optional) Representation of a configuration item for personalizing product
+  * `configuration` - (Optional) Representation of a configuration item for personalizing product. Available values can be retrieved on API using [catalog endpoint](https://eu.api.ovh.com/console/?section=%2Forder&branch=v1#get-/order/catalog/public/vps).
     * `label` - (Required) Identifier of the resource
     * `value` - (Required) Path to the resource in api.ovh.com
 * `public_ssh_key` - (String) Public SSH key to pre-install on your VPS - if set, then `image_id` must also be set

--- a/templates/resources/vps.md.tmpl
+++ b/templates/resources/vps.md.tmpl
@@ -16,7 +16,7 @@ Creates an OVHcloud Virtual Private Server (VPS).
 
 ~> **WARNING** `BANK_ACCOUNT` is not supported anymore, please update your default payment method to `SEPA_DIRECT_DEBIT`
 
-~> **NOTE** During VPS creation, the OS must be configured through the `plan.configuration` argument, using `vps_os` as key, and values from [catalog](https://eu.api.ovh.com/console/?section=%2Forder&branch=v1#get-/order/catalog/public/vps) data). The `image_id` argument should be used only when reinstalling a server.
+~> **NOTE** During VPS creation, the OS must be configured through the `plan.configuration` argument, using `vps_os` as key, and values from [catalog](https://eu.api.ovh.com/console/?section=%2Forder&branch=v1#get-/order/catalog/public/vps) data). The `image_id` argument should be used only when reinstalling a server. The available values for `image_id` can be found using this [API call](https://eu.api.ovh.com/console/?section=%2Fvps&branch=v1#get-/vps/-serviceName-/images/available)
 
 ## Example Usage
 

--- a/templates/resources/vps.md.tmpl
+++ b/templates/resources/vps.md.tmpl
@@ -16,6 +16,8 @@ Creates an OVHcloud Virtual Private Server (VPS).
 
 ~> **WARNING** `BANK_ACCOUNT` is not supported anymore, please update your default payment method to `SEPA_DIRECT_DEBIT`
 
+~> **NOTE** During VPS creation, the OS must be configured through the `plan.configuration` argument, using `vps_os` as key, and values from [catalog](https://eu.api.ovh.com/console/?section=%2Forder&branch=v1#get-/order/catalog/public/vps) data). The `image_id` argument should be used only when reinstalling a server.
+
 ## Example Usage
 
 {{tffile "examples/resources/vps/example_1.tf"}}
@@ -25,7 +27,7 @@ Creates an OVHcloud Virtual Private Server (VPS).
 The following arguments are supported:
 
 * `display_name` - Custom display name
-* `image_id` - (String) Id of the image to install on the VPS
+* `image_id` - (String) Id of the image to install on the VPS. This attribute is only useful to trigger a VPS reinstallation.
 * `netboot_mode` - VPS netboot mode (local┃rescue)
 * `ovh_subsidiary` - (Required) OVHcloud Subsidiary. Country of OVHcloud legal entity you'll be billed by. List of supported subsidiaries available on API at [/1.0/me.json](https://eu.api.ovh.com/console-preview/?section=%2Fme&branch=v1#get-/me)
 * `plan` - (Required) Product Plan to order
@@ -39,7 +41,7 @@ The following arguments are supported:
   * `duration` - (Required) duration
   * `plan_code` - (Required) Plan code
   * `pricing_mode` - (Required) Pricing model identifier
-  * `configuration` - (Optional) Representation of a configuration item for personalizing product
+  * `configuration` - (Optional) Representation of a configuration item for personalizing product. Available values can be retrieved on API using [catalog endpoint](https://eu.api.ovh.com/console/?section=%2Forder&branch=v1#get-/order/catalog/public/vps).
     * `label` - (Required) Identifier of the resource
     * `value` - (Required) Path to the resource in api.ovh.com
 * `public_ssh_key` - (String) Public SSH key to pre-install on your VPS - if set, then `image_id` must also be set

--- a/templates/resources/vps.md.tmpl
+++ b/templates/resources/vps.md.tmpl
@@ -27,7 +27,7 @@ Creates an OVHcloud Virtual Private Server (VPS).
 The following arguments are supported:
 
 * `display_name` - Custom display name
-* `image_id` - (String) Id of the image to install on the VPS. This attribute is only useful to trigger a VPS reinstallation.
+* `image_id` - (String) Id of the image to install on the VPS. This attribute is only useful to trigger a VPS reinstallation. The available values can be found using this [API call](https://eu.api.ovh.com/console/?section=%2Fvps&branch=v1#get-/vps/-serviceName-/images/available)
 * `netboot_mode` - VPS netboot mode (local┃rescue)
 * `ovh_subsidiary` - (Required) OVHcloud Subsidiary. Country of OVHcloud legal entity you'll be billed by. List of supported subsidiaries available on API at [/1.0/me.json](https://eu.api.ovh.com/console-preview/?section=%2Fme&branch=v1#get-/me)
 * `plan` - (Required) Product Plan to order


### PR DESCRIPTION
# Description

Add documentation on `vps`resource OS setup, with emphasis on the distinctive usage of `image_id` attribute for reinstallation versus `plan.configuration` at creation.

Fixes #1049 (issue)

## Type of change

Please delete options that are not relevant.

- [X] Documentation update

# How Has This Been Tested?
Not relevant

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings or issues
- [X] I have added acceptance tests that prove my fix is effective or that my feature works
- [X] New and existing acceptance tests pass locally with my changes
- [X] I ran succesfully `go mod vendor` if I added or modify `go.mod` file
