### PR TITLE
fix: error management on cloud_project_failover_ip_attach

### DIFF
--- a/ovh/resource_cloud_project_failover_ip_attach.go
+++ b/ovh/resource_cloud_project_failover_ip_attach.go
@@ -138,8 +138,7 @@ func resourceCloudProjectFailoverIpAttachRead(d *schema.ResourceData, meta inter
 	}
 
 	if !match {
-		return fmt.Errorf("your query returned no results, " +
-			"please change your search criteria and try again")
+		return fmt.Errorf("failover IP %s cannot be found in cloud project %s", d.Get("ip").(string), serviceName)
 	}
 
 	return nil
@@ -173,8 +172,7 @@ func resourceCloudProjectFailoverIpAttachCreate(d *schema.ResourceData, meta int
 	}
 
 	if !match {
-		return fmt.Errorf("your query returned no results, " +
-			"please change your search criteria and try again")
+		return fmt.Errorf("failover IP %s cannot be found in cloud project %s", d.Get("ip").(string), serviceName)
 	}
 
 	id := d.Get("id").(string)
@@ -186,7 +184,7 @@ func resourceCloudProjectFailoverIpAttachCreate(d *schema.ResourceData, meta int
 		url.PathEscape(id),
 	)
 
-	retry.RetryContext(context.Background(), 5*time.Minute, func() *retry.RetryError {
+	err := retry.RetryContext(context.Background(), 5*time.Minute, func() *retry.RetryError {
 		ip := &FailoverIp{}
 		if err := config.OVHClient.Post(endpoint, opts, ip); err != nil {
 			// Retry 400 errors because it can mean that the instance IP
@@ -211,6 +209,10 @@ func resourceCloudProjectFailoverIpAttachCreate(d *schema.ResourceData, meta int
 
 		return nil
 	})
+
+	if err != nil {
+		return err
+	}
 
 	for d.Get("status").(string) == "operationPending" {
 		if err := resourceCloudProjectFailoverIpAttachRead(d, meta); err != nil {

--- a/ovh/resource_cloud_project_failover_ip_attach.go
+++ b/ovh/resource_cloud_project_failover_ip_attach.go
@@ -191,7 +191,7 @@ func resourceCloudProjectFailoverIpAttachCreate(d *schema.ResourceData, meta int
 			// is not allocated yet.
 			ovhError, isOvhApiError := err.(*ovh.APIError)
 			if isOvhApiError && ovhError.Code == 400 {
-				log.Printf("[INFO] container registry id %s on project %s deleted", id, serviceName)
+				log.Printf("[INFO] IP with id=%s not attached yet, retrying…", id)
 				return retry.RetryableError(fmt.Errorf("error calling POST %s: %q", endpoint, err))
 			} else {
 				return retry.NonRetryableError(fmt.Errorf("failed to attach failover IP: %s", err))


### PR DESCRIPTION
# Description

- Explicit message when trying to attach failover IP outside of the current cloud project
- apply now fails when the attach is not successful

Fixes #1050 (issue)

## Type of change

Please delete options that are not relevant.

- [X] Improvement (improve existing resource(s) or datasource(s))

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [X] Test A: `make testacc TESTARGS="-run TestAccResourceCloudProjectFailoverIpAttach"`

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings or issues
- [X] I have added acceptance tests that prove my fix is effective or that my feature works
- [X] New and existing acceptance tests pass locally with my changes
- [X] I ran succesfully `go mod vendor` if I added or modify `go.mod` file
