### PR TITLE
fix(ip_mitigation): Deprecate attribute 'permanent'

### DIFF
--- a/docs/data-sources/ip_mitigation.md
+++ b/docs/data-sources/ip_mitigation.md
@@ -24,6 +24,6 @@ data "ovh_ip_mitigation" "mitigation_data" {
 
 * `ip` - The IP or the CIDR
 * `ip_on_mitigation` - IPv4 address
-* `permanent ` - Set on true if the IP is on permanent mitigation
+* `permanent ` - (Deprecated) Set on true if the IP is on permanent mitigation
 * `state` - Current state of the IP on mitigation
 * `auto` - Set on true if the IP is on auto-mitigation

--- a/docs/data-sources/okms_credential.md
+++ b/docs/data-sources/okms_credential.md
@@ -9,7 +9,7 @@ Use this data source to retrieve data associated with a KMS credential, such as 
 ## Example Usage
 
 ```terraform
-data "ovh_okms_resource" "kms" {
+data "ovh_okms_credential" "kms" {
   okms_id = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
   id      = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
 }
@@ -22,7 +22,7 @@ data "ovh_okms_resource" "kms" {
 
 ## Attributes Reference
 
-- `certificate_type` (String) Type of the certificate (ECDSA or RSA)
+- `certificate_type` (String) Type of certificate key (`ECDSA` or `RSA`).
 - `certificate_pem` (String) PEM encoded certificate of the credential
 - `created_at` (String) Creation time of the credential
 - `description` (String) Description of the credential

--- a/docs/resources/ip_mitigation.md
+++ b/docs/resources/ip_mitigation.md
@@ -19,12 +19,12 @@ resource "ovh_ip_mitigation" "mitigation" {
 
 * `ip` - (Required) The IP or the CIDR
 * `ip_on_mitigation` - (Required) IPv4 address
-* `permanent ` - Set on true if the IP is on permanent mitigation
+* `permanent ` - Deprecated, has no effect
 
 ## Attributes Reference
 
 * `ip` - The IP or the CIDR
 * `ip_on_mitigation` - IPv4 address
-* `permanent ` - Set on true if the IP is on permanent mitigation
+* `permanent ` - (Deprecated) Set on true if the IP is on permanent mitigation
 * `state` - Current state of the IP on mitigation
 * `auto` - Set on true if the IP is on auto-mitigation

--- a/docs/resources/okms_credential.md
+++ b/docs/resources/okms_credential.md
@@ -40,7 +40,6 @@ resource "ovh_okms_credential" "cred_from_csr" {
   identity_urns = ["urn:v1:eu:identity:account:${data.ovh_me.current_account.nichandle}"]
   csr           = file("cred.csr")
   description   = "Credential from CSR"
-  certificate_type = "ECDSA"
 }
 ```
 
@@ -57,11 +56,11 @@ resource "ovh_okms_credential" "cred_from_csr" {
 - `csr` (String) Certificate Signing Request. The CSR should be encoded in the PEM format. If this argument is not set, the server will generate a CSR for this credential, and the corresponding private key will be returned in the `private_key_pem` attribute.
 - `description` (String) Description of the credential (max 200 characters)
 - `validity` (Number) Validity in days (default: 365 days, max: 365 days)
-- `certificate_type` (String) Type of the certificate key algorithm. Allowed values: `ECDSA`, `RSA`. Default to `ECDSA`. Changing forces a new credential.
+- `certificate_type` (String) Type of certificate key. Allowed values: `ECDSA`, `RSA`. Default to `ECDSA`. Changing forces a new credential.
 
 ## Attributes Reference
 
-- `certificate_type` (String) Type of the certificate key algorithm (`ECDSA` or `RSA`).
+- `certificate_type` (String) Type of certificate key (`ECDSA` or `RSA`).
 - `certificate_pem` (String) Certificate PEM of the credential.
 - `created_at` (String) Creation time of the credential
 - `expired_at` (String) Expiration time of the credential

--- a/ovh/data_ip_mitigation_gen.go
+++ b/ovh/data_ip_mitigation_gen.go
@@ -41,6 +41,7 @@ func IpMitigationDataSourceSchema(ctx context.Context) schema.Schema {
 				Computed:            true,
 				Description:         "Set on true if your ip is on permanent mitigation",
 				MarkdownDescription: "Set on true if your ip is on permanent mitigation",
+				DeprecationMessage:  "Attribute 'permanent' is deprecated and has no effect.",
 			},
 			"state": schema.StringAttribute{
 				CustomType:          ovhtypes.TfStringType{},

--- a/ovh/resource_ip_mitigation_gen.go
+++ b/ovh/resource_ip_mitigation_gen.go
@@ -50,6 +50,7 @@ func IpMitigationResourceSchema(ctx context.Context) schema.Schema {
 				Optional:            true,
 				Description:         "Set on true if your ip is on permanent mitigation",
 				MarkdownDescription: "Set on true if your ip is on permanent mitigation",
+				DeprecationMessage:  "Attribute 'permanent' is deprecated and has no effect.",
 			},
 			"state": schema.StringAttribute{
 				CustomType:          ovhtypes.TfStringType{},
@@ -106,16 +107,6 @@ func (v IpMitigationModel) ToCreate() *IpMitigationWritableModel {
 
 	if !v.IpOnMitigation.IsUnknown() {
 		res.IpOnMitigation = &v.IpOnMitigation
-	}
-
-	return res
-}
-
-func (v IpMitigationModel) ToUpdate() *IpMitigationWritableModel {
-	res := &IpMitigationWritableModel{}
-
-	if !v.Permanent.IsUnknown() {
-		res.Permanent = &v.Permanent
 	}
 
 	return res

--- a/templates/data-sources/ip_mitigation.md.tmpl
+++ b/templates/data-sources/ip_mitigation.md.tmpl
@@ -23,6 +23,6 @@ Use this resource to retrieve information about an IP permanent mitigation.
 
 * `ip` - The IP or the CIDR
 * `ip_on_mitigation` - IPv4 address
-* `permanent ` - Set on true if the IP is on permanent mitigation
+* `permanent ` - (Deprecated) Set on true if the IP is on permanent mitigation
 * `state` - Current state of the IP on mitigation
 * `auto` - Set on true if the IP is on auto-mitigation

--- a/templates/resources/ip_mitigation.md.tmpl
+++ b/templates/resources/ip_mitigation.md.tmpl
@@ -18,12 +18,12 @@ Use this resource to manage an IP permanent mitigation.
 
 * `ip` - (Required) The IP or the CIDR
 * `ip_on_mitigation` - (Required) IPv4 address
-* `permanent ` - Set on true if the IP is on permanent mitigation
+* `permanent ` - Deprecated, has no effect
 
 ## Attributes Reference
 
 * `ip` - The IP or the CIDR
 * `ip_on_mitigation` - IPv4 address
-* `permanent ` - Set on true if the IP is on permanent mitigation
+* `permanent ` - (Deprecated) Set on true if the IP is on permanent mitigation
 * `state` - Current state of the IP on mitigation
 * `auto` - Set on true if the IP is on auto-mitigation


### PR DESCRIPTION
# Description

Attribute `permanent` in resource and datasource `ovh_ip_mitigation` is deprecated and has no effect already, so mark it as deprecated in the provider.

Also regenerate docs.

## Type of change

- [x] Deprecation