### PR TITLE
With data_dbaas_logs_output_graylog_stream_url

### DIFF
--- a/docs/data-sources/dbaas_logs_output_graylog_stream_url.md
+++ b/docs/data-sources/dbaas_logs_output_graylog_stream_url.md
@@ -1,0 +1,29 @@
+---
+subcategory : "Logs Data Platform"
+---
+
+# ovh_dbaas_logs_output_graylog_stream_url (Data Source)
+
+Use this data source to retrieve the list of URLs for a DBaas logs output Graylog stream.
+
+## Example Usage
+
+```terraform
+data "ovh_dbaas_logs_output_graylog_stream_url" "urls" {
+  service_name = "ldp-xx-xxxxx"
+  stream_id    = "STREAM_ID"
+}
+```
+
+## Argument Reference
+
+* `service_name` - The service name. It's the ID of your Logs Data Platform instance.
+* `stream_id` - Stream ID.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `url` - List of URLs. Each element contains:
+  * `address` - URL address
+  * `type` - URL type (e.g. `GRAYLOG_WEBUI`, `WEB_SOCKET`)

--- a/ovh/data_dbaas_logs_output_graylog_stream_url.go
+++ b/ovh/data_dbaas_logs_output_graylog_stream_url.go
@@ -1,0 +1,83 @@
+package ovh
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"net/url"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+// dataSourceDbaasLogsOutputGraylogStreamURL returns the list of URLs for a Graylog stream.
+func dataSourceDbaasLogsOutputGraylogStreamURL() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceDbaasLogsOutputGraylogStreamURLRead,
+		Schema: map[string]*schema.Schema{
+			"service_name": {
+				Type:        schema.TypeString,
+				Description: "The service name",
+				Required:    true,
+			},
+			"stream_id": {
+				Type:        schema.TypeString,
+				Description: "Stream ID",
+				Required:    true,
+			},
+			"url": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"address": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "URL address",
+						},
+						"type": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "URL type",
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func dataSourceDbaasLogsOutputGraylogStreamURLRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	config := meta.(*Config)
+
+	serviceName := d.Get("service_name").(string)
+	streamID := d.Get("stream_id").(string)
+
+	log.Printf("[DEBUG] Will read URLs for dbaas logs output graylog stream: %s/%s", serviceName, streamID)
+	endpoint := fmt.Sprintf(
+		"/dbaas/logs/%s/output/graylog/stream/%s/url",
+		url.PathEscape(serviceName),
+		url.PathEscape(streamID),
+	)
+
+	var urls []DbaasLogsOutputGraylogStreamURL
+	if err := config.OVHClient.Get(endpoint, &urls); err != nil {
+		return diag.Errorf("Error calling Get %s:\n\t %q", endpoint, err)
+	}
+
+	list := make([]map[string]interface{}, len(urls))
+	for i, u := range urls {
+		m := map[string]interface{}{
+			"address": u.Address,
+			"type":    u.Type,
+		}
+		list[i] = m
+	}
+
+	if err := d.Set("url", list); err != nil {
+		return diag.FromErr(err)
+	}
+
+	d.SetId(fmt.Sprintf("%s/%s", serviceName, streamID))
+	return nil
+}

--- a/ovh/provider.go
+++ b/ovh/provider.go
@@ -156,6 +156,7 @@ func Provider() *schema.Provider {
 			"ovh_dbaas_logs_clusters":                                        dataSourceDbaasLogsClusters(),
 			"ovh_dbaas_logs_input_engine":                                    dataSourceDbaasLogsInputEngine(),
 			"ovh_dbaas_logs_output_graylog_stream":                           dataSourceDbaasLogsOutputGraylogStream(),
+			"ovh_dbaas_logs_output_graylog_stream_url":                       dataSourceDbaasLogsOutputGraylogStreamURL(),
 			"ovh_dbaas_logs_output_opensearch_index":                         dataSourceDbaasLogsOutputOpensearchIndex(),
 			"ovh_dedicated_ceph":                                             dataSourceDedicatedCeph(),
 			"ovh_dedicated_installation_templates":                           dataSourceDedicatedInstallationTemplates(),

--- a/ovh/types_dbaas_logs_output_graylog_stream.go
+++ b/ovh/types_dbaas_logs_output_graylog_stream.go
@@ -160,3 +160,9 @@ type DbaasLogsOutputGraylogStreamRule struct {
 	Field string `json:"field"`
 	Value string `json:"value"`
 }
+
+// DbaasLogsOutputGraylogStreamURL represents a URL entry for a Graylog stream.
+type DbaasLogsOutputGraylogStreamURL struct {
+	Address string `json:"address"`
+	Type    string `json:"type"`
+}


### PR DESCRIPTION
## Add ovh_dbaas_logs_output_graylog_stream_url data source

### Description

This PR introduces a new Terraform data source—ovh_dbaas_logs_output_graylog_stream_url—to the OVH provider. It allows users to fetch the list of URLs associated with a DBaaS Logs  
Graylog stream.

### Usage

    data "ovh_dbaas_logs_output_graylog_stream_url" "urls" {
      service_name = "ldp-xx-xxxxx"
      stream_id    = "STREAM_ID"
    }

    # The `url` attribute yields a list of objects with:
    # - `address`: the URL endpoint
    # - `type`:    the URL type (e.g. GRAYLOG_WEBUI, WEB_SOCKET)
