### PR TITLE
fix: update dedicated server display name on read

### DIFF
--- a/ovh/resource_dedicated_server.go
+++ b/ovh/resource_dedicated_server.go
@@ -175,6 +175,7 @@ func (r *dedicatedServerResource) Read(ctx context.Context, req resource.ReadReq
 		return
 	}
 
+	responseData.DisplayName = responseData.Iam.DisplayName
 	responseData.MergeWith(&data)
 	responseData.ID = responseData.ServiceName
 


### PR DESCRIPTION
# Description
When the `display_name` attribute of a dedicated_server resource is modified outside of terraform, the drift isn't detected by the provider because the `display_name` value is not part of the `GET /dedicated/server/` response.

This change uses the value of the iam.display_name since this one is part of the `GET /dedicated/server/` response and is actually identical. 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
- create a dedicated server
- update the dedicated server `display_name` outside of terraform
- terraform plan -> the dedicated server resource should be updated to reset the `display_name` to the value defined in the terraform configuration 

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or issues
- [ ] I have added acceptance tests that prove my fix is effective or that my feature works -> tested manually
- [ ] New and existing acceptance tests pass locally with my changes -> I don't have all the required resources on a test account
- [x] I ran successfully `go mod vendor` if I added or modify `go.mod` file
