### PR TITLE
fix: Correctly handle blocks in resource ovh_ip_move

### DIFF
--- a/.cds/terraform-provider-ovh.yml
+++ b/.cds/terraform-provider-ovh.yml
@@ -736,14 +736,14 @@ workflow:
     pipeline: terraform-provider-ovh-testacc
     when:
     - success
-  Tests_TestAccIpMove_basic:
+  Tests_IpMove:
     application: terraform-provider-ovh
     depends_on:
     - terraform-provider-ovh-pre-sweepers
     environment: acctests
     one_at_a_time: true
     parameters:
-      testargs: -run TestAccIpMove_basic
+      testargs: -run TestAccIpMove
       skipthispipeline: "{{.workflow.terraform-provider-ovh.pip.skipthistest.ip}}"
     pipeline: terraform-provider-ovh-testacc
     when:
@@ -923,7 +923,7 @@ workflow:
     - Tests_TestAccResourceCloudProjectFailoverIpAttachTestAccResourceCloudProject_basic
     - Tests_TestAccCloudProjectWorkflowBackup
     - Tests_TestAccResourceIpService_basic
-    - Tests_TestAccIpMove_basic
+    - Tests_IpMove
     - Tests_IPFirewall
     - Tests_IPMitigation
     - Tests_Okms

--- a/ovh/resource_ip_move_test.go
+++ b/ovh/resource_ip_move_test.go
@@ -70,3 +70,41 @@ func TestAccIpMove_basic(t *testing.T) {
 		},
 	})
 }
+
+func TestAccIpMove_block(t *testing.T) {
+	ipBlock := os.Getenv("OVH_IP_BLOCK_MOVE_TEST")
+	routedToServiceName := os.Getenv("OVH_IP_MOVE_SERVICE_NAME_TEST")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheckIpMove(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(`
+					resource "ovh_ip_move" "move" {
+						ip = "%s"
+						routed_to {
+							service_name = "%s"
+						}
+					}`,
+					ipBlock, routedToServiceName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("ovh_ip_move.move", "routed_to.0.service_name", routedToServiceName),
+				),
+			},
+			{
+				Config: fmt.Sprintf(`
+					resource "ovh_ip_move" "move" {
+						ip = "%s"
+						routed_to {
+							service_name = ""
+						}
+					}`,
+					ipBlock),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("ovh_ip_move.move", "routed_to.0.service_name", ""),
+				),
+			},
+		},
+	})
+}


### PR DESCRIPTION
# Description

Several fixes in `ovh_ip_move` resource:
- Retrieve the right service name when using IP blocks
- Don't save resource in state when an error occurs during creation

Fixes #1099 (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] Test A: `make testacc TESTARGS="-run TestAccIpMove_basic"`
- [x] Test B: `make testacc TESTARGS="-run TestAccIpMove_block"`

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or issues
- [x] I have added acceptance tests that prove my fix is effective or that my feature works
- [x] New and existing acceptance tests pass locally with my changes
- [x] I ran succesfully `go mod vendor` if I added or modify `go.mod` file
