### PR TITLE
feat: add the ignore_'init_error parameter'

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -196,6 +196,8 @@ The following arguments are supported:
 
 * `api_rate_limit` - (Optional) Specify the API request rate limit, X operations by seconds. If omitted, unlimited.
 
+* `ignore_init_error` - (Optional) **⚠️ Use with caution and only if you know what you are doing.** If set to `true`, the provider will skip authentication validation during initialization. If omitted, the `OVH_IGNORE_INIT_ERROR` environment variable is used. This allows the provider to load even with invalid credentials, but any actual API calls will still fail. This is intended for development/testing purposes only where valid credentials are not available but the provider configuration must be present.
+
 ## Terraform State storage in an OVHcloud Object Storage (S3 compatibility)
 
 In order to store your Terraform states on a High Performance (S3) OVHcloud Object Storage, please follow the [guide](https://help.ovhcloud.com/csm/en-public-cloud-compute-terraform-high-perf-object-storage-backend-state?id=kb_article_view&sysparm_article=KB0051345).

--- a/ovh/provider.go
+++ b/ovh/provider.go
@@ -35,6 +35,9 @@ var (
 		// Extra info in user-agent
 		"user_agent_extra": "Extra information to append to the user-agent",
 
+		// Ignore initialization errors
+		"ignore_init_error": "If set to true, initialization errors (like invalid OAuth credentials) will be ignored",
+
 		// OVH API Rate Limit
 		"api_rate_limit": "Specify the API request rate limit, X operations by seconds (default: unlimited)",
 	}
@@ -83,6 +86,12 @@ func Provider() *schema.Provider {
 				Type:        schema.TypeString,
 				Optional:    true,
 				Description: descriptions["user_agent_extra"],
+			},
+			"ignore_init_error": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Description: descriptions["ignore_init_error"],
+				DefaultFunc: schema.EnvDefaultFunc("OVH_IGNORE_INIT_ERROR", false),
 			},
 			"api_rate_limit": {
 				Type:        schema.TypeInt,
@@ -340,6 +349,9 @@ func ConfigureContextFunc(context context.Context, d *schema.ResourceData) (inte
 	}
 	if v, ok := d.GetOk("user_agent_extra"); ok {
 		config.UserAgentExtra = v.(string)
+	}
+	if v, ok := d.GetOk("ignore_init_error"); ok {
+		config.IgnoreInitError = v.(bool)
 	}
 	if v, ok := d.GetOk("api_rate_limit"); ok {
 		config.ApiRateLimit = ratelimit.New(v.(int))

--- a/templates/index.md.tmpl
+++ b/templates/index.md.tmpl
@@ -148,6 +148,8 @@ The following arguments are supported:
 
 * `api_rate_limit` - (Optional) Specify the API request rate limit, X operations by seconds. If omitted, unlimited.
 
+* `ignore_init_error` - (Optional) **⚠️ Use with caution and only if you know what you are doing.** If set to `true`, the provider will skip authentication validation during initialization. If omitted, the `OVH_IGNORE_INIT_ERROR` environment variable is used. This allows the provider to load even with invalid credentials, but any actual API calls will still fail. This is intended for development/testing purposes only where valid credentials are not available but the provider configuration must be present.
+
 ## Terraform State storage in an OVHcloud Object Storage (S3 compatibility)
 
 In order to store your Terraform states on a High Performance (S3) OVHcloud Object Storage, please follow the [guide](https://help.ovhcloud.com/csm/en-public-cloud-compute-terraform-high-perf-object-storage-backend-state?id=kb_article_view&sysparm_article=KB0051345).


### PR DESCRIPTION
# Description

This PR allows authentication errors to be ignored during provider initialization, in cases where the provider is loaded but not actually used. This prevents unnecessary failures when the provider is present in the configuration but no resources depend on it.

## Type of change

Please delete options that are not relevant.

- [X] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Test with working credentials:
```
OVH_CLIENT_ID=${client_id} OVH_CLIENT_SECRET=${client_secret} terraform plan
╷
│ Warning: Provider development overrides are in effect
│ 
│ The following provider development overrides are set in the CLI configuration:
│  - ovh/ovh in /home/tbetranc/go/1.25.1/bin
│  - ovh/arsenal in /home/tbetranc/go/1.25.1/bin
│ 
│ The behavior may therefore not match any released version of the provider and applying changes may cause the state to become incompatible with published releases.
╵

No changes. Your infrastructure matches the configuration.

Terraform has compared your real infrastructure against your configuration and found no differences, so no changes are needed.
```

Test with bad credentials:
```
OVH_CLIENT_ID=foo OVH_CLIENT_SECRET=bar terraform plan
╷
│ Warning: Provider development overrides are in effect
│ 
│ The following provider development overrides are set in the CLI configuration:
│  - ovh/arsenal in /home/tbetranc/go/1.25.1/bin
│  - ovh/ovh in /home/tbetranc/go/1.25.1/bin
│ 
│ The behavior may therefore not match any released version of the provider and applying changes may cause the state to become incompatible with published releases.
╵

Planning failed. Terraform encountered an error while generating this plan.

╷
│ Error: OVH client seems to be misconfigured: "failed to retrieve OAuth2 Access Token: oauth2: \"invalid_client\""
│ 
│   with provider["registry.terraform.io/ovh/ovh"],
│   on test.tf line 10, in provider "ovh":
│   10: provider "ovh" {
│ 
│ failed to init OVH API client
╵
```

Test with the ignore option enabled:
```
OVH_CLIENT_ID=foo OVH_CLIENT_SECRET=bar OVH_IGNORE_INIT_ERROR=true terraform plan
╷
│ Warning: Provider development overrides are in effect
│ 
│ The following provider development overrides are set in the CLI configuration:
│  - ovh/arsenal in /home/tbetranc/go/1.25.1/bin
│  - ovh/ovh in /home/tbetranc/go/1.25.1/bin
│ 
│ The behavior may therefore not match any released version of the provider and applying changes may cause the state to become incompatible with published releases.
╵

No changes. Your infrastructure matches the configuration.

Terraform has compared your real infrastructure against your configuration and found no differences, so no changes are needed.
```

Test with the ignore option enabled but with an active datasource:
```
OVH_CLIENT_ID=foo OVH_CLIENT_SECRET=bar OVH_IGNORE_INIT_ERROR=true terraform plan
╷
│ Warning: Provider development overrides are in effect
│ 
│ The following provider development overrides are set in the CLI configuration:
│  - ovh/arsenal in /home/tbetranc/go/1.25.1/bin
│  - ovh/ovh in /home/tbetranc/go/1.25.1/bin
│ 
│ The behavior may therefore not match any released version of the provider and applying changes may cause the state to become incompatible with published releases.
╵
data.ovh_domain_zone.foo[0]: Reading...

Planning failed. Terraform encountered an error while generating this plan.

╷
│ Error: Error calling /domain/zone/foo.ovh:
│        "failed to retrieve OAuth2 Access Token: oauth2: \"invalid_client\""
│ 
│   with data.ovh_domain_zone.foo[0],
│   on test.tf line 13, in data "ovh_domain_zone" "foo":
│   13: data "ovh_domain_zone" "foo" {
│ 
╵
```

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings or issues
- [ ] I have added acceptance tests that prove my fix is effective or that my feature works
- [X] New and existing acceptance tests pass locally with my changes
- [X] I ran successfully `go mod vendor` if I added or modify `go.mod` file
