### PR TITLE
fix: Correctly recreate resource ovh_domain_zone_record when deleted outside Terraform

### DIFF
--- a/ovh/resource_domain_zone_record.go
+++ b/ovh/resource_domain_zone_record.go
@@ -124,7 +124,7 @@ func resourceOvhDomainZoneRecordCreate(d *schema.ResourceData, meta interface{})
 	// this is an API response BUG known by OVH team
 	// with no planned fix
 	// Workaround is to filter records matching the attributes
-	// and keep the last id if there are doublons
+	// and keep the last id if there are duplicates
 	if resultRecord.Id == 0 {
 		log.Printf("[WARN] Known OVH API Bug with Inconsistency API result (id = 0): %v", resultRecord)
 		records := make([]int, 0)
@@ -172,13 +172,14 @@ func resourceOvhDomainZoneRecordRead(d *schema.ResourceData, meta interface{}) e
 	config := meta.(*Config)
 
 	record, err := ovhDomainZoneRecord(config.OVHClient, d, d.Id(), d.IsNewResource())
-
 	if err != nil {
 		return err
 	}
 
 	if record == nil {
-		return fmt.Errorf("record %v has been deleted.", d.Id())
+		// ID already set to "", so just return
+		log.Print("record has been deleted")
+		return nil
 	}
 
 	d.Set("zone", record.Zone)


### PR DESCRIPTION
# Description

Fixes #1065 (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Test A: `make testacc TESTARGS="-run TestAccDomainZoneRecord_*"`

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or issues
- [x] I have added acceptance tests that prove my fix is effective or that my feature works
- [x] New and existing acceptance tests pass locally with my changes
- [x] I ran succesfully `go mod vendor` if I added or modify `go.mod` file
