### PR TITLE
fix: ignore 404 API errors when deleting domain zone DNSSEC

### DIFF
--- a/ovh/resource_domain_zone_dnssec.go
+++ b/ovh/resource_domain_zone_dnssec.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
+	"github.com/ovh/go-ovh/ovh"
 )
 
 var _ resource.ResourceWithConfigure = (*domainZoneDnssecResource)(nil)
@@ -110,6 +111,9 @@ func (r *domainZoneDnssecResource) Delete(ctx context.Context, req resource.Dele
 	// Delete API call logic
 	endpoint := "/domain/zone/" + url.PathEscape(data.ZoneName.ValueString()) + "/dnssec"
 	if err := r.config.OVHClient.Delete(endpoint, nil); err != nil {
+		if errOvh, ok := err.(*ovh.APIError); ok && errOvh.Code == 404 {
+			return
+		}
 		resp.Diagnostics.AddError(
 			fmt.Sprintf("Error calling Delete %s", endpoint),
 			err.Error(),


### PR DESCRIPTION
# Description

If a resource deletion request returns a 404, it implies the resource is already absent.

Fixes #1146 

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
I haven't set-up code-based tests for this but I tested it for my own use case (as outlined in the issue) and it solves the deletion problem.
<img width="1400" height="506" alt="image" src="https://github.com/user-attachments/assets/ff2a50e6-6143-46a7-a3e8-052e57709f70" />


# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings or issues
- [X] I have added acceptance tests that prove my fix is effective or that my feature works
- [X] New and existing acceptance tests pass locally with my changes
- [X] I ran successfully `go mod vendor` if I added or modify `go.mod` file
