### PR TITLE
Change default timeout for dedicated_server reinstall task from 45min to 60min

### DIFF
--- a/ovh/dedicated_server_task.go
+++ b/ovh/dedicated_server_task.go
@@ -53,7 +53,7 @@ func waitForDedicatedServerTask(serviceName string, task *DedicatedServerTask, c
 		Pending:    []string{"init", "todo", "doing"},
 		Target:     []string{"done"},
 		Refresh:    refreshFunc,
-		Timeout:    45 * time.Minute,
+		Timeout:    60 * time.Minute,
 		Delay:      10 * time.Second,
 		MinTimeout: 3 * time.Second,
 	}

--- a/ovh/resource_dedicated_server_reinstall_task.go
+++ b/ovh/resource_dedicated_server_reinstall_task.go
@@ -19,7 +19,7 @@ func resourceDedicatedServerReinstallTask() *schema.Resource {
 		Delete: resourceDedicatedServerReinstallTaskDelete,
 
 		Timeouts: &schema.ResourceTimeout{
-			Create: schema.DefaultTimeout(45 * time.Minute),
+			Create: schema.DefaultTimeout(60 * time.Minute),
 		},
 
 		Schema: map[string]*schema.Schema{


### PR DESCRIPTION
# Description

Change default timeout for dedicated_server reinstall task from 45min to 60min
Fixes #xx (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ X] Improvement (improve existing resource(s) or datasource(s))
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A: `make testacc TESTARGS="-run TestAccDataSourceXxxxYyyyZzzzz_basic"`
- [ ] Test B: `make testacc TESTARGS="-run TestAccDataSourceXxxxYyyyZzzzz_basic"`

**Test Configuration**:
* Terraform version: `terraform version`: Terraform vx.y.z
* Existing HCL configuration you used: 
```hcl
resource "" "" {
 xx = "yy"
 zz = "aa"
}
```

# Checklist:

- [ X] My code follows the style guidelines of this project
- [ X] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X ] My changes generate no new warnings or issues
- [ ] I have added acceptance tests that prove my fix is effective or that my feature works
- [ X] New and existing acceptance tests pass locally with my changes
- [X ] I ran successfully `go mod vendor` if I added or modify `go.mod` file
