### PR TITLE
Fix dedicated server ssh key documentation

### DIFF
--- a/docs/resources/dedicated_server.md
+++ b/docs/resources/dedicated_server.md
@@ -122,7 +122,7 @@ resource "ovh_dedicated_server" "server" {
   * `language` - Display Language
   * `post_installation_script` - Post-Installation Script
   * `post_installation_script_extension` - Post-Installation Script File Extension
-  * `ssh_key` - SSH Public Key
+  * `sshKey` - SSH Public Key
 * `storage` - Storage customization
   * `disk_group_id` - Disk group id
   * `hardware_raid` - Hardware Raid configurations


### PR DESCRIPTION
# Description

The documentation here is incorrect, if you use `ssh_key` as is - it results in:
```
╷
│ Error: failed to reinstall server
│ 
│   with module.example.ovh_dedicated_server.server,
│   on modules/dedicated_server/main.tf line 2, in resource "ovh_dedicated_server" "server":
│    2: resource "ovh_dedicated_server" "server" {
│ 
│ error calling Post /dedicated/server/REDACTED/reinstall
```

This is also documented here: https://api.us.ovhcloud.com/console/?section=%2Fdedicated%2Fserver&branch=v1#post-/dedicated/server/-serviceName-/reinstall

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (improve existing resource(s) or datasource(s))
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

# How Has This Been Tested?

I tested this locally and it worked after I updated to use the key `sshKey`


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or issues
- [x] I have added acceptance tests that prove my fix is effective or that my feature works
- [x] New and existing acceptance tests pass locally with my changes
- [x] I ran successfully `go mod vendor` if I added or modify `go.mod` file
