### PR TITLE
fix(cloud_project_alerting): Email not returned by API anymore

### DIFF
--- a/ovh/resource_cloud_project_alerting.go
+++ b/ovh/resource_cloud_project_alerting.go
@@ -63,6 +63,9 @@ func (r *cloudProjectAlertingResource) Create(ctx context.Context, req resource.
 
 	responseData.MergeWith(&data)
 
+	// Explicitly set email to the plan value as it's not returned by the API
+	responseData.Email = data.Email
+
 	// Save data into Terraform state
 	resp.Diagnostics.Append(resp.State.Set(ctx, &responseData)...)
 }
@@ -128,6 +131,9 @@ func (r *cloudProjectAlertingResource) Update(ctx context.Context, req resource.
 	}
 
 	responseData.MergeWith(&planData)
+
+	// Explicitly set email to the plan value as it's not returned by the API
+	responseData.Email = planData.Email
 
 	// Save updated data into Terraform state
 	resp.Diagnostics.Append(resp.State.Set(ctx, &responseData)...)

--- a/ovh/resource_cloud_project_alerting_gen.go
+++ b/ovh/resource_cloud_project_alerting_gen.go
@@ -6,6 +6,8 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strings"
+
 	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
@@ -14,9 +16,10 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 	"github.com/hashicorp/terraform-plugin-go/tftypes"
 	ovhtypes "github.com/ovh/terraform-provider-ovh/v2/ovh/types"
-	"strings"
 
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 )
 
 func CloudProjectAlertingResourceSchema(ctx context.Context) schema.Schema {
@@ -89,8 +92,11 @@ func CloudProjectAlertingResourceSchema(ctx context.Context) schema.Schema {
 				MarkdownDescription: "Monthly threshold for this alerting in currency",
 			},
 			"service_name": schema.StringAttribute{
-				CustomType:          ovhtypes.TfStringType{},
-				Required:            true,
+				CustomType: ovhtypes.TfStringType{},
+				Required:   true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
 				Description:         "The project id",
 				MarkdownDescription: "The project id",
 			},

--- a/ovh/resource_cloud_project_alerting_test.go
+++ b/ovh/resource_cloud_project_alerting_test.go
@@ -48,7 +48,7 @@ func TestAccCloudProjectAlerting_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"ovh_cloud_project_alerting.alert", "formatted_monthly_threshold.currency_code", "EUR"),
 					resource.TestCheckResourceAttr(
-						"ovh_cloud_project_alerting.alert", "formatted_monthly_threshold.text", "3000.00 €"),
+						"ovh_cloud_project_alerting.alert", "formatted_monthly_threshold.text", "3 000,00 €"),
 					resource.TestCheckResourceAttr(
 						"ovh_cloud_project_alerting.alert", "formatted_monthly_threshold.value", "3000"),
 				),
@@ -65,7 +65,7 @@ func TestAccCloudProjectAlerting_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"ovh_cloud_project_alerting.alert", "formatted_monthly_threshold.currency_code", "EUR"),
 					resource.TestCheckResourceAttr(
-						"ovh_cloud_project_alerting.alert", "formatted_monthly_threshold.text", "100.00 €"),
+						"ovh_cloud_project_alerting.alert", "formatted_monthly_threshold.text", "100,00 €"),
 					resource.TestCheckResourceAttr(
 						"ovh_cloud_project_alerting.alert", "formatted_monthly_threshold.value", "100"),
 				),


### PR DESCRIPTION
# Description

`email` property of resource `ovh_cloud_project_alerting` is not returned by the API anymore, so just take the value from the plan.

Fixes #1137 (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] Test A: `make testacc TESTARGS="-run TestAccCloudProjectAlerting_basic"`

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or issues
- [x] I have added acceptance tests that prove my fix is effective or that my feature works
- [x] New and existing acceptance tests pass locally with my changes
- [x] I ran successfully `go mod vendor` if I added or modify `go.mod` file
