### PR TITLE
fix(ovh_cloud_project_containerregistry_oidc): Set oidc_verify_cert as optional+computed

### DIFF
--- a/ovh/resource_cloud_project_containerregistry_oidc.go
+++ b/ovh/resource_cloud_project_containerregistry_oidc.go
@@ -77,7 +77,7 @@ func resourceCloudProjectContainerRegistryOIDC() *schema.Resource {
 			},
 			"oidc_verify_cert": {
 				Type:     schema.TypeBool,
-				Required: false,
+				Computed: true,
 				Optional: true,
 			},
 			"oidc_auto_onboard": {


### PR DESCRIPTION
# Description

Attribute `oidc_verify_cert` is computed when not input by the user.

Fixes #1042 (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] Test A: `make testacc TESTARGS="-run TestAccCloudProjectContainerRegistryOIDC_full"`

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or issues
- [x] New and existing acceptance tests pass locally with my changes
- [x] I ran succesfully `go mod vendor` if I added or modify `go.mod` file
