### PR TITLE
fix: include "UPDATING" as valid state when managing the kubernetes cluster OIDC resource

### DIFF
--- a/ovh/resource_cloud_project_kube_oidc.go
+++ b/ovh/resource_cloud_project_kube_oidc.go
@@ -126,7 +126,7 @@ func resourceCloudProjectKubeOIDCCreate(d *schema.ResourceData, meta interface{}
 	d.SetId(serviceName + "/" + kubeID)
 
 	log.Printf("[DEBUG] Waiting for kube %s to be READY", kubeID)
-	err = waitForCloudProjectKubeReady(config.OVHClient, serviceName, kubeID, []string{"INSTALLING", "REDEPLOYING"}, []string{"READY"}, d.Timeout(schema.TimeoutCreate))
+	err = waitForCloudProjectKubeReady(config.OVHClient, serviceName, kubeID, []string{"INSTALLING", "UPDATING", "REDEPLOYING"}, []string{"READY"}, d.Timeout(schema.TimeoutCreate))
 	if err != nil {
 		return fmt.Errorf("timeout while waiting kube %s to be READY: %w", kubeID, err)
 	}
@@ -178,7 +178,7 @@ func resourceCloudProjectKubeOIDCUpdate(d *schema.ResourceData, meta interface{}
 	}
 
 	log.Printf("[DEBUG] Waiting for kube %s to be READY", kubeID)
-	err = waitForCloudProjectKubeReady(config.OVHClient, serviceName, kubeID, []string{"INSTALLING", "REDEPLOYING"}, []string{"READY"}, d.Timeout(schema.TimeoutUpdate))
+	err = waitForCloudProjectKubeReady(config.OVHClient, serviceName, kubeID, []string{"INSTALLING", "UPDATING", "REDEPLOYING"}, []string{"READY"}, d.Timeout(schema.TimeoutUpdate))
 	if err != nil {
 		return fmt.Errorf("timeout while waiting kube %s to be READY: %w", kubeID, err)
 	}
@@ -202,7 +202,7 @@ func resourceCloudProjectKubeOIDCDelete(d *schema.ResourceData, meta interface{}
 	}
 
 	log.Printf("[DEBUG] Waiting for kube %s to be READY", kubeID)
-	err = waitForCloudProjectKubeReady(config.OVHClient, serviceName, kubeID, []string{"REDEPLOYING"}, []string{"READY"}, d.Timeout(schema.TimeoutDelete))
+	err = waitForCloudProjectKubeReady(config.OVHClient, serviceName, kubeID, []string{"REDEPLOYING", "UPDATING"}, []string{"READY"}, d.Timeout(schema.TimeoutDelete))
 	if err != nil {
 		return fmt.Errorf("timeout while waiting kube %s to be READY: %w", kubeID, err)
 	}


### PR DESCRIPTION
# Description

This PR fixes creating / updating / deleting the Kubernetes cluster OIDC resource. The cluster is in the "UPDATING" state when the OIDC resource is touched. This state is currently not configured as a valid state for which TF should keep waiting.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (improve existing resource(s) or datasource(s))
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A: `make testacc TESTARGS="-run TestAccDataSourceXxxxYyyyZzzzz_basic"`
- [ ] Test B: `make testacc TESTARGS="-run TestAccDataSourceXxxxYyyyZzzzz_basic"`

**Test Configuration**:
* Terraform version: `terraform version`: Terraform vx.y.z
* Existing HCL configuration you used: 
```hcl
resource "" "" {
 xx = "yy"
 zz = "aa"
}
```

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or issues
- [ ] I have added acceptance tests that prove my fix is effective or that my feature works
- [ ] New and existing acceptance tests pass locally with my changes
- [ ] I ran successfully `go mod vendor` if I added or modify `go.mod` file
