### PR TITLE
feat: Add containerregistry OIDC groupFilter parameter

### DIFF
--- a/docs/resources/cloud_project_containerregistry_oidc.md
+++ b/docs/resources/cloud_project_containerregistry_oidc.md
@@ -21,6 +21,7 @@ resource "ovh_cloud_project_containerregistry_oidc" "my_oidc" {
   oidc_scope         = "openid,profile,email,offline_access"
 
   #optional field
+  oidc_group_filter = "harbor-admin"
   oidc_groups_claim = "groups"
   oidc_admin_group  = "harbor-admin"
   oidc_verify_cert  = true
@@ -46,6 +47,7 @@ The following arguments are supported:
 * `oidc_client_id` - The client ID with which Harbor is registered as client application with the OIDC provider.
 * `oidc_client_secret` - The secret for the Harbor client application.
 * `oidc_scope` - The scope sent to OIDC server during authentication. It's a comma-separated string that must contain 'openid' and usually also contains 'profile' and 'email'. To obtain refresh tokens it should also contain 'offline_access'.
+* `oidc_group_filter` - The regular expression to select matching groups from the Group Claim Name list. Matching groups are added to Harbor. This filter does not limit the users’ capability to log in into Harbor.
 * `oidc_groups_claim` - The name of Claim in the ID token whose value is the list of group names.
 * `oidc_admin_group` - Specify an OIDC admin group name. All OIDC users in this group will have harbor admin privilege. Keep it blank if you do not want to.
 * `oidc_verify_cert` - Set it to `false` if your OIDC server is hosted via self-signed certificate.

--- a/ovh/data_cloud_project_containerregistry_oidc.go
+++ b/ovh/data_cloud_project_containerregistry_oidc.go
@@ -44,6 +44,11 @@ func dataSourceCloudProjectContainerRegistryOIDC() *schema.Resource {
 				Required: false,
 				Optional: true,
 			},
+			"oidc_group_filter": {
+				Type:     schema.TypeString,
+				Required: false,
+				Optional: true,
+			},
 			"oidc_groups_claim": {
 				Type:     schema.TypeString,
 				Required: false,

--- a/ovh/data_cloud_project_containerregistry_oidc_test.go
+++ b/ovh/data_cloud_project_containerregistry_oidc_test.go
@@ -41,6 +41,8 @@ func TestAccCloudProjectContainerRegistryOIDCDataSource_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"data.ovh_cloud_project_containerregistry_oidc.oidcData", "oidc_scope", "openid,profile,email,offline_access"),
 					resource.TestCheckResourceAttr(
+						"data.ovh_cloud_project_containerregistry_oidc.oidcData", "oidc_group_filter", "groupFilter"),
+					resource.TestCheckResourceAttr(
 						"data.ovh_cloud_project_containerregistry_oidc.oidcData", "oidc_groups_claim", "groupsClaim"),
 					resource.TestCheckResourceAttr(
 						"data.ovh_cloud_project_containerregistry_oidc.oidcData", "oidc_admin_group", "adminGroup"),
@@ -79,6 +81,7 @@ resource "ovh_cloud_project_containerregistry_oidc" "oidc" {
 	oidc_client_id = "clientID"
 	oidc_client_secret = "clientSecret"
 	oidc_scope = "openid,profile,email,offline_access"
+	oidc_group_filter = "groupFilter"
 	oidc_groups_claim = "groupsClaim"
 	oidc_admin_group = "adminGroup"
 	oidc_verify_cert = "true"

--- a/ovh/resource_cloud_project_containerregistry_oidc.go
+++ b/ovh/resource_cloud_project_containerregistry_oidc.go
@@ -66,6 +66,11 @@ func resourceCloudProjectContainerRegistryOIDC() *schema.Resource {
 				Type:     schema.TypeString,
 				Required: true,
 			},
+			"oidc_group_filter": {
+				Type:     schema.TypeString,
+				Required: false,
+				Optional: true,
+			},
 			"oidc_groups_claim": {
 				Type:     schema.TypeString,
 				Required: false,

--- a/ovh/resource_cloud_project_containerregistry_oidc_test.go
+++ b/ovh/resource_cloud_project_containerregistry_oidc_test.go
@@ -34,6 +34,7 @@ resource "ovh_cloud_project_containerregistry_oidc" "my-oidc" {
 	oidc_client_id = "%s"
 	oidc_client_secret = "clientSecret"
 	oidc_scope = "openid,profile,email,offline_access"
+	oidc_group_filter = "groupFilter"
 	oidc_groups_claim = "groupsClaim"
 	oidc_admin_group = "adminGroup"
 	oidc_verify_cert = "true"
@@ -82,6 +83,7 @@ func TestAccCloudProjectContainerRegistryOIDC_full(t *testing.T) {
 					resource.TestCheckResourceAttr("ovh_cloud_project_containerregistry_oidc.my-oidc", "oidc_client_id", "clientID"),
 					resource.TestCheckResourceAttr("ovh_cloud_project_containerregistry_oidc.my-oidc", "oidc_client_secret", "clientSecret"),
 					resource.TestCheckResourceAttr("ovh_cloud_project_containerregistry_oidc.my-oidc", "oidc_scope", "openid,profile,email,offline_access"),
+					resource.TestCheckResourceAttr("ovh_cloud_project_containerregistry_oidc.my-oidc", "oidc_group_filter", "groupFilter"),
 					resource.TestCheckResourceAttr("ovh_cloud_project_containerregistry_oidc.my-oidc", "oidc_groups_claim", "groupsClaim"),
 					resource.TestCheckResourceAttr("ovh_cloud_project_containerregistry_oidc.my-oidc", "oidc_admin_group", "adminGroup"),
 					resource.TestCheckResourceAttr("ovh_cloud_project_containerregistry_oidc.my-oidc", "oidc_verify_cert", "true"),
@@ -107,6 +109,7 @@ func TestAccCloudProjectContainerRegistryOIDC_full(t *testing.T) {
 					resource.TestCheckResourceAttr("ovh_cloud_project_containerregistry_oidc.my-oidc", "oidc_client_id", "clientIDModified"),
 					resource.TestCheckResourceAttr("ovh_cloud_project_containerregistry_oidc.my-oidc", "oidc_client_secret", "clientSecret"),
 					resource.TestCheckResourceAttr("ovh_cloud_project_containerregistry_oidc.my-oidc", "oidc_scope", "openid,profile,email,offline_access"),
+					resource.TestCheckResourceAttr("ovh_cloud_project_containerregistry_oidc.my-oidc", "oidc_group_filter", "groupFilter"),
 					resource.TestCheckResourceAttr("ovh_cloud_project_containerregistry_oidc.my-oidc", "oidc_groups_claim", "groupsClaim"),
 					resource.TestCheckResourceAttr("ovh_cloud_project_containerregistry_oidc.my-oidc", "oidc_admin_group", "adminGroup"),
 					resource.TestCheckResourceAttr("ovh_cloud_project_containerregistry_oidc.my-oidc", "oidc_verify_cert", "true"),

--- a/ovh/types_cloud_project_containerregistry_oidc.go
+++ b/ovh/types_cloud_project_containerregistry_oidc.go
@@ -13,6 +13,7 @@ type CloudProjectContainerRegistryOIDCProvider struct {
 	Scope        string `json:"scope"`
 
 	// Optional fields
+	GroupFilter string `json:"groupFilter,omitempty"`
 	GroupsClaim string `json:"groupsClaim,omitempty"`
 	AdminGroup  string `json:"adminGroup,omitempty"`
 	VerifyCert  bool   `json:"verifyCert,omitempty"`
@@ -37,6 +38,7 @@ type CloudProjectContainerRegistryOIDCResponse struct {
 	Scope    string `json:"scope"`
 
 	// Non required
+	GroupFilter string `json:"groupFilter"`
 	GroupsClaim string `json:"groupsClaim"`
 	AdminGroup  string `json:"adminGroup"`
 	VerifyCert  bool   `json:"verifyCert"`
@@ -64,6 +66,7 @@ func newCloudProjectContainerRegistryOIDCProvider(d *schema.ResourceData) *Cloud
 		ClientID:     d.Get("oidc_client_id").(string),
 		ClientSecret: d.Get("oidc_client_secret").(string),
 		Scope:        d.Get("oidc_scope").(string),
+		GroupFilter:  d.Get("oidc_group_filter").(string),
 		GroupsClaim:  d.Get("oidc_groups_claim").(string),
 		AdminGroup:   d.Get("oidc_admin_group").(string),
 		VerifyCert:   d.Get("oidc_verify_cert").(bool),
@@ -78,6 +81,7 @@ func (v CloudProjectContainerRegistryOIDCResponse) ToMap() map[string]interface{
 	obj["oidc_endpoint"] = v.Endpoint
 	obj["oidc_client_id"] = v.ClientID
 	obj["oidc_scope"] = v.Scope
+	obj["oidc_group_filter"] = v.GroupFilter
 	obj["oidc_groups_claim"] = v.GroupsClaim
 	obj["oidc_admin_group"] = v.AdminGroup
 	obj["oidc_verify_cert"] = v.VerifyCert


### PR DESCRIPTION
# Description

Add new OIDC parameter groupFilter for product Managed Private Registry.
EDIT: The new parameter is now available on the OVHcloud API.

Fixes #1048

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (improve existing resource(s) or datasource(s))
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A: `make testacc TESTARGS="-run TestAccDataSourceXxxxYyyyZzzzz_basic"`
- [ ] Test B: `make testacc TESTARGS="-run TestAccDataSourceXxxxYyyyZzzzz_basic"`

**Test Configuration**:
* Terraform version: `terraform version`: Terraform vx.y.z
* Existing HCL configuration you used: 
```hcl
resource "" "" {
 xx = "yy"
 zz = "aa"
}
```

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or issues
- [x] I have added acceptance tests that prove my fix is effective or that my feature works
- [ ] New and existing acceptance tests pass locally with my changes
- [x] I ran successfully `go mod vendor` if I added or modify `go.mod` file
