### PR TITLE
fix(ovh_cloud_project_storage): Correctly use parameters to filter returned objects

### DIFF
--- a/ovh/resource_cloud_project_storage_gen.go
+++ b/ovh/resource_cloud_project_storage_gen.go
@@ -408,29 +408,6 @@ func (v *CloudProjectRegionStorageModel) MergeWith(other *CloudProjectRegionStor
 		v.Name = other.Name
 	}
 
-	if (v.Objects.IsUnknown() || v.Objects.IsNull()) && !other.Objects.IsUnknown() {
-		v.Objects = other.Objects
-	} else if !other.Objects.IsUnknown() {
-		newSlice := make([]attr.Value, 0)
-		elems := v.Objects.Elements()
-		newElems := other.Objects.Elements()
-
-		if len(elems) != len(newElems) {
-			v.Objects = other.Objects
-		} else {
-			for idx, e := range elems {
-				tmp := e.(ObjectsValue)
-				tmp2 := newElems[idx].(ObjectsValue)
-				tmp.MergeWith(&tmp2)
-				newSlice = append(newSlice, tmp)
-			}
-
-			v.Objects = ovhtypes.TfListNestedValue[ObjectsValue]{
-				ListValue: basetypes.NewListValueMust(ObjectsValue{}.Type(context.Background()), newSlice),
-			}
-		}
-	}
-
 	if (v.ObjectsCount.IsUnknown() || v.ObjectsCount.IsNull()) && !other.ObjectsCount.IsUnknown() {
 		v.ObjectsCount = other.ObjectsCount
 	}
@@ -1944,10 +1921,9 @@ func (v *ReplicationValue) UnmarshalJSON(data []byte) error {
 }
 
 func (v *ReplicationValue) MergeWith(other *ReplicationValue) {
-
 	if (v.Rules.IsUnknown() || v.Rules.IsNull()) && !other.Rules.IsUnknown() {
 		v.Rules = other.Rules
-	} else if !other.Rules.IsUnknown() {
+	} else if !other.Rules.IsUnknown() && !other.Rules.IsNull() {
 		newSlice := make([]attr.Value, 0)
 		elems := v.Rules.Elements()
 		newElems := other.Rules.Elements()

--- a/ovh/resource_cloud_project_storage_test.go
+++ b/ovh/resource_cloud_project_storage_test.go
@@ -51,45 +51,43 @@ func TestAccCloudProjectRegionStorage_basic(t *testing.T) {
 func TestAccCloudProjectRegionStorage_withReplication(t *testing.T) {
 	bucketName := acctest.RandomWithPrefix(test_prefix)
 	replicaBucketName := acctest.RandomWithPrefix(test_prefix)
-	config := fmt.Sprintf(`
-	resource "ovh_cloud_project_storage" "storage" {
-		service_name = "%s"
-		region_name = "GRA"
-		name = "%s"
-
-		versioning = {
-			status = "enabled"
-		}
-
-		replication = {
-			rules = [
-				{
-					id          = "test"
-					priority    = 1
-					status      = "enabled"
-					destination = {
-						name   = "%s"
-						region = "GRA"
-					}
-					filter = {
-						"prefix" = "test"
-						"tags"   = {
-							"key": "test"
-						}
-					}
-					delete_marker_replication = "disabled"
-				}
-			]
-		}
-	}
-	`, os.Getenv("OVH_CLOUD_PROJECT_SERVICE_TEST"), bucketName, replicaBucketName)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheckCloud(t); testAccCheckCloudProjectExists(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: config,
+				Config: fmt.Sprintf(`
+					resource "ovh_cloud_project_storage" "storage" {
+						service_name = "%s"
+						region_name = "GRA"
+						name = "%s"
+
+						versioning = {
+							status = "enabled"
+						}
+
+						replication = {
+							rules = [
+								{
+									id          = "test"
+									priority    = 1
+									status      = "enabled"
+									destination = {
+										name   = "%s"
+										region = "GRA"
+									}
+									filter = {
+										"prefix" = "test"
+										"tags"   = {
+											"key": "test"
+										}
+									}
+									delete_marker_replication = "disabled"
+								}
+							]
+						}
+					}`, os.Getenv("OVH_CLOUD_PROJECT_SERVICE_TEST"), bucketName, replicaBucketName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("ovh_cloud_project_storage.storage", "name", bucketName),
 					resource.TestCheckResourceAttr("ovh_cloud_project_storage.storage", "region", "GRA"),
@@ -102,6 +100,53 @@ func TestAccCloudProjectRegionStorage_withReplication(t *testing.T) {
 					resource.TestCheckResourceAttr("ovh_cloud_project_storage.storage", "replication.rules.0.destination.name", replicaBucketName),
 					resource.TestCheckResourceAttr("ovh_cloud_project_storage.storage", "replication.rules.0.destination.region", "GRA"),
 					resource.TestCheckResourceAttr("ovh_cloud_project_storage.storage", "replication.rules.0.filter.prefix", "test"),
+					resource.TestCheckResourceAttrSet("ovh_cloud_project_storage.storage", "virtual_host"),
+				),
+			},
+			{
+				Config: fmt.Sprintf(`
+					resource "ovh_cloud_project_storage" "storage" {
+						service_name = "%s"
+						region_name = "GRA"
+						name = "%s"
+
+						versioning = {
+							status = "enabled"
+						}
+
+						replication = {
+							rules = [
+								{
+									id          = "test"
+									priority    = 1
+									status      = "enabled"
+									destination = {
+										name   = "%s"
+										region = "GRA"
+									}
+									filter = {
+										"prefix" = "test-updated"
+										"tags"   = {
+											"key": "test-updated"
+										}
+									}
+									delete_marker_replication = "disabled"
+								}
+							]
+						}
+					} `, os.Getenv("OVH_CLOUD_PROJECT_SERVICE_TEST"), bucketName, replicaBucketName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("ovh_cloud_project_storage.storage", "name", bucketName),
+					resource.TestCheckResourceAttr("ovh_cloud_project_storage.storage", "region", "GRA"),
+					resource.TestCheckResourceAttr("ovh_cloud_project_storage.storage", "versioning.status", "enabled"),
+					resource.TestCheckResourceAttr("ovh_cloud_project_storage.storage", "encryption.sse_algorithm", "plaintext"),
+					resource.TestCheckResourceAttr("ovh_cloud_project_storage.storage", "replication.rules.#", "1"),
+					resource.TestCheckResourceAttr("ovh_cloud_project_storage.storage", "replication.rules.0.id", "test"),
+					resource.TestCheckResourceAttr("ovh_cloud_project_storage.storage", "replication.rules.0.priority", "1"),
+					resource.TestCheckResourceAttr("ovh_cloud_project_storage.storage", "replication.rules.0.status", "enabled"),
+					resource.TestCheckResourceAttr("ovh_cloud_project_storage.storage", "replication.rules.0.destination.name", replicaBucketName),
+					resource.TestCheckResourceAttr("ovh_cloud_project_storage.storage", "replication.rules.0.destination.region", "GRA"),
+					resource.TestCheckResourceAttr("ovh_cloud_project_storage.storage", "replication.rules.0.filter.prefix", "test-updated"),
 					resource.TestCheckResourceAttrSet("ovh_cloud_project_storage.storage", "virtual_host"),
 				),
 			},


### PR DESCRIPTION
# Description

`ovh_cloud_project_storage`: The parameters `limit`, `marker` and `prefix` that control the objects that are listed in a bucket were not used, so all objects were listed with the default filters.

Fixes #1085 (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] Test A: `make testacc TESTARGS="-run TestAccCloudProjectRegionStorage_basic"`
- [x] Test B: `make testacc TESTARGS="-run TestAccCloudProjectRegionStorage_withReplication"`

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or issues
- [x] I have added acceptance tests that prove my fix is effective or that my feature works
- [x] New and existing acceptance tests pass locally with my changes
- [x] I ran succesfully `go mod vendor` if I added or modify `go.mod` file
