### PR TITLE
fix: Use a correct region for cloud gateway tests

### DIFF
--- a/ovh/data_cloud_project_gateway_interface_test.go
+++ b/ovh/data_cloud_project_gateway_interface_test.go
@@ -43,13 +43,13 @@ resource "ovh_cloud_project_network_private" "mypriv" {
 	service_name  = ovh_vrack_cloudproject.attach.project_id
 	vlan_id       = "%d"
 	name          = "%s"
-	regions       = ["GRA11"]
+	regions       = ["GRA9"]
 }
 
 resource "ovh_cloud_project_network_private_subnet" "myprivsub" {
 	service_name  = ovh_cloud_project_network_private.mypriv.service_name
 	network_id    = ovh_cloud_project_network_private.mypriv.id
-	region        = "GRA11"
+	region        = "GRA9"
 	start         = "10.0.0.2"
 	end           = "10.0.0.8"
 	network       = "10.0.0.0/24"
@@ -59,7 +59,7 @@ resource "ovh_cloud_project_network_private_subnet" "myprivsub" {
 resource "ovh_cloud_project_network_private_subnet" "my_other_privsub" {
 	service_name  = ovh_cloud_project_network_private.mypriv.service_name
 	network_id    = ovh_cloud_project_network_private.mypriv.id
-	region        = "GRA11"
+	region        = "GRA9"
 	start         = "10.0.1.10"
 	end           = "10.0.1.254"
 	network       = "10.0.1.0/24"

--- a/ovh/resource_cloud_project_gateway_interface_test.go
+++ b/ovh/resource_cloud_project_gateway_interface_test.go
@@ -43,13 +43,13 @@ resource "ovh_cloud_project_network_private" "mypriv" {
 	service_name  = ovh_vrack_cloudproject.attach.project_id
 	vlan_id       = "%d"
 	name          = "%s"
-	regions       = ["GRA11"]
+	regions       = ["GRA9"]
 }
 
 resource "ovh_cloud_project_network_private_subnet" "myprivsub" {
 	service_name  = ovh_cloud_project_network_private.mypriv.service_name
 	network_id    = ovh_cloud_project_network_private.mypriv.id
-	region        = "GRA11"
+	region        = "GRA9"
 	start         = "10.0.0.2"
 	end           = "10.0.0.8"
 	network       = "10.0.0.0/24"
@@ -59,7 +59,7 @@ resource "ovh_cloud_project_network_private_subnet" "myprivsub" {
 resource "ovh_cloud_project_network_private_subnet" "my_other_privsub" {
 	service_name  = ovh_cloud_project_network_private.mypriv.service_name
 	network_id    = ovh_cloud_project_network_private.mypriv.id
-	region        = "GRA11"
+	region        = "GRA9"
 	start         = "10.0.1.10"
 	end           = "10.0.1.254"
 	network       = "10.0.1.0/24"


### PR DESCRIPTION
# Description

Use a valid region for cloud gateway interface tests.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] Test A: `make testacc TESTARGS="-run TestAccCloudProjectGatewayInterfaceDataSource_basic"`
- [x] Test B: `make testacc TESTARGS="-run TestAccCloudProjectGatewayInterface_basic"`