### PR TITLE
Update tests on vRack resource following the release of vRack Bandwidth option

### DIFF
--- a/ovh/resource_vrack_test.go
+++ b/ovh/resource_vrack_test.go
@@ -23,6 +23,14 @@ data "ovh_order_cart_product_plan" "vrack" {
  plan_code      = "vrack"
 }
 
+data "ovh_order_cart_product_options_plan" "eu_west_rbx_15g" {
+ cart_id           = data.ovh_order_cart_product_plan.vrack.cart_id
+ price_capacity    = data.ovh_order_cart_product_plan.vrack.price_capacity
+ product           = data.ovh_order_cart_product_plan.vrack.product
+ plan_code         = data.ovh_order_cart_product_plan.vrack.plan_code
+ options_plan_code = "vrack-outgoing-bandwidth-limit-eu-west-rbx-15g"
+}
+
 resource "ovh_vrack" "vrack" {
  ovh_subsidiary = data.ovh_order_cart.mycart.ovh_subsidiary
  name          = "%s"
@@ -32,6 +40,12 @@ resource "ovh_vrack" "vrack" {
    duration     = data.ovh_order_cart_product_plan.vrack.selected_price.0.duration
    plan_code    = data.ovh_order_cart_product_plan.vrack.plan_code
    pricing_mode = data.ovh_order_cart_product_plan.vrack.selected_price.0.pricing_mode
+ }
+
+ plan_option {
+	duration     = data.ovh_order_cart_product_options_plan.eu_west_rbx_15g.selected_price.0.duration
+	plan_code    = data.ovh_order_cart_product_options_plan.eu_west_rbx_15g.options_plan_code
+	pricing_mode = data.ovh_order_cart_product_options_plan.eu_west_rbx_15g.selected_price.0.pricing_mode
  }
 }
 `


### PR DESCRIPTION
Test the order of outgoing bandwidth limit on a vRack

# Description

Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes #xx (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Test update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A: `make testacc TESTARGS="-run TestAccResourceVrack_basic""`


**Test Configuration**:
* Terraform version: `terraform version`: Terraform vx.y.z
* Existing HCL configuration you used: 
```hcl
resource "ovh_vrack" "vrack" {
 ovh_subsidiary = "FR"
 name                = "myTFvRack"
 description       = "vRack ordered from terraform"

 plan {
   duration          = "P1M"
   plan_code       = "vrack"
   pricing_mode = "default"
 }

 plan_option {
	duration         = "P1M"
	plan_code      = "vrack-outgoing-bandwidth-limit-eu-west-rbx-15g"
	pricing_mode = "default"
 }
}   
```

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or issues
- [x] I have added acceptance tests that prove my fix is effective or that my feature works
- [x] New and existing acceptance tests pass locally with my changes
- [ ] I ran succesfully `go mod vendor` if I added or modify `go.mod` file
