### PR TITLE
feat: Add import to ovh_cloud_project_volume and ovh_cloud_project_user

### DIFF
--- a/docs/resources/cloud_project_user.md
+++ b/docs/resources/cloud_project_user.md
@@ -72,3 +72,21 @@ The following attributes are exported:
 * `service_name` - See Argument Reference above.
 * `status` - the status of the user. should be normally set to 'ok'.
 * `username` - the username generated for the user. This username can be used with the Openstack API.
+
+## Import
+
+The resource can be imported using the public cloud project ID and the user ID, e.g.,
+
+```terraform
+import {
+  to = ovh_cloud_project_user.user
+  id = "<public cloud project ID>/<user ID>"
+}
+```
+
+```bash
+$ terraform plan -generate-config-out=user.tf
+$ terraform apply
+```
+
+The file `user.tf` will then contain the imported resource's configuration, that can be copied next to the `import` block above. See https://developer.hashicorp.com/terraform/language/import/generating-configuration for more details.

--- a/docs/resources/cloud_project_volume.md
+++ b/docs/resources/cloud_project_volume.md
@@ -9,7 +9,7 @@ Create volume in a public cloud project.
 ## Example Usage
 
 ```terraform
-resource "ovh_cloud_project_volume" "vol" {
+resource "ovh_cloud_project_volume" "volume" {
    region_name  = "xxx"
    service_name = "yyyyy"
    description  = "Terraform volume"
@@ -40,3 +40,21 @@ The following attributes are exported:
 * `name` - Name of the volume
 * `size` - Size of the volume
 * `id` - id of the volume
+
+## Import
+
+The resource can be imported using the public cloud project ID, region and the volume ID, e.g.,
+
+```terraform
+import {
+  to = ovh_cloud_project_volume.volume
+  id = "<public cloud project ID>/<region>/<volume ID>"
+}
+```
+
+```bash
+$ terraform plan -generate-config-out=volume.tf
+$ terraform apply
+```
+
+The file `volume.tf` will then contain the imported resource's configuration, that can be copied next to the `import` block above. See https://developer.hashicorp.com/terraform/language/import/generating-configuration for more details.

--- a/examples/resources/cloud_project_user/example_3.tf
+++ b/examples/resources/cloud_project_user/example_3.tf
@@ -1,0 +1,4 @@
+import {
+  to = ovh_cloud_project_user.user
+  id = "<public cloud project ID>/<user ID>"
+}

--- a/examples/resources/cloud_project_volume/example_1.tf
+++ b/examples/resources/cloud_project_volume/example_1.tf
@@ -1,4 +1,4 @@
-resource "ovh_cloud_project_volume" "vol" {
+resource "ovh_cloud_project_volume" "volume" {
    region_name  = "xxx"
    service_name = "yyyyy"
    description  = "Terraform volume"

--- a/examples/resources/cloud_project_volume/example_2.tf
+++ b/examples/resources/cloud_project_volume/example_2.tf
@@ -1,0 +1,4 @@
+import {
+  to = ovh_cloud_project_volume.volume
+  id = "<public cloud project ID>/<region>/<volume ID>"
+}

--- a/ovh/resource_cloud_project_user_test.go
+++ b/ovh/resource_cloud_project_user_test.go
@@ -45,6 +45,13 @@ func TestAccCloudProjectUser_basic(t *testing.T) {
 					testAccCheckCloudProjectUserOpenRC("ovh_cloud_project_user.user", t),
 				),
 			},
+			{
+				ResourceName:            "ovh_cloud_project_user.user",
+				ImportStateIdPrefix:     os.Getenv("OVH_CLOUD_PROJECT_SERVICE_TEST") + "/",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"password"},
+			},
 		},
 	})
 }

--- a/ovh/resource_cloud_project_volume.go
+++ b/ovh/resource_cloud_project_volume.go
@@ -4,8 +4,10 @@ import (
 	"context"
 	"fmt"
 	"net/url"
+	"strings"
 	"time"
 
+	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/ovh/terraform-provider-ovh/v2/ovh/ovhwrap"
@@ -44,6 +46,18 @@ func (d *cloudProjectVolumeResource) Configure(_ context.Context, req resource.C
 
 func (d *cloudProjectVolumeResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
 	resp.Schema = CloudProjectVolumeResourceSchema(ctx)
+}
+
+func (r *cloudProjectVolumeResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	splits := strings.Split(req.ID, "/")
+	if len(splits) != 3 {
+		resp.Diagnostics.AddError("Given ID is malformed", "ID must be formatted like the following: <service_name>/<region_name>/<volume_id>")
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("service_name"), splits[0])...)
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("region_name"), splits[1])...)
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("volume_id"), splits[2])...)
 }
 
 func (r *cloudProjectVolumeResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {

--- a/ovh/resource_cloud_project_volume_test.go
+++ b/ovh/resource_cloud_project_volume_test.go
@@ -64,6 +64,13 @@ func TestAccCloudProjectVolume_basic(t *testing.T) {
 					resource.TestCheckResourceAttr("ovh_cloud_project_volume.volume", "size", "20"),
 				),
 			},
+			{
+				ResourceName:            "ovh_cloud_project_volume.volume",
+				ImportStateIdPrefix:     serviceName + "/" + regionName + "/",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"type", "description"},
+			},
 		},
 	})
 }

--- a/templates/resources/cloud_project_user.md.tmpl
+++ b/templates/resources/cloud_project_user.md.tmpl
@@ -65,3 +65,16 @@ The following attributes are exported:
 * `service_name` - See Argument Reference above.
 * `status` - the status of the user. should be normally set to 'ok'.
 * `username` - the username generated for the user. This username can be used with the Openstack API.
+
+## Import
+
+The resource can be imported using the public cloud project ID and the user ID, e.g.,
+
+{{tffile "examples/resources/cloud_project_user/example_3.tf"}}
+
+```bash
+$ terraform plan -generate-config-out=user.tf
+$ terraform apply
+```
+
+The file `user.tf` will then contain the imported resource's configuration, that can be copied next to the `import` block above. See https://developer.hashicorp.com/terraform/language/import/generating-configuration for more details.

--- a/templates/resources/cloud_project_volume.md.tmpl
+++ b/templates/resources/cloud_project_volume.md.tmpl
@@ -35,3 +35,16 @@ The following attributes are exported:
 * `name` - Name of the volume
 * `size` - Size of the volume
 * `id` - id of the volume
+
+## Import
+
+The resource can be imported using the public cloud project ID, region and the volume ID, e.g.,
+
+{{tffile "examples/resources/cloud_project_volume/example_2.tf"}}
+
+```bash
+$ terraform plan -generate-config-out=volume.tf
+$ terraform apply
+```
+
+The file `volume.tf` will then contain the imported resource's configuration, that can be copied next to the `import` block above. See https://developer.hashicorp.com/terraform/language/import/generating-configuration for more details.


### PR DESCRIPTION
# Description

- Add import capability to resource `ovh_cloud_project_volume`
- Add import documentation for resource `ovh_cloud_project_user`

Fixes #1093 (issue)

## Type of change

- [x] Improvement (improve existing resource(s) or datasource(s))
- [x] Documentation update

# How Has This Been Tested?

- [ ] Test A: `make testacc TESTARGS="-run TestAccCloudProjectVolume_basic"`
- [ ] Test B: `make testacc TESTARGS="-run TestAccCloudProjectUser_basic"`

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or issues
- [x] I have added acceptance tests that prove my fix is effective or that my feature works
- [x] New and existing acceptance tests pass locally with my changes
- [x] I ran succesfully `go mod vendor` if I added or modify `go.mod` file
