### PR TITLE
add deletion protection field for database service

### DIFF
--- a/docs/data-sources/cloud_project_database.md
+++ b/docs/data-sources/cloud_project_database.md
@@ -55,7 +55,7 @@ The following attributes are exported:
   * `description` - Description of the IP restriction
   * `ip` - Authorized IP
   * `status` - Current status of the IP restriction.
-* `deletion_protection` - Enable delation protection
+* `deletion_protection` - Enable deletion protection
 * `kafka_rest_api` - Defines whether the REST API is enabled on a kafka cluster.
 * `kafka_schema_registry` - Defines whether the schema registry is enabled on a Kafka cluster
 * `maintenance_time` - Time on which maintenances can start every day.

--- a/docs/data-sources/cloud_project_database.md
+++ b/docs/data-sources/cloud_project_database.md
@@ -55,6 +55,7 @@ The following attributes are exported:
   * `description` - Description of the IP restriction
   * `ip` - Authorized IP
   * `status` - Current status of the IP restriction.
+* `deletion_protection` - Enable delation protection
 * `kafka_rest_api` - Defines whether the REST API is enabled on a kafka cluster.
 * `kafka_schema_registry` - Defines whether the schema registry is enabled on a Kafka cluster
 * `maintenance_time` - Time on which maintenances can start every day.

--- a/docs/resources/cloud_project_database.md
+++ b/docs/resources/cloud_project_database.md
@@ -223,6 +223,7 @@ The following arguments are supported:
 * `ip_restrictions` - (Optional) IP Blocks authorized to access to the cluster.
   * `description` - (Optional) Description of the IP restriction
   * `ip` - (Optional) Authorized IP
+* `deletion_protection` - (Optional) Enable deletion protection
 * `kafka_rest_api` - (Optional) Defines whether the REST API is enabled on a kafka cluster
 * `kafka_schema_registry` - (Optional) Defines whether the schema registry is enabled on a Kafka cluster
 * `nodes` - (Required, Minimum Items: 1) List of nodes object. Multi region cluster are not yet available, all node should be identical.
@@ -268,6 +269,7 @@ The following attributes are exported:
   * `description` - See Argument Reference above.
   * `ip` - See Argument Reference above.
   * `status` - Current status of the IP restriction.
+* `deletion_protection` - See Argument Reference above.
 * `kafka_rest_api` - See Argument Reference above.
 * `kafka_schema_registry` - See Argument Reference above.
 * `maintenance_time` - Time on which maintenances can start every day.

--- a/ovh/data_cloud_project_database.go
+++ b/ovh/data_cloud_project_database.go
@@ -133,7 +133,7 @@ func dataSourceCloudProjectDatabase() *schema.Resource {
 			"deletion_protection": {
 				Type:        schema.TypeBool,
 				Description: "Enable deletion protection",
-				Optional:    true,
+				Computed:    true,
 			},
 			"kafka_rest_api": {
 				Type:        schema.TypeBool,

--- a/ovh/data_cloud_project_database.go
+++ b/ovh/data_cloud_project_database.go
@@ -130,6 +130,11 @@ func dataSourceCloudProjectDatabase() *schema.Resource {
 					},
 				},
 			},
+			"deletion_protection": {
+				Type:        schema.TypeBool,
+				Description: "Enable deletion protection",
+				Optional:    true,
+			},
 			"kafka_rest_api": {
 				Type:        schema.TypeBool,
 				Description: "Defines whether the REST API is enabled on a Kafka cluster",

--- a/ovh/resource_cloud_project_database.go
+++ b/ovh/resource_cloud_project_database.go
@@ -77,6 +77,11 @@ func resourceCloudProjectDatabase() *schema.Resource {
 					},
 				},
 			},
+			"deletion_protection": {
+				Type:        schema.TypeBool,
+				Description: "Enable deletion protection",
+				Optional:    true,
+			},
 			"kafka_rest_api": {
 				Type:        schema.TypeBool,
 				Description: "Defines whether the REST API is enabled on a Kafka cluster",
@@ -305,7 +310,8 @@ func resourceCloudProjectDatabaseCreate(ctx context.Context, d *schema.ResourceD
 	if (engine != "mongodb" && len(d.Get("advanced_configuration").(map[string]interface{})) > 0) ||
 		(engine == "kafka" && d.Get("kafka_rest_api").(bool)) ||
 		(engine == "kafka" && d.Get("kafka_schema_registry").(bool)) ||
-		(engine == "opensearch" && d.Get("opensearch_acls_enabled").(bool)) {
+		(engine == "opensearch" && d.Get("opensearch_acls_enabled").(bool)) ||
+		d.Get("deletion_protection").(bool) {
 		return resourceCloudProjectDatabaseUpdate(ctx, d, meta)
 	}
 

--- a/ovh/types_cloud_project_database.go
+++ b/ovh/types_cloud_project_database.go
@@ -79,6 +79,7 @@ type CloudProjectDatabaseResponse struct {
 	Plan                  string                                      `json:"plan"`
 	NodeNumber            int                                         `json:"nodeNumber"`
 	Region                string                                      `json:"region"`
+	DeletionProtection    bool                                        `json:"deletionProtection"`
 	RestAPI               bool                                        `json:"restApi"`
 	SchemaRegistry        bool                                        `json:"schemaRegistry"`
 	Status                string                                      `json:"status"`
@@ -110,6 +111,7 @@ func (r CloudProjectDatabaseResponse) toMap() map[string]interface{} {
 	obj["endpoints"] = endpoints
 
 	obj["flavor"] = r.Flavor
+	obj["deletion_protection"] = r.DeletionProtection
 	obj["kafka_rest_api"] = r.RestAPI
 	obj["kafka_schema_registry"] = r.SchemaRegistry
 	obj["maintenance_time"] = r.MaintenanceTime
@@ -274,17 +276,18 @@ func (opts *CloudProjectDatabaseCreateOpts) fromResource(d *schema.ResourceData)
 }
 
 type CloudProjectDatabaseUpdateOpts struct {
-	AclsEnabled     bool                                `json:"aclsEnabled,omitempty"`
-	Backups         *CloudProjectDatabaseBackups        `json:"backups,omitempty"`
-	Description     string                              `json:"description,omitempty"`
-	Disk            CloudProjectDatabaseDisk            `json:"disk,omitempty"`
-	Flavor          string                              `json:"flavor,omitempty"`
-	IPRestrictions  []CloudProjectDatabaseIPRestriction `json:"ipRestrictions,omitempty"`
-	MaintenanceTime string                              `json:"maintenanceTime,omitempty"`
-	Plan            string                              `json:"plan,omitempty"`
-	RestAPI         bool                                `json:"restApi,omitempty"`
-	SchemaRegistry  bool                                `json:"schemaRegistry,omitempty"`
-	Version         string                              `json:"version,omitempty"`
+	AclsEnabled        bool                                `json:"aclsEnabled,omitempty"`
+	Backups            *CloudProjectDatabaseBackups        `json:"backups,omitempty"`
+	Description        string                              `json:"description,omitempty"`
+	Disk               CloudProjectDatabaseDisk            `json:"disk,omitempty"`
+	Flavor             string                              `json:"flavor,omitempty"`
+	IPRestrictions     []CloudProjectDatabaseIPRestriction `json:"ipRestrictions,omitempty"`
+	MaintenanceTime    string                              `json:"maintenanceTime,omitempty"`
+	Plan               string                              `json:"plan,omitempty"`
+	DeletionProtection bool                                `json:"deletionProtection,omitempty"`
+	RestAPI            bool                                `json:"restApi,omitempty"`
+	SchemaRegistry     bool                                `json:"schemaRegistry,omitempty"`
+	Version            string                              `json:"version,omitempty"`
 }
 
 func (opts *CloudProjectDatabaseUpdateOpts) fromResource(d *schema.ResourceData) (*CloudProjectDatabaseUpdateOpts, error) {
@@ -302,6 +305,8 @@ func (opts *CloudProjectDatabaseUpdateOpts) fromResource(d *schema.ResourceData)
 	opts.Flavor = d.Get("flavor").(string)
 	opts.Version = d.Get("version").(string)
 	opts.Disk = CloudProjectDatabaseDisk{Size: d.Get("disk_size").(int)}
+
+	opts.DeletionProtection = d.Get("deletion_protection").(bool)
 
 	ipRests := d.Get("ip_restrictions").(*schema.Set).List()
 	opts.IPRestrictions = make([]CloudProjectDatabaseIPRestriction, len(ipRests))

--- a/ovh/types_cloud_project_database.go
+++ b/ovh/types_cloud_project_database.go
@@ -276,7 +276,7 @@ func (opts *CloudProjectDatabaseCreateOpts) fromResource(d *schema.ResourceData)
 }
 
 type CloudProjectDatabaseUpdateOpts struct {
-	AclsEnabled        bool                                `json:"aclsEnabled,omitempty"`
+	AclsEnabled        *bool                               `json:"aclsEnabled,omitempty"`
 	Backups            *CloudProjectDatabaseBackups        `json:"backups,omitempty"`
 	Description        string                              `json:"description,omitempty"`
 	Disk               CloudProjectDatabaseDisk            `json:"disk,omitempty"`
@@ -284,20 +284,23 @@ type CloudProjectDatabaseUpdateOpts struct {
 	IPRestrictions     []CloudProjectDatabaseIPRestriction `json:"ipRestrictions,omitempty"`
 	MaintenanceTime    string                              `json:"maintenanceTime,omitempty"`
 	Plan               string                              `json:"plan,omitempty"`
-	DeletionProtection bool                                `json:"deletionProtection,omitempty"`
-	RestAPI            bool                                `json:"restApi,omitempty"`
-	SchemaRegistry     bool                                `json:"schemaRegistry,omitempty"`
+	DeletionProtection *bool                               `json:"deletionProtection,omitempty"`
+	RestAPI            *bool                               `json:"restApi,omitempty"`
+	SchemaRegistry     *bool                               `json:"schemaRegistry,omitempty"`
 	Version            string                              `json:"version,omitempty"`
 }
 
 func (opts *CloudProjectDatabaseUpdateOpts) fromResource(d *schema.ResourceData) (*CloudProjectDatabaseUpdateOpts, error) {
 	engine := d.Get("engine").(string)
 	if engine == "opensearch" {
-		opts.AclsEnabled = d.Get("opensearch_acls_enabled").(bool)
+		AclsEnabledBool := d.Get("opensearch_acls_enabled").(bool)
+		opts.AclsEnabled = &AclsEnabledBool
 	}
 	if engine == "kafka" {
-		opts.RestAPI = d.Get("kafka_rest_api").(bool)
-		opts.SchemaRegistry = d.Get("kafka_schema_registry").(bool)
+		restAPIBool := d.Get("kafka_rest_api").(bool)
+		opts.RestAPI = &restAPIBool
+		shemaRegistryBool := d.Get("kafka_schema_registry").(bool)
+		opts.SchemaRegistry = &shemaRegistryBool
 	}
 
 	opts.Description = d.Get("description").(string)
@@ -306,7 +309,8 @@ func (opts *CloudProjectDatabaseUpdateOpts) fromResource(d *schema.ResourceData)
 	opts.Version = d.Get("version").(string)
 	opts.Disk = CloudProjectDatabaseDisk{Size: d.Get("disk_size").(int)}
 
-	opts.DeletionProtection = d.Get("deletion_protection").(bool)
+	deletionProtectionBool := d.Get("deletion_protection").(bool)
+	opts.DeletionProtection = &deletionProtectionBool
 
 	ipRests := d.Get("ip_restrictions").(*schema.Set).List()
 	opts.IPRestrictions = make([]CloudProjectDatabaseIPRestriction, len(ipRests))

--- a/templates/data-sources/cloud_project_database.md.tmpl
+++ b/templates/data-sources/cloud_project_database.md.tmpl
@@ -49,6 +49,7 @@ The following attributes are exported:
   * `description` - Description of the IP restriction
   * `ip` - Authorized IP
   * `status` - Current status of the IP restriction.
+* `deletion_protection` - Enable deletion protection
 * `kafka_rest_api` - Defines whether the REST API is enabled on a kafka cluster.
 * `kafka_schema_registry` - Defines whether the schema registry is enabled on a Kafka cluster
 * `maintenance_time` - Time on which maintenances can start every day.

--- a/templates/resources/cloud_project_database.md.tmpl
+++ b/templates/resources/cloud_project_database.md.tmpl
@@ -41,6 +41,7 @@ The following arguments are supported:
 * `ip_restrictions` - (Optional) IP Blocks authorized to access to the cluster.
   * `description` - (Optional) Description of the IP restriction
   * `ip` - (Optional) Authorized IP
+* `deletion_protection` - (Optional) Enable deletion protection
 * `kafka_rest_api` - (Optional) Defines whether the REST API is enabled on a kafka cluster
 * `kafka_schema_registry` - (Optional) Defines whether the schema registry is enabled on a Kafka cluster
 * `nodes` - (Required, Minimum Items: 1) List of nodes object. Multi region cluster are not yet available, all node should be identical.
@@ -86,6 +87,7 @@ The following attributes are exported:
   * `description` - See Argument Reference above.
   * `ip` - See Argument Reference above.
   * `status` - Current status of the IP restriction.
+* `deletion_protection` - Enable deletion protection
 * `kafka_rest_api` - See Argument Reference above.
 * `kafka_schema_registry` - See Argument Reference above.
 * `maintenance_time` - Time on which maintenances can start every day.


### PR DESCRIPTION
# Description

Deletion Protection option for cloud Database service

## Type of change

Please delete options that are not relevant.

- [X] New feature (non-breaking change which adds functionality)
- [X] Improvement (improve existing resource(s) or datasource(s))
- [X] Documentation update

# How Has This Been Tested?

Tested with this code then try to delete it manualy and by remove the resource to my Terraform code to check that an error is returned and block the deletion.
```hcl
resource "ovh_cloud_project_database" "database" {
  service_name        = "xxxxxxx
  engine              = "postgresql"
  description         = "lucky-yang"
  flavor              = "db1-7"
  nodes {
    region     = "GRA"
  }
  deletion_protection = true
  plan                = "essential"
  version             = "17"
}
```
