### PR TITLE
Dev/thekrauss/cloud instances with multiple network

### DIFF
--- a/env.sh
+++ b/env.sh
@@ -1,12 +1,3 @@
 #!/usr/bin/env bash
 
-export OVH_ENDPOINT="ovh-eu"    
-export OVH_APPLICATION_KEY="000693a9655db1b5"
-export OVH_APPLICATION_SECRET="dda3dcae9b4fbd41461c07d100da6586"
-export OVH_CONSUMER_KEY="055d118f9c3ca88b4fba9ae1b984fdf8"
-
-export OVH_DOMAIN_TEST="syk-edu.com"
-
-export TF_ACC=1
-
-echo "[OK] OVH environment variables exported for acceptance tests."
+!!!

--- a/examples/resources/cloud_project_instance/example_1.tf
+++ b/examples/resources/cloud_project_instance/example_1.tf
@@ -16,3 +16,61 @@ resource "ovh_cloud_project_instance" "instance" {
         public = true
     }  
 }
+
+
+##  with Multiple Network Interfaces
+
+resource "ovh_cloud_project_network_private" "net_front" {
+  service_name = "XXX"
+  name         = "public-front"
+  regions      = ["GRA11"]
+}
+
+resource "ovh_cloud_project_subnet" "subnet_front" {
+  service_name = "XXX"
+  network_id   = ovh_cloud_project_network_private.net_front.id
+  region       = "GRA11"
+  network      = "10.0.1.0/24"
+  dhcp         = true
+}
+
+resource "ovh_cloud_project_network_private" "net_back" {
+  service_name = "XXX"
+  name         = "private-back"
+  regions      = ["GRA11"]
+}
+
+resource "ovh_cloud_project_subnet" "subnet_back" {
+  service_name = "XXX"
+  network_id   = private.net_back.id
+  region       = "GRA11"
+  network      = "10.0.2.0/24"
+  dhcp         = true
+}
+
+resource "ovh_cloud_project_instance" "multinic_instance" {
+  service_name   = "XXX"
+  region         = "GRA11"
+  name           = "multi-nic-instance"
+  flavor_id      = "UUID"
+  image_id       = "UUID"
+
+  network {
+    public = true
+
+    private {
+      network {
+        id        = private.net_front.id
+        subnet_id = subnet.subnet_front.id
+      }
+      ip = "10.0.1.10"
+    }
+
+    private {
+      network {
+        id        = private.net_back.id
+        subnet_id = subnet.subnet_back.id
+      }
+    }
+  }
+}


### PR DESCRIPTION
 Description

This PR addresses issue #1115 by enabling the attachment of multiple private network interfaces to a Public Cloud instance.

Previously, the provider limited the network.private block to a single item (MaxItems: 1). This change allows users to define multiple private blocks to connect an instance to multiple vRacks/Subnets simultaneously (e.g., Front/Back architecture).

## Type of change

• Schema: Changed network.private from TypeSet to TypeList to ensure interface ordering (eth1, eth2...) is respected and removed the MaxItems: 1 restriction.

• Structures: Updated Network struct to handle a slice of private networks ([]*PrivateNetwork) instead of a single pointer.


• Logic: Updated GetNetwork helper to iterate over all defined private blocks and construct the correct payload for the API


```hcl
resource "ovh_cloud_project_instance" "multinic_instance" {
  service_name   = "XXX"
  region         = "GRA11"
  name           = "multi-nic-instance"
  flavor_id      = "UUID"
  image_id       = "UUID"

  network {
    public = true

    private {
      network {
        id        = private.net_front.id
        subnet_id = subnet.subnet_front.id
      }
      ip = "10.0.1.10"
    }

    private {
      network {
        id        = private.net_back.id
        subnet_id = subnet.subnet_back.id
      }
    }
  }
}

```
