### PR TITLE
feat(cloud_project_storage): Add field to avoid saving objects in state

### DIFF
--- a/docs/data-sources/cloud_project_storage.md
+++ b/docs/data-sources/cloud_project_storage.md
@@ -28,6 +28,7 @@ data "ovh_cloud_project_storage" "storage" {
 
 ### Optional
 
+- `hide_objects` (Boolean) If true, objects list will not be saved in state (useful for large buckets)
 - `limit` (Number) Limit the number of objects returned (1000 maximum, defaults to 1000)
 - `marker` (String) Key to start with when listing objects
 - `prefix` (String) List objects whose key begins with this prefix

--- a/docs/data-sources/okms_secret.md
+++ b/docs/data-sources/okms_secret.md
@@ -70,19 +70,19 @@ In addition to the arguments above, the following attributes are exported:
 - `version` (Number) The resolved version number (requested or current latest).
 - `data` (String, Sensitive) Raw JSON secret payload (present only if `include_data` is true).
 - `metadata` (Block) Secret metadata:
-	- `cas_required` (Boolean)
-	- `created_at` (String)
-	- `updated_at` (String)
-	- `current_version` (Number)
-	- `oldest_version` (Number)
-	- `max_versions` (Number)
-	- `deactivate_version_after` (String)
-	- `custom_metadata` (Map of String)
+  - `cas_required` (Boolean)
+  - `created_at` (String)
+  - `updated_at` (String)
+  - `current_version` (Number)
+  - `oldest_version` (Number)
+  - `max_versions` (Number)
+  - `deactivate_version_after` (String)
+  - `custom_metadata` (Map of String)
 - `iam` (Block) IAM resource metadata:
-	- `display_name` (String)
-	- `id` (String)
-	- `tags` (Map of String)
-	- `urn` (String)
+  - `display_name` (String)
+  - `id` (String)
+  - `tags` (Map of String)
+  - `urn` (String)
 
 ## Behavior & Notes
 

--- a/docs/resources/cloud_project_storage.md
+++ b/docs/resources/cloud_project_storage.md
@@ -35,6 +35,7 @@ resource "ovh_cloud_project_storage" "storage" {
 ### Optional
 
 - `encryption` (Attributes) Encryption configuration (see [below for nested schema](#nestedatt--encryption))
+- `hide_objects` (Boolean) If true, objects list will not be saved in state (useful for large buckets)
 - `limit` (Number) Limit the number of objects returned (1000 maximum, defaults to 1000)
 - `marker` (String) Key to start with when listing objects
 - `owner_id` (Number) Container owner user ID

--- a/docs/resources/dedicated_server.md
+++ b/docs/resources/dedicated_server.md
@@ -140,7 +140,7 @@ resource "ovh_dedicated_server" "server" {
       * `raid_level` - Software raid type
       * `size` - Partition size in MiB
     * `scheme_name` - Partitioning scheme (if applicable with selected operating system)
-* `properties` - Deprecated, has no effect
+* `properties` - Attribute 'properties' is deprecated and has no effect
 
 ### Arguments used to control the lifecycle of a dedicated server
 

--- a/docs/resources/dedicated_server_reinstall_task.md
+++ b/docs/resources/dedicated_server_reinstall_task.md
@@ -128,7 +128,7 @@ resource "ovh_dedicated_server_reinstall_task" "server_install" {
     http_headers = {
       Authorization = "Basic bG9naW46cGFzc3dvcmQ="
     }
-    image_url              = "https://github.com/ashmonger/akution_test/releases/download/0.5-compress/deb11k6.qcow2"
+    image_url           = "https://github.com/ashmonger/akution_test/releases/download/0.5-compress/deb11k6.qcow2"
   }
 }
 ```
@@ -239,7 +239,7 @@ The following arguments are supported:
 
 ~> **WARNING** Some customizations may be required on some Operating Systems. [Check how to list the available and required customization(s) for your operating system](https://help.ovhcloud.com/csm/en-dedicated-servers-api-os-installation?id=kb_article_view&sysparm_article=KB0061951#os-inputs) (do not forget to adapt camel case customization name to snake case parameter).
 
-* `properties` - Deprecated, has no effect
+* `properties` - Attribute 'properties' is deprecated and has no effect.
 
 * `storage`: OS reinstallation storage configurations. [More details about disks, hardware/software RAID and partitioning configuration](https://help.ovhcloud.com/csm/en-dedicated-servers-api-partitioning?id=kb_article_view&sysparm_article=KB0043882) (do not forget to adapt camel case parameters to snake case parameters).
   * `disk_group_id`: Disk group id to install the OS to (default is 0, meaning automatic).

--- a/docs/resources/okms_secret.md
+++ b/docs/resources/okms_secret.md
@@ -47,6 +47,25 @@ output "api_key" {
 }
 ```
 
+# Reading a field from the secret version data:
+
+```terraform
+data "ovh_okms_secret" "latest_with_data" {
+	okms_id      = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
+	path         = "app/api_credentials"
+	include_data = true
+}
+
+locals {
+	secret_obj = jsondecode(data.ovh_okms_secret.latest_with_data.data)
+}
+
+output "api_key" {
+	value     = local.secret_obj.api_key
+	sensitive = true
+}
+```
+
 Updating the secret (new version) while enforcing optimistic concurrency control using CAS:
 
 ```terraform

--- a/ovh/data_cloud_project_storage.go
+++ b/ovh/data_cloud_project_storage.go
@@ -7,6 +7,7 @@ import (
 	"strconv"
 
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	ovhtypes "github.com/ovh/terraform-provider-ovh/v2/ovh/types"
 )
 
 var _ datasource.DataSourceWithConfigure = (*cloudProjectStorageDataSource)(nil)
@@ -73,6 +74,10 @@ func (d *cloudProjectStorageDataSource) Read(ctx context.Context, req datasource
 			err.Error(),
 		)
 		return
+	}
+
+	if data.HideObjects.ValueBool() {
+		data.Objects = ovhtypes.NewListNestedObjectValueOfNull[ObjectsValue](ctx)
 	}
 
 	// Save data into Terraform state

--- a/ovh/data_cloud_project_storage_gen.go
+++ b/ovh/data_cloud_project_storage_gen.go
@@ -4,6 +4,7 @@ package ovh
 
 import (
 	"context"
+
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	ovhtypes "github.com/ovh/terraform-provider-ovh/v2/ovh/types"
 
@@ -118,6 +119,11 @@ func CloudProjectStorageDataSourceSchema(ctx context.Context) schema.Schema {
 			Computed:            true,
 			Description:         "Container objects",
 			MarkdownDescription: "Container objects",
+		},
+		"hide_objects": schema.BoolAttribute{
+			CustomType:  ovhtypes.TfBoolType{},
+			Optional:    true,
+			Description: "If true, objects list will not be saved in state (useful for large buckets)",
 		},
 		"objects_count": schema.Int64Attribute{
 			CustomType:          ovhtypes.TfInt64Type{},
@@ -311,6 +317,7 @@ type CloudProjectStorageModel struct {
 	Marker       ovhtypes.TfStringValue                            `tfsdk:"marker" json:"marker"`
 	Name         ovhtypes.TfStringValue                            `tfsdk:"name" json:"name"`
 	Objects      ovhtypes.TfListNestedValue[ObjectsValue]          `tfsdk:"objects" json:"objects"`
+	HideObjects  ovhtypes.TfBoolValue                              `tfsdk:"hide_objects" json:"-"`
 	ObjectsCount ovhtypes.TfInt64Value                             `tfsdk:"objects_count" json:"objectsCount"`
 	ObjectsSize  ovhtypes.TfInt64Value                             `tfsdk:"objects_size" json:"objectsSize"`
 	OwnerId      ovhtypes.TfInt64Value                             `tfsdk:"owner_id" json:"ownerId"`

--- a/ovh/resource_cloud_project_storage.go
+++ b/ovh/resource_cloud_project_storage.go
@@ -10,6 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
+	ovhtypes "github.com/ovh/terraform-provider-ovh/v2/ovh/types"
 )
 
 var _ resource.ResourceWithConfigure = (*cloudProjectStorageResource)(nil)
@@ -115,6 +116,10 @@ func (r *cloudProjectStorageResource) Read(ctx context.Context, req resource.Rea
 
 	responseData.MergeWith(&data)
 
+	if data.HideObjects.ValueBool() {
+		responseData.Objects = ovhtypes.NewListNestedObjectValueOfNull[ObjectsValue](ctx)
+	}
+
 	// Save updated data into Terraform state
 	resp.Diagnostics.Append(resp.State.Set(ctx, &responseData)...)
 }
@@ -167,6 +172,10 @@ func (r *cloudProjectStorageResource) Update(ctx context.Context, req resource.U
 	}
 
 	responseData.MergeWith(&planData)
+
+	if planData.HideObjects.ValueBool() {
+		responseData.Objects = ovhtypes.NewListNestedObjectValueOfNull[ObjectsValue](ctx)
+	}
 
 	// Save updated data into Terraform state
 	resp.Diagnostics.Append(resp.State.Set(ctx, &responseData)...)

--- a/ovh/resource_cloud_project_storage_gen.go
+++ b/ovh/resource_cloud_project_storage_gen.go
@@ -142,6 +142,11 @@ func CloudProjectRegionStorageResourceSchema(ctx context.Context) schema.Schema 
 			Description:         "Container objects",
 			MarkdownDescription: "Container objects",
 		},
+		"hide_objects": schema.BoolAttribute{
+			CustomType:  ovhtypes.TfBoolType{},
+			Optional:    true,
+			Description: "If true, objects list will not be saved in state (useful for large buckets)",
+		},
 		"objects_count": schema.Int64Attribute{
 			CustomType:          ovhtypes.TfInt64Type{},
 			Computed:            true,
@@ -369,6 +374,7 @@ type CloudProjectRegionStorageModel struct {
 	Marker       ovhtypes.TfStringValue                   `tfsdk:"marker" json:"marker"`
 	Name         ovhtypes.TfStringValue                   `tfsdk:"name" json:"name"`
 	Objects      ovhtypes.TfListNestedValue[ObjectsValue] `tfsdk:"objects" json:"objects"`
+	HideObjects  ovhtypes.TfBoolValue                     `tfsdk:"hide_objects" json:"-"`
 	ObjectsCount ovhtypes.TfInt64Value                    `tfsdk:"objects_count" json:"objectsCount"`
 	ObjectsSize  ovhtypes.TfInt64Value                    `tfsdk:"objects_size" json:"objectsSize"`
 	OwnerId      ovhtypes.TfInt64Value                    `tfsdk:"owner_id" json:"ownerId"`
@@ -414,6 +420,10 @@ func (v *CloudProjectRegionStorageModel) MergeWith(other *CloudProjectRegionStor
 
 	if (v.ObjectsSize.IsUnknown() || v.ObjectsSize.IsNull()) && !other.ObjectsSize.IsUnknown() {
 		v.ObjectsSize = other.ObjectsSize
+	}
+
+	if (v.HideObjects.IsUnknown() || v.HideObjects.IsNull()) && !other.HideObjects.IsUnknown() {
+		v.HideObjects = other.HideObjects
 	}
 
 	if (v.OwnerId.IsUnknown() || v.OwnerId.IsNull()) && !other.OwnerId.IsUnknown() {

--- a/templates/data-sources/cloud_project_storage.md.tmpl
+++ b/templates/data-sources/cloud_project_storage.md.tmpl
@@ -26,6 +26,7 @@ Get S3™* compatible storage container. \* S3 is a trademark filed by Amazon Te
 
 ### Optional
 
+- `hide_objects` (Boolean) If true, objects list will not be saved in state (useful for large buckets)
 - `limit` (Number) Limit the number of objects returned (1000 maximum, defaults to 1000)
 - `marker` (String) Key to start with when listing objects
 - `prefix` (String) List objects whose key begins with this prefix

--- a/templates/resources/cloud_project_storage.md.tmpl
+++ b/templates/resources/cloud_project_storage.md.tmpl
@@ -30,6 +30,7 @@ Create S3™* compatible storage container (* S3 is a trademark filed by Amazon 
 ### Optional
 
 - `encryption` (Attributes) Encryption configuration (see [below for nested schema](#nestedatt--encryption))
+- `hide_objects` (Boolean) If true, objects list will not be saved in state (useful for large buckets)
 - `limit` (Number) Limit the number of objects returned (1000 maximum, defaults to 1000)
 - `marker` (String) Key to start with when listing objects
 - `owner_id` (Number) Container owner user ID


### PR DESCRIPTION
# Description

Add field `hide_objects` to avoid saving objects in state (useful for large buckets).

Fixes #1122 (issue)

## Type of change

- [x] Improvement (improve existing resource(s) or datasource(s))

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or issues
- [x] I have added acceptance tests that prove my fix is effective or that my feature works
- [x] New and existing acceptance tests pass locally with my changes
- [x] I ran successfully `go mod vendor` if I added or modify `go.mod` file
