### PR TITLE
fix: kube nodepool: cap desired_nodes when reducing max_nodes

### DIFF
--- a/ovh/resource_cloud_project_kube_nodepool.go
+++ b/ovh/resource_cloud_project_kube_nodepool.go
@@ -353,6 +353,16 @@ func resourceCloudProjectKubeNodePoolUpdate(d *schema.ResourceData, meta interfa
 		return err
 	}
 
+	if params.MaxNodes != nil && params.DesiredNodes == nil {
+		current := &CloudProjectKubeNodePoolResponse{}
+		if err := config.OVHClient.Get(endpoint, current); err == nil {
+			if current.DesiredNodes > *params.MaxNodes {
+				log.Printf("[DEBUG] desired_nodes (%d) exceeds new max_nodes (%d), capping desired_nodes to max_nodes", current.DesiredNodes, *params.MaxNodes)
+				params.DesiredNodes = params.MaxNodes
+			}
+		}
+	}
+
 	log.Printf("[DEBUG] Will update nodepool: %#v", *params)
 	err = config.OVHClient.Put(endpoint, params, nil)
 	if err != nil {

--- a/ovh/resource_cloud_project_kube_nodepool.go
+++ b/ovh/resource_cloud_project_kube_nodepool.go
@@ -360,6 +360,13 @@ func resourceCloudProjectKubeNodePoolUpdate(d *schema.ResourceData, meta interfa
 				log.Printf("[DEBUG] desired_nodes (%d) exceeds new max_nodes (%d), capping desired_nodes to max_nodes", current.DesiredNodes, *params.MaxNodes)
 				params.DesiredNodes = params.MaxNodes
 			}
+		} else {
+			log.Printf("[WARN] failed to GET existing nodepool %s before update (skipping desired_nodes capping): %v", d.Id(), err)
+			if apiErr, ok := err.(*ovh.APIError); ok && apiErr.Code == 404 {
+				// Nodepool not found when attempting pre-update GET; proceed without capping.
+			} else {
+				return fmt.Errorf("failed to GET existing nodepool %s before update: %w", d.Id(), err)
+			}
 		}
 	}
 

--- a/ovh/resource_cloud_project_kube_nodepool_test.go
+++ b/ovh/resource_cloud_project_kube_nodepool_test.go
@@ -255,6 +255,40 @@ resource "ovh_cloud_project_kube_nodepool" "pool" {
 
 `
 
+var testAccCloudProjectKubeNodePoolConfigMaxNodesReducedBelowDesired = `
+resource "ovh_cloud_project_kube" "cluster" {
+  service_name = "%s"
+  name         = "%s"
+  region       = "%s"
+  version      = "%s"
+}
+
+resource "ovh_cloud_project_kube_nodepool" "pool" {
+  service_name  = ovh_cloud_project_kube.cluster.service_name
+  kube_id       = ovh_cloud_project_kube.cluster.id
+  name          = ovh_cloud_project_kube.cluster.name
+  flavor_name   = "b2-7"
+  min_nodes     = 0
+  max_nodes     = 1
+  template {
+    metadata {
+      annotations = {
+        a2 = "av2"
+      }
+      finalizers = []
+      labels = {
+        l2 = "lv2"
+      }
+    }
+    spec {
+      unschedulable = false
+      taints = []
+    }
+  }
+}
+
+`
+
 var testAccCloudProjectKubeNodePoolConfigUpdatedScaleToZero = `
 resource "ovh_cloud_project_kube" "cluster" {
   service_name = "%s"
@@ -496,6 +530,13 @@ func TestAccCloudProjectKubeNodePoolRessource(t *testing.T) {
 		region,
 		version,
 	)
+	configMaxNodesReducedBelowDesired := fmt.Sprintf(
+		testAccCloudProjectKubeNodePoolConfigMaxNodesReducedBelowDesired,
+		os.Getenv("OVH_CLOUD_PROJECT_SERVICE_TEST"),
+		name,
+		region,
+		version,
+	)
 	configUpdatedScaleToZero := fmt.Sprintf(
 		testAccCloudProjectKubeNodePoolConfigUpdatedScaleToZero,
 		os.Getenv("OVH_CLOUD_PROJECT_SERVICE_TEST"),
@@ -611,6 +652,16 @@ func TestAccCloudProjectKubeNodePoolRessource(t *testing.T) {
 
 					resource.TestCheckResourceAttr("ovh_cloud_project_kube_nodepool.pool", "template.0.spec.0.taints.#", "0"),
 					resource.TestCheckResourceAttr("ovh_cloud_project_kube_nodepool.pool", "template.0.spec.0.unschedulable", "false"),
+				),
+			},
+			{
+				// Reduce max_nodes below the current desired_nodes without setting desired_nodes
+				// explicitly. The provider should automatically cap desired_nodes to the new
+				// max_nodes so the API accepts the request and the pool downscales.
+				Config: configMaxNodesReducedBelowDesired,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("ovh_cloud_project_kube_nodepool.pool", "max_nodes", "1"),
+					resource.TestCheckResourceAttr("ovh_cloud_project_kube_nodepool.pool", "desired_nodes", "1"),
 				),
 			},
 			{


### PR DESCRIPTION
# Description

When `max_nodes` is reduced below the current `desired_nodes`, the OVH API rejects the request with a 400. The provider now reads the current `desired_nodes` before the update and automatically caps it to the new max_nodes unless explicitly set in the same PUT request, allowing the pool to downscale cleanly.

Adds an acceptance test step that exercises this path by reducing `max_nodes` from 2 to 1 on a pool with 2 desired nodes, without setting desired_nodes explicitly.

Doesn't have an issue attached to it

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Added a test case to `‎ovh/resource_cloud_project_kube_nodepool_test.go‎`

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or issues
- [x] I have added acceptance tests that prove my fix is effective or that my feature works
- [x] New and existing acceptance tests pass locally with my changes
- [x] I ran successfully `go mod vendor` if I added or modify `go.mod` file
