### PR TITLE
remove zone attribut from resource_vrack_ip

### DIFF
--- a/docs/resources/vrack_ip.md
+++ b/docs/resources/vrack_ip.md
@@ -77,5 +77,4 @@ The following attributes are exported:
 
 * `gateway` - Your gateway
 * `ip` - Your IP block
-* `zone` - Where you want your block announced on the network
 * `region` - See Argument Reference above.

--- a/ovh/resource_vrack_ip.go
+++ b/ovh/resource_vrack_ip.go
@@ -49,11 +49,6 @@ func resourceVrackIp() *schema.Resource {
 				Computed:    true,
 				Description: "Your IP block",
 			},
-			"zone": {
-				Type:        schema.TypeString,
-				Computed:    true,
-				Description: "Where you want your block announced on the network",
-			},
 		},
 	}
 }

--- a/ovh/types_vrack.go
+++ b/ovh/types_vrack.go
@@ -44,7 +44,6 @@ func (opts *VrackUpdateOpts) FromResource(d *schema.ResourceData) *VrackUpdateOp
 type VrackIp struct {
 	Gateway string `json:"gateway"`
 	Ip      string `json:"ip"`
-	Zone    string `json:"zone"`
 	Region  string `json:"region"`
 }
 
@@ -53,7 +52,6 @@ func (v VrackIp) ToMap() map[string]interface{} {
 
 	obj["gateway"] = v.Gateway
 	obj["ip"] = v.Ip
-	obj["zone"] = v.Zone
 	obj["region"] = v.Region
 
 	return obj

--- a/templates/resources/vrack_ip.md.tmpl
+++ b/templates/resources/vrack_ip.md.tmpl
@@ -28,5 +28,4 @@ The following attributes are exported:
 
 * `gateway` - Your gateway
 * `ip` - Your IP block
-* `zone` - Where you want your block announced on the network
 * `region` - See Argument Reference above.


### PR DESCRIPTION
PR recreated from https://github.com/chaufmaurice/terraform-provider-ovh/tree/dev/rchereau/update-vrack-ip-routes as it was a breaking change mistakenly merged. 

# Description

Remove zone attribut from GET /vrack/{serviceName}/ip/{ip}
It concerns `resource_vrack_ip`

## Type of change

Please delete options that are not relevant.

- [x] Improvement (improve existing resource(s) or datasource(s))

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Test A: `make testacc TESTARGS="-run TestAccVrackIpWithRegion_basic"`

**Test Configuration**:
* Terraform version: `terraform version`: Terraform v1.14.0
* Existing HCL configuration you used: 
```hcl
resource "ovh_vrack_ip" "vrack_ip_x_x_x_x" {
  service_name = {servicename}
  block = {block}
}
```

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings or issues
- [ ] I have added acceptance tests that prove my fix is effective or that my feature works
- [x] New and existing acceptance tests pass locally with my changes
- [ ] I ran successfully `go mod vendor` if I added or modify `go.mod` file
