### PR TITLE
Fix okms secret category in docs

### DIFF
--- a/docs/resources/okms_secret.md
+++ b/docs/resources/okms_secret.md
@@ -1,4 +1,3 @@
-
 ---
 subcategory : "Key Management Service (KMS)"
 ---


### PR DESCRIPTION
# Description

The documentation page is listed in Resources category instead of KMS.

## Type of change

- [x] Documentation update
