### PR TITLE
feat(mks): add plan as mks cluster attribute

### DIFF
--- a/examples/resources/cloud_project_kube/example_10.tf
+++ b/examples/resources/cloud_project_kube/example_10.tf
@@ -32,6 +32,7 @@ resource "ovh_cloud_project_kube" "my_multizone_cluster" {
   service_name  = ovh_cloud_project_network_private.network.service_name
   name          = "multi-zone-mks"
   region        = "EU-WEST-PAR"
+  plan          = "standard"
 
   private_network_id = tolist(ovh_cloud_project_network_private.network.regions_attributes[*].openstackid)[0]
   nodes_subnet_id    = ovh_cloud_project_network_private_subnet.subnet.id

--- a/examples/resources/cloud_project_kube/example_9.tf
+++ b/examples/resources/cloud_project_kube/example_9.tf
@@ -2,6 +2,7 @@ resource "ovh_cloud_project_kube" "my_multizone_cluster" {
   service_name       = "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
   name               = "terraform-multi-zone-cluster"
   region             = "EU-WEST-PAR"
+  plan               = "standard"
 
   private_network_id = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
   nodes_subnet_id    = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" //Subnet must has a OVHcloud Gateway/OpenStack router

--- a/ovh/data_cloud_project_kube.go
+++ b/ovh/data_cloud_project_kube.go
@@ -30,6 +30,13 @@ func dataSourceCloudProjectKube() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 			},
+			"plan": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ForceNew:     false,
+				Default:      "free",
+				ValidateFunc: helpers.ValidateEnum([]string{"standard", "free"}),
+			},
 			kubeClusterProxyModeKey: {
 				Type:         schema.TypeString,
 				Optional:     true,

--- a/ovh/resource_cloud_project_kube.go
+++ b/ovh/resource_cloud_project_kube.go
@@ -24,6 +24,7 @@ const (
 	kubeClusterPrivateNetworkConfigurationKey = "private_network_configuration"
 	kubeClusterUpdatePolicyKey                = "update_policy"
 	kubeClusterVersionKey                     = "version"
+	kubeClusterPlanKey                        = "plan"
 
 	kubeClusterProxyModeKey = "kube_proxy_mode"
 
@@ -68,6 +69,13 @@ func resourceCloudProjectKube() *schema.Resource {
 				Computed: true,
 				Optional: true,
 				ForceNew: false,
+			},
+			kubeClusterPlanKey: {
+				Type:         schema.TypeString,
+				Computed:     true,
+				Optional:     true,
+				ForceNew:     false,
+				ValidateFunc: helpers.ValidateEnum([]string{"standard", "free"}),
 			},
 			kubeClusterCustomizationApiServerKey: {
 				Type:          schema.TypeSet,
@@ -622,6 +630,17 @@ func resourceCloudProjectKubeUpdate(d *schema.ResourceData, meta interface{}) er
 			return fmt.Errorf("timeout while waiting kube %s to be READY: %w", d.Id(), err)
 		}
 		log.Printf("[DEBUG] kube %s is READY", d.Id())
+	}
+
+	if d.HasChanges(kubeClusterPlanKey) {
+		oldValue, newValue := d.GetChange(kubeClusterPlanKey)
+		newPlan := newValue.(string)
+		oldPlan := oldValue.(string)
+		if oldPlan == "standard" {
+			return fmt.Errorf("you cannot migrate from %s to %s", oldPlan, newPlan)
+		}
+
+		return fmt.Errorf("migrate from %s to %s is not available yet", oldPlan, newPlan)
 	}
 
 	if d.HasChange(kubeClusterUpdatePolicyKey) {

--- a/ovh/resource_cloud_project_kube_test.go
+++ b/ovh/resource_cloud_project_kube_test.go
@@ -1051,6 +1051,7 @@ func TestAccCloudProjectKube_basic(t *testing.T) {
 					resource.TestCheckResourceAttrSet("ovh_cloud_project_kube.cluster", "kubeconfig"),
 					resource.TestCheckResourceAttr("ovh_cloud_project_kube.cluster", kubeClusterNameKey, name),
 					resource.TestCheckResourceAttr("ovh_cloud_project_kube.cluster", "version", version),
+					resource.TestCheckResourceAttrSet("ovh_cloud_project_kube.cluster", kubeClusterPlanKey),
 					resource.TestCheckResourceAttrSet("ovh_cloud_project_kube.cluster", "kubeconfig"),
 					resource.TestCheckResourceAttrSet("ovh_cloud_project_kube.cluster", "kubeconfig_attributes.0.host"),
 					resource.TestCheckResourceAttrSet("ovh_cloud_project_kube.cluster", "kubeconfig_attributes.0.cluster_ca_certificate"),
@@ -1110,6 +1111,7 @@ func TestAccCloudProjectKubeEmptyVersion_basic(t *testing.T) {
 					resource.TestCheckResourceAttrSet("ovh_cloud_project_kube.cluster", "kubeconfig"),
 					resource.TestCheckResourceAttr("ovh_cloud_project_kube.cluster", kubeClusterNameKey, name),
 					resource.TestCheckResourceAttrSet("ovh_cloud_project_kube.cluster", "version"),
+					resource.TestCheckResourceAttrSet("ovh_cloud_project_kube.cluster", kubeClusterPlanKey),
 				),
 			},
 			{
@@ -1119,6 +1121,7 @@ func TestAccCloudProjectKubeEmptyVersion_basic(t *testing.T) {
 					resource.TestCheckResourceAttrSet("ovh_cloud_project_kube.cluster", "kubeconfig"),
 					resource.TestCheckResourceAttr("ovh_cloud_project_kube.cluster", kubeClusterNameKey, updatedName),
 					resource.TestCheckResourceAttrSet("ovh_cloud_project_kube.cluster", "version"),
+					resource.TestCheckResourceAttrSet("ovh_cloud_project_kube.cluster", kubeClusterPlanKey),
 				),
 			},
 		},

--- a/ovh/types_cloud_project_kube.go
+++ b/ovh/types_cloud_project_kube.go
@@ -33,6 +33,7 @@ type CloudProjectKubeCreateOpts struct {
 	PrivateNetworkConfiguration *privateNetworkConfiguration `json:"privateNetworkConfiguration,omitempty"`
 	Region                      string                       `json:"region"`
 	Version                     *string                      `json:"version,omitempty"`
+	Plan                        *string                      `json:"plan,omitempty"`
 	UpdatePolicy                *string                      `json:"updatePolicy,omitempty"`
 	Customization               *Customization               `json:"customization,omitempty"`
 	KubeProxyMode               *string                      `json:"kubeProxyMode,omitempty"`
@@ -76,6 +77,7 @@ type AdmissionPlugins struct {
 func (opts *CloudProjectKubeCreateOpts) FromResource(d *schema.ResourceData) {
 	opts.Region = d.Get("region").(string)
 	opts.Version = helpers.GetNilStringPointerFromData(d, "version")
+	opts.Plan = helpers.GetNilStringPointerFromData(d, kubeClusterPlanKey)
 	opts.Name = helpers.GetNilStringPointerFromData(d, "name")
 	opts.UpdatePolicy = helpers.GetNilStringPointerFromData(d, "update_policy")
 	opts.LoadBalancersSubnetId = helpers.GetNilStringPointerFromData(d, "load_balancers_subnet_id")
@@ -275,6 +277,7 @@ type CloudProjectKubeResponse struct {
 	UpdatePolicy           string        `json:"updatePolicy"`
 	Url                    string        `json:"url"`
 	Version                string        `json:"version"`
+	Plan                   string        `json:"plan"`
 	Customization          Customization `json:"customization"`
 	KubeProxyMode          string        `json:"kubeProxyMode"`
 }
@@ -294,6 +297,7 @@ func (v *CloudProjectKubeResponse) ToMap(d *schema.ResourceData) map[string]inte
 	obj["status"] = v.Status
 	obj["update_policy"] = v.UpdatePolicy
 	obj["url"] = v.Url
+	obj[kubeClusterPlanKey] = v.Plan
 	versionPatch, err := version.NewVersion(v.Version)
 	if err != nil {
 		// if fail, return to the previous implementation

--- a/templates/data-sources/cloud_project_kube.md.tmpl
+++ b/templates/data-sources/cloud_project_kube.md.tmpl
@@ -30,6 +30,7 @@ The following attributes are exported:
 * `name` - The name of the managed kubernetes cluster.
 * `region` - The OVHcloud public cloud region ID of the managed kubernetes cluster.
 * `version` - Kubernetes version of the managed kubernetes cluster.
+* `plan` - Plan of the managed kubernetes cluster.
 * `private_network_id` - OpenStack private network (or vrack) ID to use.
 * `load_balancers_subnet_id` - Openstack private network (or vRack) ID to use for load balancers.
 * `nodes_subnet_id` - Openstack private network (or vRack) ID to use for nodes.

--- a/templates/resources/cloud_project_kube.md.tmpl
+++ b/templates/resources/cloud_project_kube.md.tmpl
@@ -12,37 +12,37 @@ Creates a OVHcloud Managed Kubernetes Service cluster in a public cloud project.
 
 ## Example Usage
 
-Create a simple Kubernetes cluster in `GRA11` region:
+Create a simple Kubernetes Free cluster in `GRA11` region:
 
 {{tffile "examples/resources/cloud_project_kube/example_1.tf"}}
 
-Create a simple Kubernetes cluster in `GRA11` region and export its kubeconfig file:
+Create a simple Kubernetes Free cluster in `GRA11` region and export its kubeconfig file:
 
 {{tffile "examples/resources/cloud_project_kube/example_2.tf"}}
 
-Create a simple Kubernetes cluster in `GRA11` region and read kubeconfig attributes:
+Create a simple Kubernetes Free cluster in `GRA11` region and read kubeconfig attributes:
 
 -> Sensitive attributes cannot be displayed using `terraform output` command. You need to specify the output's name: `terraform output my_cluster_host`.
 
 {{tffile "examples/resources/cloud_project_kube/example_3.tf"}}
 
-Create a simple Kubernetes cluster in `GRA11` region and use kubeconfig with [Helm provider](https://registry.terraform.io/providers/hashicorp/helm/latest/docs):
+Create a simple Kubernetes Free cluster in `GRA11` region and use kubeconfig with [Helm provider](https://registry.terraform.io/providers/hashicorp/helm/latest/docs):
 
 {{tffile "examples/resources/cloud_project_kube/example_4.tf"}}
 
-Create a Kubernetes cluster in `GRA11` region with API Server AdmissionPlugins configuration:
+Create a Kubernetes Free cluster in `GRA11` region with API Server AdmissionPlugins configuration:
 
 {{tffile "examples/resources/cloud_project_kube/example_5.tf"}}
 
-Create a Kubernetes cluster in `GRA11` region with Kube proxy configuration, by specifying iptables or ipvs configurations:
+Create a Kubernetes Free cluster in `GRA11` region with Kube proxy configuration, by specifying iptables or ipvs configurations:
 
 {{tffile "examples/resources/cloud_project_kube/example_6.tf"}}
 
-Kubernetes cluster creation on a private network / subnet in `GRA11` region with a managed gateway:
+Kubernetes Free cluster creation on a private network / subnet in `GRA11` region with a managed gateway:
 
 {{tffile "examples/resources/cloud_project_kube/example_7.tf"}}
 
-Create a multi-zone Kubernetes cluster (on 3 availability zones):
+Create a multi-zone Kubernetes Standard cluster (on 3 availability zones):
 
 {{tffile "examples/resources/cloud_project_kube/example_10.tf"}}
 
@@ -54,6 +54,7 @@ The following arguments are supported:
 * `name` - (Optional) The name of the kubernetes cluster.
 * `region` - a valid OVHcloud public cloud region ID in which the kubernetes cluster will be available. Ex.: "GRA9". Defaults to all public cloud regions. **Changing this value recreates the resource.**
 * `version` - (Optional) kubernetes version to use. Changing this value updates the resource. Defaults to the latest available.
+* `plan` - (Optional) Plan of the MKS cluster `free` or `standard`. Default to `free`. Migration to another plan is not implemented yet.
 * `kube_proxy_mode` - (Optional) Selected mode for kube-proxy. **Changing this value recreates the resource, including ETCD user data.** Defaults to `iptables`.
 * `customization` - **Deprecated** (Optional) Use `customization_apiserver` and `customization_kube_proxy` instead. Kubernetes cluster customization
   * `apiserver` - Kubernetes API server customization


### PR DESCRIPTION
# Description
On Manager Kubernetes Service, the customer may choose his `Plan` for his cluster.
In few days, this parameter will be required for EU-WEST-PAR (api restriction) and must be `standard` even if the cluster creation will be refused.

## Type of change

- [X] New feature (non-breaking change which adds functionality)
- [X] Documentation update

# How Has This Been Tested?

- [X] Test A: `make testacc TESTARGS="-run TestAccCloudProjectKube_basic""`

**Test Configuration**:
checkout examples updated.

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings or issues
- [X] I have added acceptance tests that prove my fix is effective or that my feature works
- [X] New and existing acceptance tests pass locally with my changes
- [X] I ran succesfully `go mod vendor` if I added or modify `go.mod` file
