### PR TITLE
fix: handle enabled flag on ovh_ip_firewall creation (#1187)

### DIFF
--- a/docs/resources/ip_firewall.md
+++ b/docs/resources/ip_firewall.md
@@ -12,6 +12,7 @@ Use this resource to manage an IP firewall.
 resource "ovh_ip_firewall" "my_firewall" {
   ip             = "XXXXXX"
   ip_on_firewall = "XXXXXX"
+  enabled        = true
 }
 ```
 
@@ -19,11 +20,11 @@ resource "ovh_ip_firewall" "my_firewall" {
 
 * `ip` - (Required) The IP or the CIDR
 * `ip_on_firewall` - (Required) IPv4 address
-* `enabled ` - Whether firewall should be enabled
+* `enabled` - Whether firewall should be enabled
 
 ## Attributes Reference
 
 * `ip` - The IP or the CIDR
 * `ip_on_firewall` - IPv4 address
-* `enabled ` - Whether firewall is enabled
+* `enabled` - Whether firewall is enabled
 * `state` - Current state of your ip on firewall

--- a/examples/resources/ip_firewall/example_1.tf
+++ b/examples/resources/ip_firewall/example_1.tf
@@ -1,4 +1,5 @@
 resource "ovh_ip_firewall" "my_firewall" {
   ip             = "XXXXXX"
   ip_on_firewall = "XXXXXX"
+  enabled        = true
 }

--- a/ovh/resource_ip_firewall_test.go
+++ b/ovh/resource_ip_firewall_test.go
@@ -54,6 +54,14 @@ resource "ovh_ip_firewall" "firewall" {
 }
 `
 
+const testAccIPFirewallEnabledConfig = `
+resource "ovh_ip_firewall" "firewall" {
+	ip             = "%s"
+	ip_on_firewall = "%s"
+	enabled        = true
+}
+`
+
 func TestAccIPFirewall_basic(t *testing.T) {
 	ip := os.Getenv("OVH_IP_FIREWALL_TEST")
 
@@ -77,6 +85,30 @@ func TestAccIPFirewall_basic(t *testing.T) {
 			},
 			{
 				Config: updatedConfig,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(
+						"ovh_ip_firewall.firewall", "ip_on_firewall", ip),
+					resource.TestCheckResourceAttr(
+						"ovh_ip_firewall.firewall", "state", "ok"),
+					resource.TestCheckResourceAttr(
+						"ovh_ip_firewall.firewall", "enabled", "true"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccIPFirewall_createEnabled(t *testing.T) {
+	ip := os.Getenv("OVH_IP_FIREWALL_TEST")
+
+	config := fmt.Sprintf(testAccIPFirewallEnabledConfig, ip, ip)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheckIp(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(
 						"ovh_ip_firewall.firewall", "ip_on_firewall", ip),


### PR DESCRIPTION
# Description

This PR fixes issue #1187 where creating an `ovh_ip_firewall` resource with `enabled = true` causes Terraform to fail with a state inconsistency error.

**Issue:** <https://github.com/ovh/terraform-provider-ovh/issues/1187>

**Problem:** When creating a firewall with `enabled = true`, Terraform fails with:

```text
Error: Provider produced inconsistent result after apply
.enabled: was cty.True, but now cty.False
```

**Root Cause:** The POST endpoint for creating IP firewalls doesn't accept the `enabled` parameter, so the API always creates firewalls with `enabled = false` by default. The `ToCreate()` method only sends `ipOnFirewall` to the API and ignores the `enabled` field, causing a state mismatch.

**Solution:** Modified the `Create()` method in `ovh/resource_ip_firewall.go` to:

1. Create the firewall (POST)
2. If `enabled = true` in plan, call the PUT endpoint to enable it
3. Wait for the firewall state to be "ok"
4. Save the correct state to Terraform

Fixes #1187

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] Test A: `make testacc TESTARGS="-run TestAccIPFirewall_createEnabled"` - New test that creates firewall with enabled=true directly (tests the fix for #1187)
- [x] Test B: `make testacc TESTARGS="-run TestAccIPFirewall_basic"` - Existing test still passes (creates disabled, then updates to enabled)
- [x] Manual full cycle test (destroy, create) on dedicated IP with my own OVH account

**Test Configuration**:

- Terraform version: `1.x+`
- Test HCL configuration:

```hcl
  resource "ovh_ip_firewall" "test" {
    ip             = "51.178.216.213/32"
    ip_on_firewall = "51.178.216.213"
    enabled        = true  # This now works correctly (fixes #1187)
  }

  resource "ovh_ip_firewall_rule" "permit_ssh" {
    ip               = ovh_ip_firewall.test.ip
    ip_on_firewall   = ovh_ip_firewall.test.ip_on_firewall
    sequence         = 0
    action           = "permit"
    protocol         = "tcp"
    destination_port = 22
}
```

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or issues
- [x] I have added acceptance tests that prove my fix is effective or that my feature works
- [x] New and existing acceptance tests pass locally with my changes
- [x] I ran successfully go mod vendor if I added or modify go.mod file (N/A - no go.mod changes)

