### PR TITLE
fix: Ensure all cloud resources can take cloud project ID from env

### DIFF
--- a/docs/resources/cloud_project_alerting.md
+++ b/docs/resources/cloud_project_alerting.md
@@ -20,7 +20,6 @@ resource "ovh_cloud_project_alerting" "my_alert" {
 ## Argument Reference
 
 * `service_name` - The id of the public cloud project. If omitted, the `OVH_CLOUD_PROJECT_SERVICE` environment variable is used.
-
 * `delay` - Delay between two alerts in seconds
 * `email` - Email to contact
 * `monthly_threshold` - Monthly threshold for this alerting in currency

--- a/docs/resources/cloud_project_gateway_interface.md
+++ b/docs/resources/cloud_project_gateway_interface.md
@@ -57,7 +57,7 @@ resource "ovh_cloud_project_gateway_interface" "interface" {
 
 The following arguments are supported:
 
-* `service_name` - (Required) ID of the cloud project
+* `service_name` - (Required) ID of the cloud project. If omitted, the `OVH_CLOUD_PROJECT_SERVICE` environment variable is used.
 * `region` - (Required) Region of the gateway
 * `id` - (Required) ID of the gateway
 * `subnet_id` - (Required) ID of the subnet to add

--- a/docs/resources/cloud_project_instance_snapshot.md
+++ b/docs/resources/cloud_project_instance_snapshot.md
@@ -22,8 +22,11 @@ resource "ovh_cloud_project_instance_snapshot" "snapshot" {
 ### Required
 
 - `instance_id` (String, Forces new resource) Instance ID
-- `service_name` (String, Forces new resource) Service name
 - `name` (String, Forces new resource) Snapshot name
+
+### Optional
+
+- `service_name` (String, Forces new resource) Service name. If omitted, the `OVH_CLOUD_PROJECT_SERVICE` environment variable is used.
 
 ### Read-Only
 

--- a/docs/resources/cloud_project_loadbalancer.md
+++ b/docs/resources/cloud_project_loadbalancer.md
@@ -4,6 +4,14 @@ subcategory : "Load Balancer (Public Cloud / Octavia)"
 
 # ovh_cloud_project_loadbalancer
 
+Create a load balancer in a public cloud project.
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `service_name` - (Optional) ID of the public cloud project. If omitted, the `OVH_CLOUD_PROJECT_SERVICE` environment variable is used.
+
 ## Example Usage
 
 ```terraform

--- a/docs/resources/cloud_project_region.md
+++ b/docs/resources/cloud_project_region.md
@@ -19,7 +19,10 @@ resource "ovh_cloud_project_region" "region" {
 ### Required
 
 - `region` (String) Region to add to your project
-- `service_name` (String) Service name
+
+### Optional
+
+- `service_name` (String) Service name. If omitted, the `OVH_CLOUD_PROJECT_SERVICE` environment variable is used.
 
 ### Read-Only
 

--- a/docs/resources/cloud_project_region_network.md
+++ b/docs/resources/cloud_project_region_network.md
@@ -26,7 +26,7 @@ resource "ovh_cloud_project_region_network" "net" {
 
 The following arguments are supported:
 
-* `service_name` - (Required) The id of the public cloud project
+* `service_name` - (Optional) The id of the public cloud project. If omitted, the `OVH_CLOUD_PROJECT_SERVICE` environment variable is used.
 * `region_name` - (Required) Network region
 * `name` - (Required) Name of the network
 * `subnet` - (Required) Parameters to create a subnet

--- a/docs/resources/cloud_project_ssh_key.md
+++ b/docs/resources/cloud_project_ssh_key.md
@@ -23,11 +23,11 @@ resource "ovh_cloud_project_ssh_key" "key" {
 
 - `name` (String) SSH key name
 - `public_key` (String) SSH public key
-- `service_name` (String) Service name
 
 ### Optional
 
 - `region` (String) Region to create SSH key
+- `service_name` (String) Service name. If omitted, the `OVH_CLOUD_PROJECT_SERVICE` environment variable is used.
 
 ### Read-Only
 

--- a/docs/resources/cloud_project_storage.md
+++ b/docs/resources/cloud_project_storage.md
@@ -69,7 +69,6 @@ resource "ovh_cloud_project_storage" "storage_with_lock" {
 
 - `name` (String) Container name
 - `region_name` (String) Region name
-- `service_name` (String) Service name
 
 ### Optional
 
@@ -78,6 +77,7 @@ resource "ovh_cloud_project_storage" "storage_with_lock" {
 - `limit` (Number) Limit the number of objects returned (1000 maximum, defaults to 1000)
 - `marker` (String) Key to start with when listing objects
 - `owner_id` (Number) Container owner user ID
+- `service_name` (String) Service name. If omitted, the `OVH_CLOUD_PROJECT_SERVICE` environment variable is used.
 - `prefix` (String) List objects whose key begins with this prefix
 - `replication` (Attributes) Replication configuration (see [below for nested schema](#nestedatt--replication))
 - `versioning` (Attributes) Versioning configuration (see [below for nested schema](#nestedatt--versioning))

--- a/docs/resources/cloud_project_volume.md
+++ b/docs/resources/cloud_project_volume.md
@@ -23,7 +23,7 @@ resource "ovh_cloud_project_volume" "volume" {
 
 The following arguments are supported:
 
-* `service_name` - Required. The id of the public cloud project. **Changing this value recreates the resource.**
+* `service_name` - Optional. The id of the public cloud project. If omitted, the `OVH_CLOUD_PROJECT_SERVICE` environment variable is used. **Changing this value recreates the resource.**
 * `region_name` - Required. A valid OVHcloud public cloud region name in which the volume will be available. Ex.: "GRA11". **Changing this value recreates the resource.**
 * `description` - A description of the volume
 * `name` - Name of the volume

--- a/docs/resources/cloud_project_volume_backup.md
+++ b/docs/resources/cloud_project_volume_backup.md
@@ -22,12 +22,12 @@ resource "ovh_cloud_project_volume_backup" "backup" {
 ### Required
 
 - `region_name` (String) Region name
-- `service_name` (String) Service name
 - `volume_id` (String) ID of the volume to backup
 
 ### Optional
 
 - `name` (String) name of the backup
+- `service_name` (String) Service name. If omitted, the `OVH_CLOUD_PROJECT_SERVICE` environment variable is used.
 
 ### Read-Only
 

--- a/ovh/resource_cloud_project_alerting.go
+++ b/ovh/resource_cloud_project_alerting.go
@@ -4,8 +4,10 @@ import (
 	"context"
 	"fmt"
 	"net/url"
+	"os"
 
 	"github.com/hashicorp/terraform-plugin-framework/resource"
+	ovhtypes "github.com/ovh/terraform-provider-ovh/v2/ovh/types"
 )
 
 var _ resource.ResourceWithConfigure = (*cloudProjectAlertingResource)(nil)
@@ -50,6 +52,19 @@ func (r *cloudProjectAlertingResource) Create(ctx context.Context, req resource.
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
 	if resp.Diagnostics.HasError() {
 		return
+	}
+
+	// Handle service_name: use provided value or fall back to environment variable
+	if data.ServiceName.IsNull() || data.ServiceName.IsUnknown() || data.ServiceName.ValueString() == "" {
+		envServiceName := os.Getenv("OVH_CLOUD_PROJECT_SERVICE")
+		if envServiceName == "" {
+			resp.Diagnostics.AddError(
+				"Missing service_name",
+				"The service_name attribute is required. Please provide it in the resource configuration or set the OVH_CLOUD_PROJECT_SERVICE environment variable.",
+			)
+			return
+		}
+		data.ServiceName = ovhtypes.NewTfStringValue(envServiceName)
 	}
 
 	endpoint := "/cloud/project/" + url.PathEscape(data.ServiceName.ValueString()) + "/alerting"

--- a/ovh/resource_cloud_project_alerting_gen.go
+++ b/ovh/resource_cloud_project_alerting_gen.go
@@ -93,12 +93,12 @@ func CloudProjectAlertingResourceSchema(ctx context.Context) schema.Schema {
 			},
 			"service_name": schema.StringAttribute{
 				CustomType: ovhtypes.TfStringType{},
-				Required:   true,
+				Optional:   true,
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.RequiresReplace(),
 				},
-				Description:         "The project id",
-				MarkdownDescription: "The project id",
+				Description:         "The project id. If omitted, the `OVH_CLOUD_PROJECT_SERVICE` environment variable is used.",
+				MarkdownDescription: "The project id. If omitted, the `OVH_CLOUD_PROJECT_SERVICE` environment variable is used.",
 			},
 		},
 	}

--- a/ovh/resource_cloud_project_failover_ip_attach.go
+++ b/ovh/resource_cloud_project_failover_ip_attach.go
@@ -33,9 +33,10 @@ func resourceCloudProjectFailoverIpAttachSchema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"service_name": {
 			Type:        schema.TypeString,
-			Description: "The service name",
+			Description: "The service name. If omitted, the `OVH_CLOUD_PROJECT_SERVICE` environment variable is used.",
 			ForceNew:    true,
 			Required:    true,
+			DefaultFunc: schema.EnvDefaultFunc("OVH_CLOUD_PROJECT_SERVICE", nil),
 		},
 
 		"block": {

--- a/ovh/resource_cloud_project_gateway_interface.go
+++ b/ovh/resource_cloud_project_gateway_interface.go
@@ -4,10 +4,12 @@ import (
 	"context"
 	"fmt"
 	"net/url"
+	"os"
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
+	ovhtypes "github.com/ovh/terraform-provider-ovh/v2/ovh/types"
 )
 
 var _ resource.ResourceWithConfigure = (*cloudProjectGatewayInterfaceResource)(nil)
@@ -69,6 +71,19 @@ func (r *cloudProjectGatewayInterfaceResource) Create(ctx context.Context, req r
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
 	if resp.Diagnostics.HasError() {
 		return
+	}
+
+	// Handle service_name: use provided value or fall back to environment variable
+	if data.ServiceName.IsNull() || data.ServiceName.IsUnknown() || data.ServiceName.ValueString() == "" {
+		envServiceName := os.Getenv("OVH_CLOUD_PROJECT_SERVICE")
+		if envServiceName == "" {
+			resp.Diagnostics.AddError(
+				"Missing service_name",
+				"The service_name attribute is required. Please provide it in the resource configuration or set the OVH_CLOUD_PROJECT_SERVICE environment variable.",
+			)
+			return
+		}
+		data.ServiceName = ovhtypes.NewTfStringValue(envServiceName)
 	}
 
 	endpoint := "/cloud/project/" + url.PathEscape(data.ServiceName.ValueString()) +

--- a/ovh/resource_cloud_project_gateway_interface_gen.go
+++ b/ovh/resource_cloud_project_gateway_interface_gen.go
@@ -47,11 +47,11 @@ func CloudProjectGatewayInterfaceResourceSchema(ctx context.Context) schema.Sche
 		},
 		"service_name": schema.StringAttribute{
 			CustomType: ovhtypes.TfStringType{},
-			Required:   true,
+			Optional:   true,
 			PlanModifiers: []planmodifier.String{
 				stringplanmodifier.RequiresReplace(),
 			},
-			Description: "Service name",
+			Description: "Service name. If omitted, the `OVH_CLOUD_PROJECT_SERVICE` environment variable is used.",
 		},
 		"subnet_id": schema.StringAttribute{
 			CustomType: ovhtypes.TfStringType{},

--- a/ovh/resource_cloud_project_instance_snapshot_gen.go
+++ b/ovh/resource_cloud_project_instance_snapshot_gen.go
@@ -76,9 +76,9 @@ func CloudProjectInstanceSnapshotResourceSchema(ctx context.Context) schema.Sche
 		},
 		"service_name": schema.StringAttribute{
 			CustomType:          ovhtypes.TfStringType{},
-			Required:            true,
-			Description:         "Service name",
-			MarkdownDescription: "Service name",
+			Optional:            true,
+			Description:         "Service name. If omitted, the `OVH_CLOUD_PROJECT_SERVICE` environment variable is used.",
+			MarkdownDescription: "Service name. If omitted, the `OVH_CLOUD_PROJECT_SERVICE` environment variable is used.",
 			PlanModifiers: []planmodifier.String{
 				stringplanmodifier.RequiresReplace(),
 			},

--- a/ovh/resource_cloud_project_loadbalancer.go
+++ b/ovh/resource_cloud_project_loadbalancer.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net/url"
+	"os"
 	"strings"
 	"time"
 
@@ -86,6 +87,19 @@ func (r *cloudProjectLoadbalancerResource) Create(ctx context.Context, req resou
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
 	if resp.Diagnostics.HasError() {
 		return
+	}
+
+	// Handle service_name: use provided value or fall back to environment variable
+	if data.ServiceName.IsNull() || data.ServiceName.IsUnknown() || data.ServiceName.ValueString() == "" {
+		envServiceName := os.Getenv("OVH_CLOUD_PROJECT_SERVICE")
+		if envServiceName == "" {
+			resp.Diagnostics.AddError(
+				"Missing service_name",
+				"The service_name attribute is required. Please provide it in the resource configuration or set the OVH_CLOUD_PROJECT_SERVICE environment variable.",
+			)
+			return
+		}
+		data.ServiceName = types.NewTfStringValue(envServiceName)
 	}
 
 	// Create resource and get operation ID

--- a/ovh/resource_cloud_project_loadbalancer_gen.go
+++ b/ovh/resource_cloud_project_loadbalancer_gen.go
@@ -730,9 +730,9 @@ func CloudProjectLoadbalancerResourceSchema(ctx context.Context) schema.Schema {
 		},
 		"service_name": schema.StringAttribute{
 			CustomType:          ovhtypes.TfStringType{},
-			Required:            true,
-			Description:         "Service name",
-			MarkdownDescription: "Service name",
+			Optional:            true,
+			Description:         "Service name. If omitted, the `OVH_CLOUD_PROJECT_SERVICE` environment variable is used.",
+			MarkdownDescription: "Service name. If omitted, the `OVH_CLOUD_PROJECT_SERVICE` environment variable is used.",
 			PlanModifiers: []planmodifier.String{
 				stringplanmodifier.RequiresReplace(),
 			},

--- a/ovh/resource_cloud_project_region.go
+++ b/ovh/resource_cloud_project_region.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net/url"
+	"os"
 
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	ovhtypes "github.com/ovh/terraform-provider-ovh/v2/ovh/types"
@@ -51,6 +52,19 @@ func (r *cloudProjectRegionResource) Create(ctx context.Context, req resource.Cr
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
 	if resp.Diagnostics.HasError() {
 		return
+	}
+
+	// Handle service_name: use provided value or fall back to environment variable
+	if data.ServiceName.IsNull() || data.ServiceName.IsUnknown() || data.ServiceName.ValueString() == "" {
+		envServiceName := os.Getenv("OVH_CLOUD_PROJECT_SERVICE")
+		if envServiceName == "" {
+			resp.Diagnostics.AddError(
+				"Missing service_name",
+				"The service_name attribute is required. Please provide it in the resource configuration or set the OVH_CLOUD_PROJECT_SERVICE environment variable.",
+			)
+			return
+		}
+		data.ServiceName = ovhtypes.NewTfStringValue(envServiceName)
 	}
 
 	endpoint := "/cloud/project/" + url.PathEscape(data.ServiceName.ValueString()) + "/region"

--- a/ovh/resource_cloud_project_region_gen.go
+++ b/ovh/resource_cloud_project_region_gen.go
@@ -80,9 +80,9 @@ func CloudProjectRegionResourceSchema(ctx context.Context) schema.Schema {
 		},
 		"service_name": schema.StringAttribute{
 			CustomType:          ovhtypes.TfStringType{},
-			Required:            true,
-			Description:         "Service name",
-			MarkdownDescription: "Service name",
+			Optional:            true,
+			Description:         "Service name. If omitted, the `OVH_CLOUD_PROJECT_SERVICE` environment variable is used.",
+			MarkdownDescription: "Service name. If omitted, the `OVH_CLOUD_PROJECT_SERVICE` environment variable is used.",
 			PlanModifiers: []planmodifier.String{
 				stringplanmodifier.RequiresReplace(),
 			},

--- a/ovh/resource_cloud_project_region_network_gen.go
+++ b/ovh/resource_cloud_project_region_network_gen.go
@@ -58,12 +58,12 @@ func CloudProjectRegionNetworkResourceSchema(ctx context.Context) schema.Schema 
 		},
 		"service_name": schema.StringAttribute{
 			CustomType: ovhtypes.TfStringType{},
-			Required:   true,
+			Optional:   true,
 			PlanModifiers: []planmodifier.String{
 				stringplanmodifier.RequiresReplace(),
 			},
-			Description:         "Service name",
-			MarkdownDescription: "Service name",
+			Description:         "Service name. If omitted, the `OVH_CLOUD_PROJECT_SERVICE` environment variable is used.",
+			MarkdownDescription: "Service name. If omitted, the `OVH_CLOUD_PROJECT_SERVICE` environment variable is used.",
 		},
 		"subnet": schema.SingleNestedAttribute{
 			Attributes: map[string]schema.Attribute{

--- a/ovh/resource_cloud_project_ssh_key_gen.go
+++ b/ovh/resource_cloud_project_ssh_key_gen.go
@@ -63,12 +63,12 @@ func CloudProjectSshKeyResourceSchema(ctx context.Context) schema.Schema {
 		},
 		"service_name": schema.StringAttribute{
 			CustomType: ovhtypes.TfStringType{},
-			Required:   true,
+			Optional:   true,
 			PlanModifiers: []planmodifier.String{
 				stringplanmodifier.RequiresReplace(),
 			},
-			Description:         "Service name",
-			MarkdownDescription: "Service name",
+			Description:         "Service name. If omitted, the `OVH_CLOUD_PROJECT_SERVICE` environment variable is used.",
+			MarkdownDescription: "Service name. If omitted, the `OVH_CLOUD_PROJECT_SERVICE` environment variable is used.",
 		},
 	}
 

--- a/ovh/resource_cloud_project_storage_gen.go
+++ b/ovh/resource_cloud_project_storage_gen.go
@@ -331,9 +331,9 @@ func CloudProjectRegionStorageResourceSchema(ctx context.Context) schema.Schema 
 		},
 		"service_name": schema.StringAttribute{
 			CustomType:          ovhtypes.TfStringType{},
-			Required:            true,
-			Description:         "Service name",
-			MarkdownDescription: "Service name",
+			Optional:            true,
+			Description:         "Service name. If omitted, the `OVH_CLOUD_PROJECT_SERVICE` environment variable is used.",
+			MarkdownDescription: "Service name. If omitted, the `OVH_CLOUD_PROJECT_SERVICE` environment variable is used.",
 		},
 		"object_lock": schema.SingleNestedAttribute{
 			Attributes: map[string]schema.Attribute{

--- a/ovh/resource_cloud_project_volume.go
+++ b/ovh/resource_cloud_project_volume.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net/url"
+	"os"
 	"strings"
 	"time"
 
@@ -11,6 +12,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/ovh/terraform-provider-ovh/v2/ovh/ovhwrap"
+	ovhtypes "github.com/ovh/terraform-provider-ovh/v2/ovh/types"
 )
 
 var _ resource.ResourceWithConfigure = (*cloudProjectVolumeResource)(nil)
@@ -67,6 +69,19 @@ func (r *cloudProjectVolumeResource) Create(ctx context.Context, req resource.Cr
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
 	if resp.Diagnostics.HasError() {
 		return
+	}
+
+	// Handle service_name: use provided value or fall back to environment variable
+	if data.ServiceName.IsNull() || data.ServiceName.IsUnknown() || data.ServiceName.ValueString() == "" {
+		envServiceName := os.Getenv("OVH_CLOUD_PROJECT_SERVICE")
+		if envServiceName == "" {
+			resp.Diagnostics.AddError(
+				"Missing service_name",
+				"The service_name attribute is required. Please provide it in the resource configuration or set the OVH_CLOUD_PROJECT_SERVICE environment variable.",
+			)
+			return
+		}
+		data.ServiceName = ovhtypes.NewTfStringValue(envServiceName)
 	}
 
 	endpoint := "/cloud/project/" + url.PathEscape(data.ServiceName.ValueString()) + "/region/" + url.PathEscape(data.RegionName.ValueString()) + "/volume"

--- a/ovh/resource_cloud_project_volume_backup.go
+++ b/ovh/resource_cloud_project_volume_backup.go
@@ -5,12 +5,14 @@ import (
 	"errors"
 	"fmt"
 	"net/url"
+	"os"
 	"strings"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
+	ovhtypes "github.com/ovh/terraform-provider-ovh/v2/ovh/types"
 )
 
 var _ resource.ResourceWithConfigure = (*cloudProjectVolumeBackupResource)(nil)
@@ -67,6 +69,19 @@ func (r *cloudProjectVolumeBackupResource) Create(ctx context.Context, req resou
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
 	if resp.Diagnostics.HasError() {
 		return
+	}
+
+	// Handle service_name: use provided value or fall back to environment variable
+	if data.ServiceName.IsNull() || data.ServiceName.IsUnknown() || data.ServiceName.ValueString() == "" {
+		envServiceName := os.Getenv("OVH_CLOUD_PROJECT_SERVICE")
+		if envServiceName == "" {
+			resp.Diagnostics.AddError(
+				"Missing service_name",
+				"The service_name attribute is required. Please provide it in the resource configuration or set the OVH_CLOUD_PROJECT_SERVICE environment variable.",
+			)
+			return
+		}
+		data.ServiceName = ovhtypes.NewTfStringValue(envServiceName)
 	}
 
 	// Create volume backup

--- a/ovh/resource_cloud_project_volume_backup_gen.go
+++ b/ovh/resource_cloud_project_volume_backup_gen.go
@@ -53,9 +53,9 @@ func CloudProjectVolumeBackupResourceSchema(ctx context.Context) schema.Schema {
 		},
 		"service_name": schema.StringAttribute{
 			CustomType:          ovhtypes.TfStringType{},
-			Required:            true,
-			Description:         "Service name",
-			MarkdownDescription: "Service name",
+			Optional:            true,
+			Description:         "Service name. If omitted, the `OVH_CLOUD_PROJECT_SERVICE` environment variable is used.",
+			MarkdownDescription: "Service name. If omitted, the `OVH_CLOUD_PROJECT_SERVICE` environment variable is used.",
 			PlanModifiers: []planmodifier.String{
 				stringplanmodifier.RequiresReplace(),
 			},

--- a/ovh/resource_cloud_project_volume_gen.go
+++ b/ovh/resource_cloud_project_volume_gen.go
@@ -105,9 +105,9 @@ func CloudProjectVolumeResourceSchema(ctx context.Context) schema.Schema {
 		},
 		"service_name": schema.StringAttribute{
 			CustomType:          ovhtypes.TfStringType{},
-			Required:            true,
-			Description:         "Service name",
-			MarkdownDescription: "Service name",
+			Optional:            true,
+			Description:         "Service name. If omitted, the `OVH_CLOUD_PROJECT_SERVICE` environment variable is used.",
+			MarkdownDescription: "Service name. If omitted, the `OVH_CLOUD_PROJECT_SERVICE` environment variable is used.",
 			PlanModifiers: []planmodifier.String{
 				stringplanmodifier.RequiresReplace(),
 			},


### PR DESCRIPTION
# Description

It is now possible for all public cloud resources to define the `service_name` attribute by using the environment variable `OVH_CLOUD_PROJECT_SERVICE`.

Fixes #1129 (issue)

## Type of change

- [x] Improvement (improve existing resource(s) or datasource(s))