### PR TITLE
feat(cloud_project_storage): Add an option to delete bucket replicas on deletion

### DIFF
--- a/docs/resources/cloud_project_storage.md
+++ b/docs/resources/cloud_project_storage.md
@@ -93,6 +93,7 @@ Required:
 Optional:
 
 - `storage_class` (String) Destination storage class
+- `remove_on_main_bucket_deletion` (Boolean) Whether to remove replicated bucket when the main bucket is deleted (make sure to apply your configuration when changing this value before deleting the main bucket)
 
 <a id="nestedatt--replication--rules--filter"></a>
 

--- a/ovh/resource_cloud_project_storage_test.go
+++ b/ovh/resource_cloud_project_storage_test.go
@@ -76,6 +76,7 @@ func TestAccCloudProjectRegionStorage_withReplication(t *testing.T) {
 									destination = {
 										name   = "%s"
 										region = "GRA"
+										remove_on_main_bucket_deletion = true
 									}
 									filter = {
 										"prefix" = "test"
@@ -123,6 +124,7 @@ func TestAccCloudProjectRegionStorage_withReplication(t *testing.T) {
 									destination = {
 										name   = "%s"
 										region = "GRA"
+										remove_on_main_bucket_deletion = true
 									}
 									filter = {
 										"prefix" = "test-updated"
@@ -156,7 +158,9 @@ func TestAccCloudProjectRegionStorage_withReplication(t *testing.T) {
 				ImportStateVerifyIdentifierAttribute: "name",
 				ResourceName:                         "ovh_cloud_project_storage.storage",
 				ImportStateId:                        fmt.Sprintf("%s/GRA/%s", os.Getenv("OVH_CLOUD_PROJECT_SERVICE_TEST"), bucketName),
-				ImportStateVerifyIgnore:              []string{"created_at"}, // Ignore created_at since its value is invalid in response of the POST.
+				// Ignore created_at since its value is invalid in response of the POST.
+				// Also ignore remove_on_main_bucket_deletion since its computed value is not returned by the API.
+				ImportStateVerifyIgnore: []string{"created_at", "replication.rules.0.destination.remove_on_main_bucket_deletion"},
 			},
 		},
 	})

--- a/templates/resources/cloud_project_storage.md.tmpl
+++ b/templates/resources/cloud_project_storage.md.tmpl
@@ -88,6 +88,7 @@ Required:
 Optional:
 
 - `storage_class` (String) Destination storage class
+- `remove_on_main_bucket_deletion` (Boolean) Whether to remove replicated bucket when the main bucket is deleted (make sure to apply your configuration when changing this value before deleting the main bucket)
 
 <a id="nestedatt--replication--rules--filter"></a>
 


### PR DESCRIPTION
# Description

Add option `remove_on_main_bucket_deletion` on the target buckets in replication rules to allow cleanup of all buckets created via Terraform.

Fixes #1141 (issue)

## Type of change

- [x] Improvement (improve existing resource(s) or datasource(s))

# How Has This Been Tested?

- [x] Test A: `make testacc TESTARGS="-run TestAccCloudProjectRegionStorage_basic"`
- [x] Test B: `make testacc TESTARGS="-run TestAccCloudProjectRegionStorage_withReplication"`

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or issues
- [x] I have added acceptance tests that prove my fix is effective or that my feature works
- [x] New and existing acceptance tests pass locally with my changes
- [x] I ran successfully `go mod vendor` if I added or modify `go.mod` file
