### PR TITLE
feat: cloud-project-kube data source now expose kubeconfig and kubeconfig_attributes as sensitive data

### DIFF
--- a/docs/data-sources/cloud_project_kube.md
+++ b/docs/data-sources/cloud_project_kube.md
@@ -17,6 +17,15 @@ data "ovh_cloud_project_kube" "my_kube_cluster" {
 output "version" {
   value = data.ovh_cloud_project_kube.my_kube_cluster.version
 }
+
+output "kubeconfig" {
+  value = data.ovh_cloud_project_kube.my_kube_cluster.kubeconfig
+  sensitive = true
+}
+
+output "kube_host" {
+  value = data.ovh_cloud_project_kube.my_kube_cluster.kubeconfig_attributes[0].host
+}
 ```
 
 ## Argument Reference
@@ -45,6 +54,12 @@ The following attributes are exported:
 * `status` - Cluster status. Should be normally set to 'READY'.
 * `update_policy` - Cluster update policy. Choose between [ALWAYS_UPDATE,MINIMAL_DOWNTIME,NEVER_UPDATE]'.
 * `url` - Management URL of your cluster.
+* `kubeconfig` - (Sensitive) Raw kubeconfig file content for connecting to the cluster.
+* `kubeconfig_attributes` - (Sensitive) Structured kubeconfig data for connecting to the cluster.
+  * `host` - Kubernetes API server endpoint.
+  * `cluster_ca_certificate` - (Sensitive) Cluster certificate authority data.
+  * `client_certificate` - (Sensitive) Client certificate data for authentication.
+  * `client_key` - (Sensitive) Client private key data for authentication.
 * `kube_proxy_mode` - Selected mode for kube-proxy.
 * `customization` - **Deprecated** (Optional) Use `customization_apiserver` and `customization_kube_proxy` instead. Kubernetes cluster customization
   * `apiserver` - Kubernetes API server customization

--- a/examples/data-sources/cloud_project_kube/example_1.tf
+++ b/examples/data-sources/cloud_project_kube/example_1.tf
@@ -6,3 +6,12 @@ data "ovh_cloud_project_kube" "my_kube_cluster" {
 output "version" {
   value = data.ovh_cloud_project_kube.my_kube_cluster.version
 }
+
+output "kubeconfig" {
+  value = data.ovh_cloud_project_kube.my_kube_cluster.kubeconfig
+  sensitive = true
+}
+
+output "kube_host" {
+  value = data.ovh_cloud_project_kube.my_kube_cluster.kubeconfig_attributes[0].host
+}

--- a/ovh/data_cloud_project_kube.go
+++ b/ovh/data_cloud_project_kube.go
@@ -366,7 +366,7 @@ func dataSourceKubeconfig(d *schema.ResourceData, meta interface{}) error {
 	kubeconf["cluster_ca_certificate"] = kubeConfig.Clusters[0].Cluster.CertificateAuthorityData
 	kubeconf["client_certificate"] = kubeConfig.Users[0].User.ClientCertificateData
 	kubeconf["client_key"] = kubeConfig.Users[0].User.ClientKeyData
-	_ = d.Set("kubeconfig_attributes", []map[string]interface{}{kubeconf})
+	d.Set("kubeconfig_attributes", []map[string]interface{}{kubeconf})
 
 	return nil
 }

--- a/ovh/data_cloud_project_kube_test.go
+++ b/ovh/data_cloud_project_kube_test.go
@@ -37,6 +37,15 @@ func TestAccCloudProjectKubeDataSource_basic(t *testing.T) {
 					resource.TestCheckResourceAttr("data.ovh_cloud_project_kube.cluster", "region", region),
 					resource.TestCheckResourceAttr("data.ovh_cloud_project_kube.cluster", "name", name),
 					resource.TestMatchResourceAttr("data.ovh_cloud_project_kube.cluster", "version", matchVersion),
+
+					// Check kubeconfig is present and not empty
+					resource.TestCheckResourceAttrSet("data.ovh_cloud_project_kube.cluster", "kubeconfig"),
+
+					// Check kubeconfig_attributes are present
+					resource.TestCheckResourceAttrSet("data.ovh_cloud_project_kube.cluster", "kubeconfig_attributes.0.host"),
+					resource.TestCheckResourceAttrSet("data.ovh_cloud_project_kube.cluster", "kubeconfig_attributes.0.cluster_ca_certificate"),
+					resource.TestCheckResourceAttrSet("data.ovh_cloud_project_kube.cluster", "kubeconfig_attributes.0.client_certificate"),
+					resource.TestCheckResourceAttrSet("data.ovh_cloud_project_kube.cluster", "kubeconfig_attributes.0.client_key"),
 				),
 			},
 		},
@@ -77,6 +86,15 @@ func TestAccCloudProjectKubeDataSource_kubeProxy(t *testing.T) {
 					resource.TestCheckResourceAttr("data.ovh_cloud_project_kube.cluster", "customization_kube_proxy.0.ipvs.0.tcp_fin_timeout", "PT30S"),
 					resource.TestCheckResourceAttr("data.ovh_cloud_project_kube.cluster", "customization_kube_proxy.0.ipvs.0.tcp_timeout", "PT30S"),
 					resource.TestCheckResourceAttr("data.ovh_cloud_project_kube.cluster", "customization_kube_proxy.0.ipvs.0.udp_timeout", "PT30S"),
+
+					// Check kubeconfig is present and not empty
+					resource.TestCheckResourceAttrSet("data.ovh_cloud_project_kube.cluster", "kubeconfig"),
+
+					// Check kubeconfig_attributes are present
+					resource.TestCheckResourceAttrSet("data.ovh_cloud_project_kube.cluster", "kubeconfig_attributes.0.host"),
+					resource.TestCheckResourceAttrSet("data.ovh_cloud_project_kube.cluster", "kubeconfig_attributes.0.cluster_ca_certificate"),
+					resource.TestCheckResourceAttrSet("data.ovh_cloud_project_kube.cluster", "kubeconfig_attributes.0.client_certificate"),
+					resource.TestCheckResourceAttrSet("data.ovh_cloud_project_kube.cluster", "kubeconfig_attributes.0.client_key"),
 				),
 			},
 		},

--- a/templates/data-sources/cloud_project_kube.md.tmpl
+++ b/templates/data-sources/cloud_project_kube.md.tmpl
@@ -40,6 +40,12 @@ The following attributes are exported:
 * `status` - Cluster status. Should be normally set to 'READY'.
 * `update_policy` - Cluster update policy. Choose between [ALWAYS_UPDATE,MINIMAL_DOWNTIME,NEVER_UPDATE]'.
 * `url` - Management URL of your cluster.
+* `kubeconfig` - (Sensitive) Raw kubeconfig file content for connecting to the cluster.
+* `kubeconfig_attributes` - (Sensitive) Structured kubeconfig data for connecting to the cluster.
+  * `host` - Kubernetes API server endpoint.
+  * `cluster_ca_certificate` - (Sensitive) Cluster certificate authority data.
+  * `client_certificate` - (Sensitive) Client certificate data for authentication.
+  * `client_key` - (Sensitive) Client private key data for authentication.
 * `kube_proxy_mode` - Selected mode for kube-proxy.
 * `customization` - **Deprecated** (Optional) Use `customization_apiserver` and `customization_kube_proxy` instead. Kubernetes cluster customization
   * `apiserver` - Kubernetes API server customization


### PR DESCRIPTION
# Description

The cloud-project-kube data source can now return kubeconfig and kubeconfig_attributes as sensitive data (which are already returned by the resource during the creation).
This can be useful when you want to reuse an existing kube cluster in another project.

## Type of change

Please delete options that are not relevant.

- [x] Improvement (improve existing resource(s) or datasource(s))

# How Has This Been Tested?

I've followed the `Readme` -> `Using the locally built provider` part, and test it with a project that need to get an existing kube project + update the existing unit tests.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or issues
- [x] I have added acceptance tests that prove my fix is effective or that my feature works
- [x] New and existing acceptance tests pass locally with my changes
- [x] I ran succesfully `go mod vendor` if I added or modify `go.mod` file
