### PR TITLE
Add DoNotSendPassword field to VpsModel and InstallOptionsModel

### DIFF
--- a/docs/resources/vps.md
+++ b/docs/resources/vps.md
@@ -75,6 +75,7 @@ The following arguments are supported:
     * `label` - (Required) Identifier of the resource
     * `value` - (Required) Path to the resource in api.ovh.com
 * `public_ssh_key` - (String) Public SSH key to pre-install on your VPS - if set, then `image_id` must also be set
+* `do_not_send_password` - (Boolean) Indicates if default password should be set and sent by email. Default false: a password is set and an email is sent
 
 ## Attributes Reference
 

--- a/ovh/resource_vps_gen.go
+++ b/ovh/resource_vps_gen.go
@@ -38,6 +38,11 @@ func VpsResourceSchema(ctx context.Context) schema.Schema {
 			Description:         "Set the name displayed in Manager for your VPS (max 50 chars)",
 			MarkdownDescription: "Set the name displayed in Manager for your VPS (max 50 chars)",
 		},
+		"do_not_send_password": schema.BoolAttribute{
+			CustomType: ovhtypes.TfBoolType{},
+			Optional:   true,
+			Computed:   true,
+		},
 		"iam": schema.SingleNestedAttribute{
 			Attributes: map[string]schema.Attribute{
 				"display_name": schema.StringAttribute{
@@ -296,13 +301,15 @@ type VpsModel struct {
 	Plan          ovhtypes.TfListNestedValue[PlanValue]       `tfsdk:"plan" json:"plan"`
 	PlanOption    ovhtypes.TfListNestedValue[PlanOptionValue] `tfsdk:"plan_option" json:"planOption"`
 	// Installation options
-	PublicSSHKey ovhtypes.TfStringValue `tfsdk:"public_ssh_key" json:"publicSshKey"`
-	ImageId      ovhtypes.TfStringValue `tfsdk:"image_id" json:"imageId"`
+	PublicSSHKey      ovhtypes.TfStringValue `tfsdk:"public_ssh_key" json:"publicSshKey"`
+	ImageId           ovhtypes.TfStringValue `tfsdk:"image_id" json:"imageId"`
+	DoNotSendPassword ovhtypes.TfBoolValue   `tfsdk:"do_not_send_password" json:"doNotSendPassword"`
 }
 
 type InstallOptionsModel struct {
-	PublicSSHKey ovhtypes.TfStringValue `tfsdk:"public_ssh_key" json:"publicSshKey"`
-	ImageId      ovhtypes.TfStringValue `tfsdk:"image_id" json:"imageId"`
+	PublicSSHKey      ovhtypes.TfStringValue `tfsdk:"public_ssh_key" json:"publicSshKey"`
+	ImageId           ovhtypes.TfStringValue `tfsdk:"image_id" json:"imageId"`
+	DoNotSendPassword ovhtypes.TfBoolValue   `tfsdk:"do_not_send_password" json:"doNotSendPassword"`
 }
 
 func (v *VpsModel) MergeWith(other *VpsModel) {
@@ -412,8 +419,9 @@ func (v *VpsModel) ToOrder() *OrderModel {
 
 func (v *VpsModel) ToInstallOptions() *InstallOptionsModel {
 	return &InstallOptionsModel{
-		ImageId:      v.ImageId,
-		PublicSSHKey: v.PublicSSHKey,
+		ImageId:           v.ImageId,
+		PublicSSHKey:      v.PublicSSHKey,
+		DoNotSendPassword: v.DoNotSendPassword,
 	}
 }
 

--- a/ovh/resource_vps_test.go
+++ b/ovh/resource_vps_test.go
@@ -52,6 +52,50 @@ resource "ovh_vps" "myvps" {
 }
 `
 
+const testAccVpsDoNotSendPassword = `
+data "ovh_me" "myaccount" {}
+
+data "ovh_order_cart" "mycart" {
+  ovh_subsidiary = data.ovh_me.myaccount.ovh_subsidiary
+}
+
+data "ovh_order_cart_product_plan" "vps" {
+  cart_id        = data.ovh_order_cart.mycart.id
+  price_capacity = "renew"
+  product        = "vps"
+  plan_code      = "vps-le-2-2-40"
+}
+
+resource "ovh_vps" "myvps" {
+  display_name = "%s"
+  netboot_mode = "rescue"
+
+  image_id = "45b2f222-ab10-44ed-863f-720942762b6f"
+  public_ssh_key = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDSD76EaLUzJjf70W8W2uU9FzEyl68di67Bd20qtYfBLJpFJuX/RJC9StI1y1RnXXqC1Lf/Yo+yJzvNx0iqLxCX1G7g0XYex74HkgC6a2QeNhp9M56ANZtA3TKKAbkZ1xobfhOPWpq3lEFp7dgJctcILBPL3l6OjKf6NIxHo5yF67Vy4D0nWl5utumNdWhhlX7MtVQooszLyIwPlNO+DzD3ZnJFCt2Z1jdRkhm/Oobtx17CZ+5SN23tgHXS6pLOgM6w30M11zkI510z95IAIHhRT7MbiXICkvG/0qHuSftz1j/CcHFbttNB27dH86vByumfSEgRKaoRkCqrn64IWrSsFr3Smsf7gZWLBlYLliGPyn8Tsr9bT5pRul6yTvVbfZ31RREBr1I0Lp4q++d+fIpa3LtMGRaMb9huJYy8cwW/Vfzbxsqfz9xzjIOFNcYl7J9l4cvz3hgSlai2Jgngw5ShNVlxcIKUdiynZWm09nQudlYNHgor9ID+JACzCfPkUZ8"
+  do_not_send_password = true
+
+  ovh_subsidiary = data.ovh_order_cart.mycart.ovh_subsidiary
+  plan = [
+    {
+      duration     = "P1M"
+      plan_code    = data.ovh_order_cart_product_plan.vps.plan_code
+      pricing_mode = "default"
+
+      configuration = [
+        {
+          label = "vps_datacenter"
+          value = "WAW"
+        },
+        {
+          label = "vps_os"
+          value = "Debian 10"
+        }
+      ]
+    }
+  ]
+}
+`
+
 const testAccVpsReinstallImageOnly = `
 data "ovh_me" "myaccount" {}
 
@@ -114,6 +158,36 @@ func TestAccResourceVps_basic(t *testing.T) {
 						"ovh_vps.myvps", "display_name", displayName),
 					resource.TestCheckResourceAttr(
 						"ovh_vps.myvps", "public_ssh_key", "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDSD76EaLUzJjf70W8W2uU9FzEyl68di67Bd20qtYfBLJpFJuX/RJC9StI1y1RnXXqC1Lf/Yo+yJzvNx0iqLxCX1G7g0XYex74HkgC6a2QeNhp9M56ANZtA3TKKAbkZ1xobfhOPWpq3lEFp7dgJctcILBPL3l6OjKf6NIxHo5yF67Vy4D0nWl5utumNdWhhlX7MtVQooszLyIwPlNO+DzD3ZnJFCt2Z1jdRkhm/Oobtx17CZ+5SN23tgHXS6pLOgM6w30M11zkI510z95IAIHhRT7MbiXICkvG/0qHuSftz1j/CcHFbttNB27dH86vByumfSEgRKaoRkCqrn64IWrSsFr3Smsf7gZWLBlYLliGPyn8Tsr9bT5pRul6yTvVbfZ31RREBr1I0Lp4q++d+fIpa3LtMGRaMb9huJYy8cwW/Vfzbxsqfz9xzjIOFNcYl7J9l4cvz3hgSlai2Jgngw5ShNVlxcIKUdiynZWm09nQudlYNHgor9ID+JACzCfPkUZ8"),
+					resource.TestCheckResourceAttr(
+						"ovh_vps.myvps", "image_id", os.Getenv("OVH_VPS_IMAGE_ID")),
+				),
+			},
+		},
+	})
+}
+
+func TestAccResourceVps_doNotSendPassword(t *testing.T) {
+	displayName := acctest.RandomWithPrefix(test_prefix)
+	config := fmt.Sprintf(
+		testAccVpsBasic,
+		displayName,
+	)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheckOrderVPS(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(
+						"ovh_vps.myvps", "netboot_mode", "rescue"),
+					resource.TestCheckResourceAttr(
+						"ovh_vps.myvps", "display_name", displayName),
+					resource.TestCheckResourceAttr(
+						"ovh_vps.myvps", "public_ssh_key", "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDSD76EaLUzJjf70W8W2uU9FzEyl68di67Bd20qtYfBLJpFJuX/RJC9StI1y1RnXXqC1Lf/Yo+yJzvNx0iqLxCX1G7g0XYex74HkgC6a2QeNhp9M56ANZtA3TKKAbkZ1xobfhOPWpq3lEFp7dgJctcILBPL3l6OjKf6NIxHo5yF67Vy4D0nWl5utumNdWhhlX7MtVQooszLyIwPlNO+DzD3ZnJFCt2Z1jdRkhm/Oobtx17CZ+5SN23tgHXS6pLOgM6w30M11zkI510z95IAIHhRT7MbiXICkvG/0qHuSftz1j/CcHFbttNB27dH86vByumfSEgRKaoRkCqrn64IWrSsFr3Smsf7gZWLBlYLliGPyn8Tsr9bT5pRul6yTvVbfZ31RREBr1I0Lp4q++d+fIpa3LtMGRaMb9huJYy8cwW/Vfzbxsqfz9xzjIOFNcYl7J9l4cvz3hgSlai2Jgngw5ShNVlxcIKUdiynZWm09nQudlYNHgor9ID+JACzCfPkUZ8"),
+					resource.TestCheckResourceAttr(
+						"ovh_vps.myvps", "do_not_send_password", "true"),
 					resource.TestCheckResourceAttr(
 						"ovh_vps.myvps", "image_id", os.Getenv("OVH_VPS_IMAGE_ID")),
 				),

--- a/templates/resources/vps.md.tmpl
+++ b/templates/resources/vps.md.tmpl
@@ -45,6 +45,7 @@ The following arguments are supported:
     * `label` - (Required) Identifier of the resource
     * `value` - (Required) Path to the resource in api.ovh.com
 * `public_ssh_key` - (String) Public SSH key to pre-install on your VPS - if set, then `image_id` must also be set
+* `do_not_send_password` - (Boolean) Indicates if default password should be set and sent by email. Default false: a password is set and an email is sent.
 
 ## Attributes Reference
 


### PR DESCRIPTION
# Description

When (re)installing a VPS from Terraform, there is not equivalent of the " I do not wish to receive my VPS authentication codes by email. " option.
This PR adds an attribute `do_not_send_password` to disable password authentication. This allows a complete automatized workflow where the first authentication on the VPS with the SSH key is successful.


## Type of change

- [X] Improvement (improve existing resource(s) or datasource(s))

# How Has This Been Tested?

No

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings or issues
- [X] I have added acceptance tests that prove my fix is effective or that my feature works
- [x] New and existing acceptance tests pass locally with my changes
- [X] I ran successfully `go mod vendor` if I added or modify `go.mod` file
