### PR TITLE
fix(ovh_cloud_project_network_private): Use the right route to delete regional network

### DIFF
--- a/ovh/resource_cloud_project_network_private.go
+++ b/ovh/resource_cloud_project_network_private.go
@@ -295,11 +295,12 @@ func resourceCloudProjectNetworkPrivateUpdate(d *schema.ResourceData, meta inter
 		}
 	}
 
+	regionOpenstackIDs := d.Get("regions_openstack_ids").(map[string]any)
 	for _, reg := range regionsToRemove {
-		endpoint = fmt.Sprintf("/cloud/project/%s/network/private/%s/region/%s",
+		endpoint = fmt.Sprintf("/cloud/project/%s/region/%s/network/%s",
 			url.PathEscape(serviceName),
-			url.PathEscape(d.Id()),
 			url.PathEscape(reg),
+			url.PathEscape(regionOpenstackIDs[reg].(string)),
 		)
 
 		if err := config.OVHClient.Delete(endpoint, params); err != nil {


### PR DESCRIPTION
# Description

Resource `ovh_cloud_project_network_private` didn't use the right route to remove a regional network from a global private network. This PR uses the right one.

Fixes #1143 (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [ ] Test A: `make testacc TESTARGS="-run TestAccCloudProjectNetworkPrivate_basic"`

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or issues
- [x] I have added acceptance tests that prove my fix is effective or that my feature works
- [x] New and existing acceptance tests pass locally with my changes
- [x] I ran successfully `go mod vendor` if I added or modify `go.mod` file
