### PR TITLE
feat(savings_plans): Add 1AZ/3AZ choice

### DIFF
--- a/docs/resources/savings_plan.md
+++ b/docs/resources/savings_plan.md
@@ -29,6 +29,7 @@ The following arguments are supported:
 * `size` - (Required) Size of the Savings Plan
 * `display_name` - (Required) Custom display name, used in invoices
 * `auto_renewal` - Whether Savings Plan should be renewed at the end of the period (defaults to false)
+* `deployment_type` - (Optional) Deployment type of the Savings Plan. Can be either `1AZ` or `3AZ`. Defaults to `1AZ` and cannot be set to `3AZ` for Rancher flavors.
 
 ### Available flavors
 

--- a/templates/resources/savings_plan.md.tmpl
+++ b/templates/resources/savings_plan.md.tmpl
@@ -24,6 +24,7 @@ The following arguments are supported:
 * `size` - (Required) Size of the Savings Plan
 * `display_name` - (Required) Custom display name, used in invoices
 * `auto_renewal` - Whether Savings Plan should be renewed at the end of the period (defaults to false)
+* `deployment_type` - (Optional) Deployment type of the Savings Plan. Can be either `1AZ` or `3AZ`. Defaults to `1AZ` and cannot be set to `3AZ` for Rancher flavors.
 
 ### Available flavors
 


### PR DESCRIPTION
# Description

Add ability to choose 1AZ or 3AZ deployment type on resource `ovh_savings_plan`.

## Type of change

- [x] Improvement (improve existing resource(s) or datasource(s))
