### PR TITLE
fix(cloud_project_user_s3_credential): Don't remove id in case of read error

### DIFF
--- a/ovh/resource_cloud_project_user_s3_credential.go
+++ b/ovh/resource_cloud_project_user_s3_credential.go
@@ -8,7 +8,6 @@ import (
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/ovh/terraform-provider-ovh/v2/ovh/helpers"
 )
 
 func resourceCloudProjectUserS3Credential() *schema.Resource {
@@ -120,7 +119,7 @@ func resourceCloudProjectUserS3CredentialRead(d *schema.ResourceData, meta inter
 	)
 
 	if err := config.OVHClient.Post(endpoint, nil, &s3Credential); err != nil {
-		return helpers.CheckDeleted(d, err, endpoint)
+		return err
 	}
 
 	// The API returns only secret key.


### PR DESCRIPTION
# Description

In case of an API error at read-time, the provider does a `d.SetId("")`, which removes the resource from the state. This is an unwanted behavior that is fixed in this PR.

Fixes #1157 (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] Test A: `make testacc TESTARGS="-run TestAccCloudProjectUserS3Credential_basic"`

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or issues
- [x] I have added acceptance tests that prove my fix is effective or that my feature works
- [x] New and existing acceptance tests pass locally with my changes
- [x] I ran successfully `go mod vendor` if I added or modify `go.mod` file
