### PR TITLE
feat(dedicated/server): add orderable bandwidth datasource

### DIFF
--- a/docs/data-sources/dedicated_server_orderable_bandwidth.md
+++ b/docs/data-sources/dedicated_server_orderable_bandwidth.md
@@ -1,0 +1,28 @@
+---
+subcategory : "Dedicated Server"
+---
+
+# ovh_dedicated_server_order_bandwidth (Data Source)
+
+Use this data source to get the list of orderable additional bandwidth for a dedicated server associated with your OVHcloud Account.
+
+## Example Usage
+
+```terraform
+data "ovh_dedicated_server_orderable_bandwidth" "bp" {
+  service_name = "myserver"
+}
+```
+
+## Argument Reference
+
+* `service_name` - (Required) The internal name of your dedicated server.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `orderable` - Wether or not additional bandwidth is orderable.
+* `platinium` - The list of orderable platinimum bandwidth in mbps.
+* `ultimate` - The list of orderable ultimate bandwidth in mbps.
+* `premium` - The list of orderable premium bandwidth in mbps.

--- a/docs/data-sources/dedicated_server_orderable_bandwidth_vrack.md
+++ b/docs/data-sources/dedicated_server_orderable_bandwidth_vrack.md
@@ -1,0 +1,26 @@
+---
+subcategory : "Dedicated Server"
+---
+
+# ovh_dedicated_server_order_bandwidth_vrack (Data Source)
+
+Use this data source to get the list of orderable additional vrack bandwidth for a dedicated server associated with your OVHcloud Account.
+
+## Example Usage
+
+```terraform
+data "ovh_dedicated_server_orderable_bandwidth_vrack" "bp" {
+  service_name = "myserver"
+}
+```
+
+## Argument Reference
+
+* `service_name` - (Required) The internal name of your dedicated server.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `orderable` - Wether or not additional bandwidth is orderable.
+* `vrack` - The list of orderable vrack bandwidth in mbps.

--- a/examples/data-sources/dedicated_server_orderable_bandwidth/example_1.tf
+++ b/examples/data-sources/dedicated_server_orderable_bandwidth/example_1.tf
@@ -1,0 +1,3 @@
+data "ovh_dedicated_server_orderable_bandwidth" "spec" {
+  service_name = "myserver"
+}

--- a/examples/data-sources/dedicated_server_orderable_bandwidth_vrack/example_1.tf
+++ b/examples/data-sources/dedicated_server_orderable_bandwidth_vrack/example_1.tf
@@ -1,0 +1,3 @@
+data "ovh_dedicated_server_orderable_bandwidth_vrack" "spec" {
+  service_name = "myserver"
+}

--- a/ovh/data_dedicated_server_orderable_bandwidth.go
+++ b/ovh/data_dedicated_server_orderable_bandwidth.go
@@ -1,0 +1,81 @@
+package ovh
+
+import (
+	"fmt"
+	"net/url"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func dataSourceDedicatedServerOrderableBandwidth() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceDedicatedServerOrderableBandwidthRead,
+		Schema: map[string]*schema.Schema{
+			"service_name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+
+			// Computed
+			"orderable": {
+				Type:        schema.TypeBool,
+				Computed:    true,
+				Description: "Is bandwidth orderable for this server",
+			},
+			"platinium": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Description: "Platinium orderable bandwidth in mbps",
+				Elem: &schema.Schema{
+					Type: schema.TypeInt,
+				},
+			},
+			"premium": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Description: "Premium orderable bandwidth in mbps",
+				Elem: &schema.Schema{
+					Type: schema.TypeInt,
+				},
+			},
+			"ultimate": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Description: "Ultimate orderable bandwidth in mbps",
+				Elem: &schema.Schema{
+					Type: schema.TypeInt,
+				},
+			},
+		},
+	}
+}
+
+func dataSourceDedicatedServerOrderableBandwidthRead(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+	serviceName := d.Get("service_name").(string)
+
+	var ds DedicatedServerOrderableBandwidth
+	err := config.OVHClient.Get(
+		fmt.Sprintf(
+			"/dedicated/server/%s/orderable/bandwidth",
+			url.PathEscape(serviceName),
+		),
+		&ds,
+	)
+
+	if err != nil {
+		return fmt.Errorf(
+			"Error calling /dedicated/server/%s/orderable/bandwidth:\n\t %q",
+			serviceName,
+			err,
+		)
+	}
+
+	d.SetId(serviceName)
+	d.Set("orderable", ds.Orderable)
+	d.Set("platinium", ds.Platinium)
+	d.Set("ultimate", ds.Ultimate)
+	d.Set("premium", ds.Premium)
+
+	return nil
+}

--- a/ovh/data_dedicated_server_orderable_bandwidth_test.go
+++ b/ovh/data_dedicated_server_orderable_bandwidth_test.go
@@ -1,0 +1,35 @@
+package ovh
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+func TestAccDedicatedServerOrderableBandwidthDataSource_basic(t *testing.T) {
+	testAccDedicatedServerOrderableBandwidthDatasourceConfig_Basic := fmt.Sprintf(`
+	data "ovh_dedicated_server_orderable_bandwidth" "bp" {
+		service_name = "%s"
+	}`, os.Getenv("OVH_DEDICATED_SERVER"))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheckCredentials(t)
+			testAccPreCheckDedicatedServer(t)
+		},
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDedicatedServerOrderableBandwidthDatasourceConfig_Basic,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("data.ovh_dedicated_server_orderable_bandwidth.bp", "orderable"),
+					resource.TestCheckResourceAttrSet("data.ovh_dedicated_server_orderable_bandwidth.bp", "platinium"),
+					resource.TestCheckResourceAttrSet("data.ovh_dedicated_server_orderable_bandwidth.bp", "premium"),
+					resource.TestCheckResourceAttrSet("data.ovh_dedicated_server_orderable_bandwidth.bp", "ultimate"),
+				),
+			},
+		},
+	})
+}

--- a/ovh/data_dedicated_server_orderable_bandwidth_vrack.go
+++ b/ovh/data_dedicated_server_orderable_bandwidth_vrack.go
@@ -1,0 +1,63 @@
+package ovh
+
+import (
+	"fmt"
+	"net/url"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func dataSourceDedicatedServerOrderableBandwidthVrack() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceDedicatedServerOrderableBandwidthVrackRead,
+		Schema: map[string]*schema.Schema{
+			"service_name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+
+			// Computed
+			"orderable": {
+				Type:        schema.TypeBool,
+				Computed:    true,
+				Description: "Is bandwidth orderable for this server",
+			},
+			"vrack": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Description: "Vrack orderable bandwidth in mbps",
+				Elem: &schema.Schema{
+					Type: schema.TypeInt,
+				},
+			},
+		},
+	}
+}
+
+func dataSourceDedicatedServerOrderableBandwidthVrackRead(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+	serviceName := d.Get("service_name").(string)
+
+	var ds DedicatedServerOrderableBandwidthVrack
+	err := config.OVHClient.Get(
+		fmt.Sprintf(
+			"/dedicated/server/%s/orderable/bandwidthvRack",
+			url.PathEscape(serviceName),
+		),
+		&ds,
+	)
+
+	if err != nil {
+		return fmt.Errorf(
+			"Error calling /dedicated/server/%s/orderable/bandwidthvRack:\n\t %q",
+			serviceName,
+			err,
+		)
+	}
+
+	d.SetId(serviceName)
+	d.Set("orderable", ds.Orderable)
+	d.Set("vrack", ds.Vrack)
+
+	return nil
+}

--- a/ovh/data_dedicated_server_orderable_bandwidth_vrack_test.go
+++ b/ovh/data_dedicated_server_orderable_bandwidth_vrack_test.go
@@ -1,0 +1,33 @@
+package ovh
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+func TestAccDedicatedServerOrderableBandwidthVrackDataSource_basic(t *testing.T) {
+	testAccDedicatedServerOrderableBandwidthDatasourceConfig_Basic := fmt.Sprintf(`
+	data "ovh_dedicated_server_orderable_bandwidth_vrack" "bp" {
+		service_name = "%s"
+	}`, os.Getenv("OVH_DEDICATED_SERVER"))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheckCredentials(t)
+			testAccPreCheckDedicatedServer(t)
+		},
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDedicatedServerOrderableBandwidthDatasourceConfig_Basic,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("data.ovh_dedicated_server_orderable_bandwidth_vrack.bp", "orderable"),
+					resource.TestCheckResourceAttrSet("data.ovh_dedicated_server_orderable_bandwidth_vrack.bp", "vrack"),
+				),
+			},
+		},
+	})
+}

--- a/ovh/provider.go
+++ b/ovh/provider.go
@@ -165,6 +165,8 @@ func Provider() *schema.Provider {
 			"ovh_dedicated_nasha_partition":                                  dataSourceDedicatedNashaPartition(),
 			"ovh_dedicated_server":                                           dataSourceDedicatedServer(),
 			"ovh_dedicated_server_boots":                                     dataSourceDedicatedServerBoots(),
+			"ovh_dedicated_server_orderable_bandwidth":                       dataSourceDedicatedServerOrderableBandwidth(),
+			"ovh_dedicated_server_orderable_bandwidth_vrack":                 dataSourceDedicatedServerOrderableBandwidthVrack(),
 			"ovh_dedicated_servers":                                          dataSourceDedicatedServers(),
 			"ovh_hosting_privatedatabase":                                    dataSourceHostingPrivateDatabase(),
 			"ovh_hosting_privatedatabase_database":                           dataSourceHostingPrivateDatabaseDatabase(),

--- a/ovh/types_dedicated_server_orderable_bandwidth.go
+++ b/ovh/types_dedicated_server_orderable_bandwidth.go
@@ -1,0 +1,13 @@
+package ovh
+
+type DedicatedServerOrderableBandwidth struct {
+	Orderable bool  `json:"orderable"`
+	Platinium []int `json:"platinium"`
+	Ultimate  []int `json:"ultimate"`
+	Premium   []int `json:"premium"`
+}
+
+type DedicatedServerOrderableBandwidthVrack struct {
+	Orderable bool  `json:"orderable"`
+	Vrack     []int `json:"vrack"`
+}

--- a/templates/data-sources/dedicated_server_orderable_bandwidth.tmpl
+++ b/templates/data-sources/dedicated_server_orderable_bandwidth.tmpl
@@ -1,0 +1,28 @@
+---
+subcategory : "Dedicated Server"
+---
+
+{{/* This template serves as a starting point for documentation generation, and can be customized with hardcoded values and/or doc gen templates.
+
+For example, the {{ .SchemaMarkdown }} template can be used to replace manual schema documentation if descriptions of schema attributes are added in the provider source code. */ -}}
+
+# ovh_dedicated_server_orderable_bandwidth (Data Source)
+
+Use this data source to get the hardward information about a dedicated server associated with your OVHcloud Account.
+
+## Example Usage
+
+{{tffile "examples/data-sources/dedicated_server_orderable_bandwidth/example_1.tf"}}
+
+## Argument Reference
+
+* `service_name` - (Required) The internal name of your dedicated server.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `orderable` - Whether or not additional bandwidth is orderable
+* `platinium` - Additional orderable platinium bandwidth
+* `ultimate` - Additional orderable ultimate bandwidth
+* `premium` - Additional orderable premium bandwidth

--- a/templates/data-sources/dedicated_server_orderable_bandwidth_vrack.tmpl
+++ b/templates/data-sources/dedicated_server_orderable_bandwidth_vrack.tmpl
@@ -1,0 +1,26 @@
+---
+subcategory : "Dedicated Server"
+---
+
+{{/* This template serves as a starting point for documentation generation, and can be customized with hardcoded values and/or doc gen templates.
+
+For example, the {{ .SchemaMarkdown }} template can be used to replace manual schema documentation if descriptions of schema attributes are added in the provider source code. */ -}}
+
+# ovh_dedicated_server_orderable_bandwidth_vrack (Data Source)
+
+Use this data source to get the orderable vrack bandwidth information about a dedicated server associated with your OVHcloud Account.
+
+## Example Usage
+
+{{tffile "examples/data-sources/dedicated_server_orderable_bandwidth_vrack/example_1.tf"}}
+
+## Argument Reference
+
+* `service_name` - (Required) The internal name of your dedicated server.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `orderable` - Whether or not additional bandwidth is orderable
+* `vrack` - Additional orderable vrack bandwidth


### PR DESCRIPTION
# Description

Add the data sources `ovh_dedicated_server_orderable_bandwidth` and `ovh_dedicated_server_orderable_bandwidth_vrack` for dedicated servers.
This will allow us to check that we have configured the maximum available bandwidth on our servers before installing them.

## Type of change

- [x] New feature (non-breaking change which adds functionality)


# How Has This Been Tested?

```
export OVH_ENDPOINT=ovh-eu
export OVH_APPLICATION_KEY=
export OVH_APPLICATION_SECRET=
export OVH_CONSUMER_KEY=

go test -timeout 5m -run TestAccDedicatedServerOrderableBandwidthDataSource_basic  github.com/ovh/terraform-provider-ovh/v2/ovh -count=1
go test -timeout 5m -run TestAccDedicatedServerOrderableBandwidthVrackDataSource_basic  github.com/ovh/terraform-provider-ovh/v2/ovh -count=1
```

I also tested locally with a simple terraform manifest and checked that the tfstate is properly populated.
```
data "ovh_dedicated_server_orderable_bandwidth" "bp" {
  service_name = "myserver"
}

data "ovh_dedicated_server_orderable_bandwidth_vrack" "bp" {
  service_name = "myserver"
}
```

Tfstate result:
```
"resources": [
    {
      "mode": "data",
      "type": "ovh_dedicated_server_orderable_bandwidth",
      "name": "bp",
      "provider": "provider[\"registry.terraform.io/ovh/ovh\"]",
      "instances": [
        {
          "schema_version": 0,
          "attributes": {
            "id": "myserver",
            "orderable": true,
            "platinum": [],
            "premium": [],
            "service_name": "myserver",
            "ultimate": [
              1000
            ]
          },
          "sensitive_attributes": []
        }
      ]
    },
    {
      "mode": "data",
      "type": "ovh_dedicated_server_orderable_bandwidth_vrack",
      "name": "bp",
      "provider": "provider[\"registry.terraform.io/ovh/ovh\"]",
      "instances": [
        {
          "schema_version": 0,
          "attributes": {
            "id": "myserver",
            "orderable": true,
            "service_name": "myserver",
            "vrack": []
          },
          "sensitive_attributes": []
        }
      ]
    }
  ],

```


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or issues
- [x] I have added acceptance tests that prove my fix is effective or that my feature works
- [x] New and existing acceptance tests pass locally with my changes
- [x] I ran succesfully `go mod vendor` if I added or modify `go.mod` file
