### PR TITLE
fix: do not fail creating / updating an OIDC provider because the cluster pending state is INSTALLING instead of REDEPLOYING while waiting for the cluster to become ready

### DIFF
--- a/ovh/resource_cloud_project_kube_oidc.go
+++ b/ovh/resource_cloud_project_kube_oidc.go
@@ -126,7 +126,7 @@ func resourceCloudProjectKubeOIDCCreate(d *schema.ResourceData, meta interface{}
 	d.SetId(serviceName + "/" + kubeID)
 
 	log.Printf("[DEBUG] Waiting for kube %s to be READY", kubeID)
-	err = waitForCloudProjectKubeReady(config.OVHClient, serviceName, kubeID, []string{"REDEPLOYING"}, []string{"READY"}, d.Timeout(schema.TimeoutCreate))
+	err = waitForCloudProjectKubeReady(config.OVHClient, serviceName, kubeID, []string{"INSTALLING", "REDEPLOYING"}, []string{"READY"}, d.Timeout(schema.TimeoutCreate))
 	if err != nil {
 		return fmt.Errorf("timeout while waiting kube %s to be READY: %w", kubeID, err)
 	}
@@ -178,7 +178,7 @@ func resourceCloudProjectKubeOIDCUpdate(d *schema.ResourceData, meta interface{}
 	}
 
 	log.Printf("[DEBUG] Waiting for kube %s to be READY", kubeID)
-	err = waitForCloudProjectKubeReady(config.OVHClient, serviceName, kubeID, []string{"REDEPLOYING"}, []string{"READY"}, d.Timeout(schema.TimeoutUpdate))
+	err = waitForCloudProjectKubeReady(config.OVHClient, serviceName, kubeID, []string{"INSTALLING", "REDEPLOYING"}, []string{"READY"}, d.Timeout(schema.TimeoutUpdate))
 	if err != nil {
 		return fmt.Errorf("timeout while waiting kube %s to be READY: %w", kubeID, err)
 	}


### PR DESCRIPTION
# Description

The cluster state can also be "INSTALLING" when the cluster is being modified after an oidc provider has been created. Currently TF will fail with an error (see #1173) when this happens now, even though that the provider is properly created.

Fixes #1173 

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (improve existing resource(s) or datasource(s))
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A: `make testacc TESTARGS="-run TestAccDataSourceXxxxYyyyZzzzz_basic"`
- [ ] Test B: `make testacc TESTARGS="-run TestAccDataSourceXxxxYyyyZzzzz_basic"`

**Test Configuration**:
* Terraform version: `terraform version`: Terraform v1.14.0
* Existing HCL configuration you used: 
```hcl
# OIDC configuration
# Note: This resource modifies the cluster and triggers a reconfiguration
# The OVH provider has a bug where it doesn't wait long enough for the cluster
# to return to READY state after applying OIDC configuration
resource "ovh_cloud_project_kube_oidc" "oidc" {
  service_name         = local.project_id
  kube_id              = ovh_cloud_project_kube.cluster.id
  client_id            = var.cluster_oidc_client_id
  issuer_url           = "https://${var.cluster_sso_server}"
  oidc_username_claim  = var.cluster_oidc_username_claim
  oidc_groups_claim    = [var.cluster_oidc_groups_claim]

  timeouts {
    create = "30m"
    update = "30m"
    delete = "10m"
  }
}
```

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings or issues
- [ ] I have added acceptance tests that prove my fix is effective or that my feature works
- [ ] New and existing acceptance tests pass locally with my changes
- [ ] I ran successfully `go mod vendor` if I added or modify `go.mod` file
