### PR TITLE
Add support for advanced configuration

### DIFF
--- a/docs/resources/hosting_privatedatabase.md
+++ b/docs/resources/hosting_privatedatabase.md
@@ -59,6 +59,7 @@ output "privatedatabase_service_name" {
 The following arguments are supported:
 
 * `description` - Custom description on your privatedatabase order.
+* `advanced_configuration` - (Optional) Advanced configuration key / value.
 * `ovh_subsidiary` - (Required) OVHcloud Subsidiary. Country of OVHcloud legal entity you'll be billed by. List of supported subsidiaries available on API at [/1.0/me.json under `models.nichandle.OvhSubsidiaryEnum`](https://eu.api.ovh.com/1.0/me.json)
 * `plan` - (Required) Product Plan to order
   * `duration` - (Required) duration.
@@ -78,6 +79,7 @@ The following attributes are exported:
 * `urn` - URN of the private database, used when writing IAM policies
 * `cpu` - Number of CPU on your private database
 * `datacenter` - Datacenter where this private database is located
+* `advanced_configuration` - Advanced configuration key / value
 * `display_name` - Name displayed in customer panel for your private database
 * `hostname` - Private database hostname
 * `hostname_ftp` - Private database FTP hostname

--- a/examples/resources/hosting_privatedatabase/example_1.tf
+++ b/examples/resources/hosting_privatedatabase/example_1.tf
@@ -30,6 +30,10 @@ resource "ovh_hosting_privatedatabase" "database" {
       value = "postgresql_12"
     }
   }
+
+  advanced_configuration = {
+    log_min_messages = "ERROR"
+  }
 }
 
 output "privatedatabase_service_name" {

--- a/ovh/resource_hosting_privatedatabase.go
+++ b/ovh/resource_hosting_privatedatabase.go
@@ -39,6 +39,15 @@ func resourceHostingPrivateDatabaseSchema() map[string]*schema.Schema {
 		},
 
 		// Computed
+		"advanced_configuration": {
+			Type:        schema.TypeMap,
+			Optional:    true,
+			Computed:    true,
+			Description: "Advanced configuration key / value",
+			Elem: &schema.Schema{
+				Type: schema.TypeString,
+			},
+		},
 		"urn": {
 			Type:     schema.TypeString,
 			Computed: true,
@@ -170,14 +179,36 @@ func resourceHostingPrivateDatabaseUpdate(d *schema.ResourceData, meta interface
 	config := meta.(*Config)
 	serviceName := d.Get("service_name").(string)
 
-	log.Printf("[DEBUG] Will update privateDatabase: %s", serviceName)
-	opts := (&HostingPrivateDatabaseOpts{}).FromResource(d)
-	endpoint := fmt.Sprintf("/hosting/privateDatabase/%s", url.PathEscape(serviceName))
-	if err := config.OVHClient.Put(endpoint, opts, nil); err != nil {
-		return fmt.Errorf("calling Put %s: %q", endpoint, err)
+	if d.HasChange("display_name") {
+		log.Printf("[DEBUG] Will update privateDatabase: %s", serviceName)
+		opts := (&HostingPrivateDatabaseOpts{}).FromResource(d)
+		endpoint := fmt.Sprintf("/hosting/privateDatabase/%s", url.PathEscape(serviceName))
+		if err := config.OVHClient.Put(endpoint, opts, nil); err != nil {
+			return fmt.Errorf("calling Put %s: %q", endpoint, err)
+		}
+	}
+
+	if d.HasChange("advanced_configuration") {
+		log.Printf("[DEBUG] Will update privateDatabase config: %s", serviceName)
+		configEndpoint := fmt.Sprintf("/hosting/privateDatabase/%s/config/update", url.PathEscape(serviceName))
+		acParams := d.Get("advanced_configuration").(map[string]interface{})
+		parameters := make([]map[string]interface{}, 0, len(acParams))
+		for k, v := range acParams {
+			parameters = append(parameters, map[string]interface{}{
+				"key":   k,
+				"value": v,
+			})
+		}
+		payload := map[string]interface{}{
+			"parameters": parameters,
+		}
+		if err := config.OVHClient.Post(configEndpoint, payload, nil); err != nil {
+			return fmt.Errorf("calling Post %s with params %+v:\n\t %q", configEndpoint, payload, err)
+		}
 	}
 
 	return resourceHostingPrivateDatabaseRead(d, meta)
+
 }
 
 func resourceHostingPrivateDatabaseRead(d *schema.ResourceData, meta interface{}) error {
@@ -194,6 +225,46 @@ func resourceHostingPrivateDatabaseRead(d *schema.ResourceData, meta interface{}
 
 	for k, v := range ds.ToMap() {
 		d.Set(k, v)
+	}
+
+	configEndpoint := fmt.Sprintf("/hosting/privateDatabase/%s/config", url.PathEscape(serviceName))
+	var rawCfg map[string]interface{}
+	if err := config.OVHClient.Get(configEndpoint, &rawCfg); err != nil {
+		return fmt.Errorf("calling Get %s: %q", configEndpoint, err)
+	}
+
+	// The OVH API returns the advanced configuration as an object containing a "details"
+	// array (each item includes "key" and "value", plus metadata). The Terraform schema
+	// for advanced_configuration is a simple key/value map, so we flatten it here.
+	advancedCfg := make(map[string]interface{})
+
+	if detailsRaw, ok := rawCfg["details"]; ok {
+		if details, ok := detailsRaw.([]interface{}); ok {
+			for _, item := range details {
+				m, ok := item.(map[string]interface{})
+				if !ok {
+					continue
+				}
+				key, _ := m["key"].(string)
+				if key == "" {
+					continue
+				}
+				if v, exists := m["value"]; exists && v != nil {
+					advancedCfg[key] = fmt.Sprint(v)
+				}
+			}
+		}
+	} else {
+		// Backward/alternate API shapes: keep any top-level keys as strings.
+		for k, v := range rawCfg {
+			if v != nil {
+				advancedCfg[k] = fmt.Sprint(v)
+			}
+		}
+	}
+
+	if err := d.Set("advanced_configuration", advancedCfg); err != nil {
+		return fmt.Errorf("setting advanced_configuration from %s: %w", configEndpoint, err)
 	}
 
 	return nil

--- a/templates/resources/hosting_privatedatabase.md.tmpl
+++ b/templates/resources/hosting_privatedatabase.md.tmpl
@@ -25,6 +25,7 @@ Creates an OVHcloud managed private cloud database.
 The following arguments are supported:
 
 * `description` - Custom description on your privatedatabase order.
+* `advanced_configuration` - (Optional) Advanced configuration key / value.
 * `ovh_subsidiary` - (Required) OVHcloud Subsidiary. Country of OVHcloud legal entity you'll be billed by. List of supported subsidiaries available on API at [/1.0/me.json under `models.nichandle.OvhSubsidiaryEnum`](https://eu.api.ovh.com/1.0/me.json)
 * `plan` - (Required) Product Plan to order
   * `duration` - (Required) duration.
@@ -44,6 +45,7 @@ The following attributes are exported:
 * `urn` - URN of the private database, used when writing IAM policies
 * `cpu` - Number of CPU on your private database
 * `datacenter` - Datacenter where this private database is located
+* `advanced_configuration` - Advanced configuration key / value.
 * `display_name` - Name displayed in customer panel for your private database
 * `hostname` - Private database hostname
 * `hostname_ftp` - Private database FTP hostname


### PR DESCRIPTION
# Description

This pull-requests allows to handle the configurations of a Web Cloud Database (marketing name) / hosting_privatedatabase (Terraform resource type). Those configurations can be managed for ages on the APIv6 and the Manager. Now available via the Terraform provider.

Fixes #1240 (issue)

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] Documentation update

# How Has This Been Tested?

**Test Configuration**:
* Terraform version: `terraform version`: Terraform v1.12.2
* Existing HCL configuration you used: 
```hcl
resource "ovh_hosting_privatedatabase" "instance" {
  service_name           = var.ovh_privatedb_service_name
  advanced_configuration = var.ovh_privatedb_advanced_configuration
}
```
```hcl
variable "ovh_privatedb_service_name" {
  description = "OVH Private Database serviceName"
  type        = string
  default     = "xxx"
}

variable "ovh_privatedb_advanced_configuration" {
  description = "Advanced configuration key/value pairs to apply on the Private Database instance"
  type        = map(string)
  default = {
    autocommit = "ON",
    event_scheduler = "OFF",
    innodb_buffer_pool_size = "128M",
    interactive_timeout = "600",
    local_infile = "ON",
    log_bin_trust_function_creators = "OFF",
    long_query_time = "10",
    max_allowed_packet = "64M",
    max_connections = "100",
    max_user_connections = "50",
    wait_timeout = "600",
    sql_mode = "NO_ENGINE_SUBSTITUTION"
  }
}
```
`xxx` had been replaced by my existing Web Cloud Database (used to import it instead of buying a new one).
`max_allowed_packet` was set to `32M`. I ask Terrafom to set it to `64M`.
Apply:
```
Terraform will perform the following actions:

  # ovh_hosting_privatedatabase.instance will be updated in-place
  ~ resource "ovh_hosting_privatedatabase" "instance" {
      ~ advanced_configuration = {
          ~ "max_allowed_packet"              = "32M" -> "64M"
            # (11 unchanged elements hidden)
        }
        id                     = "xxx"
        # (19 unchanged attributes hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.

Do you want to perform these actions?
  Terraform will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: yes

ovh_hosting_privatedatabase.instance: Modifying... [id=xxx]
ovh_hosting_privatedatabase.instance: Modifications complete after 1s [id=xxx]

Apply complete! Resources: 0 added, 1 changed, 0 destroyed. 
```
On the Manager, I observed the `32M` value that has been changed to `64M`.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or issues
- [x] I have added acceptance tests that prove my fix is effective or that my feature works
- [x] New and existing acceptance tests pass locally with my changes
- [x] I ran successfully `go mod vendor` if I added or modify `go.mod` file