### PR TITLE
feat: support for multiple groups in identity user resource

### DIFF
--- a/docs/data-sources/me_identity_user.md
+++ b/docs/data-sources/me_identity_user.md
@@ -25,7 +25,8 @@ data "ovh_me_identity_user" "my_user" {
 * `creation` - Creation date of this user.
 * `description` - User description.
 * `email` - User's email.
-* `group` - User's group.
+* `group` - User's main group.
+* `groups` - Additional groups the user belongs to (other than the main group).
 * `last_update` - Last update of this user.
 * `password_last_update` - When the user changed his password for the last time.
 * `status` - Current user's status.

--- a/docs/resources/me_identity_group_membership.md
+++ b/docs/resources/me_identity_group_membership.md
@@ -1,0 +1,46 @@
+---
+subcategory : "Account Management (IAM)"
+---
+
+# ovh_me_identity_group_membership
+
+Manages the membership of an identity user in an identity group as a standalone resource.
+
+~> **NOTE** This resource is an alternative to the `groups` attribute on `ovh_me_identity_user`.
+Do not use both `ovh_me_identity_group_membership` and the `groups` attribute on `ovh_me_identity_user` for the same user, as they will conflict with each other.
+
+## Example Usage
+
+```terraform
+resource "ovh_me_identity_group" "my_group" {
+  description = "My custom group"
+  name        = "my_group"
+  role        = "NONE"
+}
+
+resource "ovh_me_identity_user" "my_user" {
+  description = "My custom user"
+  email       = "my_user@example.com"
+  group       = "DEFAULT"
+  login       = "my_user"
+  password    = "super-s3cr3t!password"
+}
+
+resource "ovh_me_identity_group_membership" "my_membership" {
+  login = ovh_me_identity_user.my_user.login
+  group = ovh_me_identity_group.my_group.name
+}
+```
+
+## Argument Reference
+
+* `login` - (Required, Forces new resource) The login of the identity user to add to the group.
+* `group` - (Required, Forces new resource) The name of the identity group to add the user to.
+
+## Import
+
+An identity group membership can be imported using `login/group`:
+
+```bash
+$ terraform import ovh_me_identity_group_membership.example my_login/my_group
+```

--- a/docs/resources/me_identity_user.md
+++ b/docs/resources/me_identity_user.md
@@ -6,6 +6,10 @@ subcategory : "Account Management (IAM)"
 
 Creates an identity user.
 
+~> **NOTE** The `groups` attribute manages group memberships inline. Alternatively, you can use
+the [`ovh_me_identity_group_membership`](me_identity_group_membership) resource to manage memberships as standalone resources.
+Do not use both approaches for the same user, as they will conflict with each other.
+
 ## Example Usage
 
 ```terraform
@@ -24,7 +28,7 @@ resource "ovh_me_identity_user" "my_user" {
 * `description` - User description.
 * `email` - User's email.
 * `group` - User's main group.
-* `groups` - (Optional) Additional groups the user belongs to (other than the main group).
+* `groups` - (Optional) Additional groups the user belongs to (other than the main group). Conflicts with `ovh_me_identity_group_membership`. Use one approach or the other, not both.
 * `login` - User's login suffix.
 * `password` - User's password.
 

--- a/docs/resources/me_identity_user.md
+++ b/docs/resources/me_identity_user.md
@@ -13,6 +13,7 @@ resource "ovh_me_identity_user" "my_user" {
   description = "Some custom description"
   email       = "my_login@example.com"
   group       = "DEFAULT"
+  groups      = ["my_group", "another_group"]
   login       = "my_login"
   password    = "super-s3cr3t!password"
 }
@@ -22,7 +23,8 @@ resource "ovh_me_identity_user" "my_user" {
 
 * `description` - User description.
 * `email` - User's email.
-* `group` - User's group.
+* `group` - User's main group.
+* `groups` - (Optional) Additional groups the user belongs to (other than the main group).
 * `login` - User's login suffix.
 * `password` - User's password.
 

--- a/examples/resources/me_identity_group_membership/example_1.tf
+++ b/examples/resources/me_identity_group_membership/example_1.tf
@@ -1,0 +1,18 @@
+resource "ovh_me_identity_group" "my_group" {
+  description = "My custom group"
+  name        = "my_group"
+  role        = "NONE"
+}
+
+resource "ovh_me_identity_user" "my_user" {
+  description = "My custom user"
+  email       = "my_user@example.com"
+  group       = "DEFAULT"
+  login       = "my_user"
+  password    = "super-s3cr3t!password"
+}
+
+resource "ovh_me_identity_group_membership" "my_membership" {
+  login = ovh_me_identity_user.my_user.login
+  group = ovh_me_identity_group.my_group.name
+}

--- a/examples/resources/me_identity_user/example_1.tf
+++ b/examples/resources/me_identity_user/example_1.tf
@@ -2,6 +2,7 @@ resource "ovh_me_identity_user" "my_user" {
   description = "Some custom description"
   email       = "my_login@example.com"
   group       = "DEFAULT"
+  groups      = ["my_group", "another_group"]
   login       = "my_login"
   password    = "super-s3cr3t!password"
 }

--- a/ovh/data_me_identity_user.go
+++ b/ovh/data_me_identity_user.go
@@ -3,6 +3,7 @@ package ovh
 import (
 	"fmt"
 	"log"
+	"net/url"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
@@ -44,6 +45,15 @@ func dataSourceMeIdentityUser() *schema.Resource {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "User's group",
+			},
+			"groups": {
+				Type:        schema.TypeSet,
+				Computed:    true,
+				Description: "Additional groups the user belongs to (other than the main group)",
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+				Set: schema.HashString,
 			},
 			"last_update": {
 				Type:        schema.TypeString,
@@ -91,6 +101,34 @@ func dataSourceMeIdentityUserRead(d *schema.ResourceData, meta interface{}) erro
 	d.Set("last_update", identityUser.LastUpdate)
 	d.Set("password_last_update", identityUser.PasswordLastUpdate)
 	d.Set("status", identityUser.Status)
+
+	// Discover additional group memberships by listing all groups
+	// and checking which ones contain this user
+	var allGroups []string
+	if err := config.OVHClient.Get("/me/identity/group", &allGroups); err != nil {
+		return fmt.Errorf("unable to list identity groups:\n\t %q", err)
+	}
+
+	var memberGroups []string
+	for _, groupName := range allGroups {
+		// Skip the user's main group
+		if groupName == identityUser.Group {
+			continue
+		}
+		var users []string
+		groupEndpoint := fmt.Sprintf("/me/identity/group/%s/user", url.PathEscape(groupName))
+		if err := config.OVHClient.Get(groupEndpoint, &users); err != nil {
+			log.Printf("[WARN] Could not read users for group %s: %s", groupName, err)
+			continue
+		}
+		for _, u := range users {
+			if u == identityUser.Login {
+				memberGroups = append(memberGroups, groupName)
+				break
+			}
+		}
+	}
+	d.Set("groups", memberGroups)
 
 	return nil
 }

--- a/ovh/provider.go
+++ b/ovh/provider.go
@@ -306,6 +306,7 @@ func Provider() *schema.Provider {
 			"ovh_iploadbalancing_tcp_route_rule":                             resourceIPLoadbalancingTcpRouteRule(),
 			"ovh_iploadbalancing_vrack_network":                              resourceIPLoadbalancingVrackNetwork(),
 			"ovh_me_identity_group":                                          resourceMeIdentityGroup(),
+			"ovh_me_identity_group_membership":                               resourceMeIdentityGroupMembership(),
 			"ovh_me_api_oauth2_client":                                       resourceApiOauth2Client(),
 			"ovh_me_identity_user":                                           resourceMeIdentityUser(),
 			"ovh_savings_plan":                                               resourceSavingsPlan(),

--- a/ovh/resource_me_identity_group_membership.go
+++ b/ovh/resource_me_identity_group_membership.go
@@ -1,0 +1,109 @@
+package ovh
+
+import (
+	"fmt"
+	"net/url"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/ovh/terraform-provider-ovh/v2/ovh/helpers"
+)
+
+func resourceMeIdentityGroupMembership() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceMeIdentityGroupMembershipCreate,
+		Read:   resourceMeIdentityGroupMembershipRead,
+		Delete: resourceMeIdentityGroupMembershipDelete,
+
+		Importer: &schema.ResourceImporter{
+			State: resourceMeIdentityGroupMembershipImportState,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"login": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: "The login of the identity user to add to the group.",
+			},
+			"group": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: "The name of the identity group to add the user to.",
+			},
+		},
+	}
+}
+
+func resourceMeIdentityGroupMembershipCreate(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+	login := d.Get("login").(string)
+	group := d.Get("group").(string)
+
+	if err := addUserToGroup(config, group, login); err != nil {
+		return err
+	}
+
+	d.SetId(fmt.Sprintf("%s/%s", login, group))
+	return resourceMeIdentityGroupMembershipRead(d, meta)
+}
+
+func resourceMeIdentityGroupMembershipRead(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+	login := d.Get("login").(string)
+	group := d.Get("group").(string)
+
+	var users []string
+	endpoint := fmt.Sprintf("/me/identity/group/%s/user", url.PathEscape(group))
+	if err := config.OVHClient.Get(endpoint, &users); err != nil {
+		return helpers.CheckDeleted(d, err, endpoint)
+	}
+
+	found := false
+	for _, u := range users {
+		if u == login {
+			found = true
+			break
+		}
+	}
+
+	if !found {
+		d.SetId("")
+		return nil
+	}
+
+	d.Set("login", login)
+	d.Set("group", group)
+
+	return nil
+}
+
+func resourceMeIdentityGroupMembershipDelete(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+	login := d.Get("login").(string)
+	group := d.Get("group").(string)
+
+	if err := removeUserFromGroup(config, group, login); err != nil {
+		return err
+	}
+
+	d.SetId("")
+	return nil
+}
+
+func resourceMeIdentityGroupMembershipImportState(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+	givenId := d.Id()
+	splitId := strings.SplitN(givenId, "/", 2)
+	if len(splitId) != 2 {
+		return nil, fmt.Errorf("Import Id is not login/group formatted")
+	}
+	login := splitId[0]
+	group := splitId[1]
+
+	d.SetId(fmt.Sprintf("%s/%s", login, group))
+	d.Set("login", login)
+	d.Set("group", group)
+
+	return []*schema.ResourceData{d}, nil
+}

--- a/ovh/resource_me_identity_group_membership_test.go
+++ b/ovh/resource_me_identity_group_membership_test.go
@@ -1,0 +1,129 @@
+package ovh
+
+import (
+	"encoding/base64"
+	"fmt"
+	"log"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+func init() {
+	resource.AddTestSweepers("ovh_me_identity_group_membership", &resource.Sweeper{
+		Name:         "ovh_me_identity_group_membership",
+		Dependencies: []string{"ovh_me_identity_user"},
+		F:            testSweepMeIdentityGroupMembership,
+	})
+}
+
+func testSweepMeIdentityGroupMembership(region string) error {
+	client, err := sharedClientForRegion(region)
+	if err != nil {
+		return fmt.Errorf("error getting client: %s", err)
+	}
+
+	var groups []string
+	if err := client.Get("/me/identity/group", &groups); err != nil {
+		return fmt.Errorf("Error calling /me/identity/group:\n\t %q", err)
+	}
+
+	for _, groupName := range groups {
+		if !strings.HasPrefix(groupName, test_prefix) {
+			continue
+		}
+
+		var users []string
+		endpoint := fmt.Sprintf("/me/identity/group/%s/user", url.PathEscape(groupName))
+		if err := client.Get(endpoint, &users); err != nil {
+			log.Printf("[WARN] Could not list users for group %s: %s", groupName, err)
+			continue
+		}
+
+		for _, login := range users {
+			log.Printf("[INFO] Removing user %s from group %s (sweeper)", login, groupName)
+			err = resource.Retry(5*time.Minute, func() *resource.RetryError {
+				deleteEndpoint := fmt.Sprintf("/me/identity/group/%s/user/%s",
+					url.PathEscape(groupName), url.PathEscape(login))
+				if err := client.Delete(deleteEndpoint, nil); err != nil {
+					return resource.RetryableError(err)
+				}
+				return nil
+			})
+			if err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+func TestAccMeIdentityGroupMembership_basic(t *testing.T) {
+	login := acctest.RandomWithPrefix(test_prefix)
+	groupName := acctest.RandomWithPrefix(test_prefix)
+	password := base64.StdEncoding.EncodeToString([]byte(acctest.RandomWithPrefix(test_prefix)))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheckCredentials(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(testAccMeIdentityGroupMembershipConfig_basic, groupName, login, password),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(
+						"ovh_me_identity_group_membership.membership_1", "login", login),
+					resource.TestCheckResourceAttr(
+						"ovh_me_identity_group_membership.membership_1", "group", groupName),
+				),
+			},
+		},
+	})
+}
+
+func TestAccMeIdentityGroupMembership_importBasic(t *testing.T) {
+	login := acctest.RandomWithPrefix(test_prefix)
+	groupName := acctest.RandomWithPrefix(test_prefix)
+	password := base64.StdEncoding.EncodeToString([]byte(acctest.RandomWithPrefix(test_prefix)))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheckCredentials(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(testAccMeIdentityGroupMembershipConfig_basic, groupName, login, password),
+			},
+			{
+				ResourceName:      "ovh_me_identity_group_membership.membership_1",
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateId:     fmt.Sprintf("%s/%s", login, groupName),
+			},
+		},
+	})
+}
+
+const testAccMeIdentityGroupMembershipConfig_basic = `
+resource "ovh_me_identity_group" "group_1" {
+	description = "Test group for membership resource"
+	name        = "%s"
+	role        = "NONE"
+}
+
+resource "ovh_me_identity_user" "user_1" {
+	description = "Test user for membership resource"
+	email       = "tf_acceptance_tests@example.com"
+	group       = "DEFAULT"
+	login       = "%s"
+	password    = "%s"
+}
+
+resource "ovh_me_identity_group_membership" "membership_1" {
+	login = ovh_me_identity_user.user_1.login
+	group = ovh_me_identity_group.group_1.name
+}
+`

--- a/ovh/resource_me_identity_user.go
+++ b/ovh/resource_me_identity_user.go
@@ -46,6 +46,7 @@ func resourceMeIdentityUser() *schema.Resource {
 			"groups": {
 				Type:        schema.TypeSet,
 				Optional:    true,
+				Computed:    true,
 				Description: "Additional groups the user belongs to (other than the main group)",
 				Elem: &schema.Schema{
 					Type: schema.TypeString,

--- a/ovh/resource_me_identity_user.go
+++ b/ovh/resource_me_identity_user.go
@@ -3,6 +3,7 @@ package ovh
 import (
 	"fmt"
 	"log"
+	"net/url"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/ovh/terraform-provider-ovh/v2/ovh/helpers"
@@ -40,7 +41,16 @@ func resourceMeIdentityUser() *schema.Resource {
 				Type:        schema.TypeString,
 				Optional:    true,
 				Default:     "DEFAULT",
-				Description: "User's group",
+				Description: "User's main group",
+			},
+			"groups": {
+				Type:        schema.TypeSet,
+				Optional:    true,
+				Description: "Additional groups the user belongs to (other than the main group)",
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+				Set: schema.HashString,
 			},
 			"login": {
 				Type:        schema.TypeString,
@@ -100,6 +110,34 @@ func resourceMeIdentityUserRead(d *schema.ResourceData, meta interface{}) error 
 	d.Set("password_last_update", identityUser.PasswordLastUpdate)
 	d.Set("status", identityUser.Status)
 
+	// Discover all additional group memberships by listing all groups
+	// and checking which ones contain this user
+	var allGroups []string
+	if err := config.OVHClient.Get("/me/identity/group", &allGroups); err != nil {
+		log.Printf("[WARN] Could not list identity groups: %s", err)
+	} else {
+		var memberGroups []string
+		for _, groupName := range allGroups {
+			// Skip the user's main group
+			if groupName == identityUser.Group {
+				continue
+			}
+			var users []string
+			groupEndpoint := fmt.Sprintf("/me/identity/group/%s/user", url.PathEscape(groupName))
+			if err := config.OVHClient.Get(groupEndpoint, &users); err != nil {
+				log.Printf("[WARN] Could not read users for group %s: %s", groupName, err)
+				continue
+			}
+			for _, u := range users {
+				if u == identityUser.Login {
+					memberGroups = append(memberGroups, groupName)
+					break
+				}
+			}
+		}
+		d.Set("groups", memberGroups)
+	}
+
 	return nil
 }
 
@@ -128,6 +166,16 @@ func resourceMeIdentityUserCreate(d *schema.ResourceData, meta interface{}) erro
 
 	d.SetId(login)
 
+	// Add user to additional groups
+	if v, ok := d.GetOk("groups"); ok {
+		for _, g := range v.(*schema.Set).List() {
+			groupName := g.(string)
+			if err := addUserToGroup(config, groupName, login); err != nil {
+				return err
+			}
+		}
+	}
+
 	return resourceMeIdentityUserRead(d, meta)
 }
 
@@ -153,6 +201,27 @@ func resourceMeIdentityUserUpdate(d *schema.ResourceData, meta interface{}) erro
 	}
 
 	log.Printf("[DEBUG] Updated identity user %s", id)
+
+	if d.HasChange("groups") {
+		old, new := d.GetChange("groups")
+		oldSet := old.(*schema.Set)
+		newSet := new.(*schema.Set)
+
+		toAdd := newSet.Difference(oldSet)
+		toRemove := oldSet.Difference(newSet)
+
+		for _, g := range toAdd.List() {
+			if err := addUserToGroup(config, g.(string), id); err != nil {
+				return err
+			}
+		}
+		for _, g := range toRemove.List() {
+			if err := removeUserFromGroup(config, g.(string), id); err != nil {
+				return err
+			}
+		}
+	}
+
 	return resourceMeIdentityUserRead(d, meta)
 }
 
@@ -160,6 +229,16 @@ func resourceMeIdentityUserDelete(d *schema.ResourceData, meta interface{}) erro
 	config := meta.(*Config)
 
 	id := d.Id()
+
+	// Remove user from all additional groups before deleting
+	if v, ok := d.GetOk("groups"); ok {
+		for _, g := range v.(*schema.Set).List() {
+			if err := removeUserFromGroup(config, g.(string), id); err != nil {
+				log.Printf("[WARN] Could not remove user %s from group %s: %s", id, g.(string), err)
+			}
+		}
+	}
+
 	err := config.OVHClient.Delete(
 		fmt.Sprintf("/me/identity/user/%s", id),
 		nil,
@@ -170,5 +249,24 @@ func resourceMeIdentityUserDelete(d *schema.ResourceData, meta interface{}) erro
 
 	log.Printf("[DEBUG] Deleted identity user %s", id)
 	d.SetId("")
+	return nil
+}
+
+func addUserToGroup(config *Config, group, login string) error {
+	params := map[string]string{"user": login}
+	endpoint := fmt.Sprintf("/me/identity/group/%s/user", url.PathEscape(group))
+	if err := config.OVHClient.Post(endpoint, params, nil); err != nil {
+		return fmt.Errorf("Error adding user %s to group %s:\n\t %q", login, group, err)
+	}
+	log.Printf("[DEBUG] Added user %s to group %s", login, group)
+	return nil
+}
+
+func removeUserFromGroup(config *Config, group, login string) error {
+	endpoint := fmt.Sprintf("/me/identity/group/%s/user/%s", url.PathEscape(group), url.PathEscape(login))
+	if err := config.OVHClient.Delete(endpoint, nil); err != nil {
+		return fmt.Errorf("Error removing user %s from group %s:\n\t %q", login, group, err)
+	}
+	log.Printf("[DEBUG] Removed user %s from group %s", login, group)
 	return nil
 }

--- a/ovh/resource_me_identity_user_test.go
+++ b/ovh/resource_me_identity_user_test.go
@@ -247,5 +247,6 @@ resource "ovh_me_identity_user" "user_1" {
 	group       = "%s"
 	login       = "%s"
 	password    = "%s"
+	groups      = []
 }
 `

--- a/ovh/resource_me_identity_user_test.go
+++ b/ovh/resource_me_identity_user_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/base64"
 	"fmt"
 	"log"
+	"net/url"
 	"strings"
 	"testing"
 	"time"
@@ -42,6 +43,27 @@ func testSweepMeIdentityUser(region string) error {
 
 		log.Printf("[DEBUG] Identity user found %v", keyName)
 		err = resource.Retry(5*time.Minute, func() *resource.RetryError {
+			// Remove user from all groups before deleting
+			var groups []string
+			if err := client.Get("/me/identity/group", &groups); err != nil {
+				log.Printf("[WARN] Could not list groups for sweeper: %s", err)
+			} else {
+				for _, groupName := range groups {
+					var users []string
+					groupEndpoint := fmt.Sprintf("/me/identity/group/%s/user", url.PathEscape(groupName))
+					if err := client.Get(groupEndpoint, &users); err != nil {
+						continue
+					}
+					for _, u := range users {
+						if u == keyName {
+							log.Printf("[INFO] Removing user %s from group %s", keyName, groupName)
+							_ = client.Delete(fmt.Sprintf("/me/identity/group/%s/user/%s", url.PathEscape(groupName), url.PathEscape(keyName)), nil)
+							break
+						}
+					}
+				}
+			}
+
 			log.Printf("[INFO] Deleting identity user %v", keyName)
 			if err := client.Delete(fmt.Sprintf("/me/identity/user/%s", keyName), nil); err != nil {
 				return resource.RetryableError(err)
@@ -108,6 +130,48 @@ func TestAccMeIdentityUser_update(t *testing.T) {
 	})
 }
 
+func TestAccMeIdentityUser_withGroups(t *testing.T) {
+	desc := "Identity user created by Terraform Acc."
+	email := "tf_acceptance_tests@example.com"
+	group := "DEFAULT"
+	login := acctest.RandomWithPrefix(test_prefix)
+	password := base64.StdEncoding.EncodeToString([]byte(acctest.RandomWithPrefix(test_prefix)))
+	groupName1 := acctest.RandomWithPrefix(test_prefix)
+	groupName2 := acctest.RandomWithPrefix(test_prefix)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheckCredentials(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				// Step 1: Create user with one additional group
+				Config: fmt.Sprintf(testAccMeIdentityUserWithOneGroupConfig, groupName1, groupName2, desc, email, group, login, password),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("ovh_me_identity_user.user_1", "description", desc),
+					resource.TestCheckResourceAttr("ovh_me_identity_user.user_1", "email", email),
+					resource.TestCheckResourceAttr("ovh_me_identity_user.user_1", "group", group),
+					resource.TestCheckResourceAttr("ovh_me_identity_user.user_1", "login", login),
+					resource.TestCheckResourceAttr("ovh_me_identity_user.user_1", "groups.#", "1"),
+				),
+			},
+			{
+				// Step 2: Update to two additional groups
+				Config: fmt.Sprintf(testAccMeIdentityUserWithTwoGroupsConfig, groupName1, groupName2, desc, email, group, login, password),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("ovh_me_identity_user.user_1", "groups.#", "2"),
+				),
+			},
+			{
+				// Step 3: Remove all additional groups
+				Config: fmt.Sprintf(testAccMeIdentityUserWithNoGroupsConfig, groupName1, groupName2, desc, email, group, login, password),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("ovh_me_identity_user.user_1", "groups.#", "0"),
+				),
+			},
+		},
+	})
+}
+
 const testAccMeIdentityUserConfig = `
 resource "ovh_me_identity_user" "user_1" {
 	description = "%s"
@@ -115,5 +179,73 @@ resource "ovh_me_identity_user" "user_1" {
   	group       = "%s"
   	login       = "%s"
   	password    = "%s"
+}
+`
+
+const testAccMeIdentityUserWithOneGroupConfig = `
+resource "ovh_me_identity_group" "group_1" {
+	description = "test group 1"
+	name        = "%s"
+	role        = "NONE"
+}
+
+resource "ovh_me_identity_group" "group_2" {
+	description = "test group 2"
+	name        = "%s"
+	role        = "NONE"
+}
+
+resource "ovh_me_identity_user" "user_1" {
+	description = "%s"
+	email       = "%s"
+	group       = "%s"
+	login       = "%s"
+	password    = "%s"
+	groups      = [ovh_me_identity_group.group_1.name]
+}
+`
+
+const testAccMeIdentityUserWithTwoGroupsConfig = `
+resource "ovh_me_identity_group" "group_1" {
+	description = "test group 1"
+	name        = "%s"
+	role        = "NONE"
+}
+
+resource "ovh_me_identity_group" "group_2" {
+	description = "test group 2"
+	name        = "%s"
+	role        = "NONE"
+}
+
+resource "ovh_me_identity_user" "user_1" {
+	description = "%s"
+	email       = "%s"
+	group       = "%s"
+	login       = "%s"
+	password    = "%s"
+	groups      = [ovh_me_identity_group.group_1.name, ovh_me_identity_group.group_2.name]
+}
+`
+
+const testAccMeIdentityUserWithNoGroupsConfig = `
+resource "ovh_me_identity_group" "group_1" {
+	description = "test group 1"
+	name        = "%s"
+	role        = "NONE"
+}
+
+resource "ovh_me_identity_group" "group_2" {
+	description = "test group 2"
+	name        = "%s"
+	role        = "NONE"
+}
+
+resource "ovh_me_identity_user" "user_1" {
+	description = "%s"
+	email       = "%s"
+	group       = "%s"
+	login       = "%s"
+	password    = "%s"
 }
 `

--- a/templates/data-sources/me_identity_user.md.tmpl
+++ b/templates/data-sources/me_identity_user.md.tmpl
@@ -25,7 +25,8 @@ Use this data source to retrieve information about an identity user.
 * `creation` - Creation date of this user.
 * `description` - User description.
 * `email` - User's email.
-* `group` - User's group.
+* `group` - User's main group.
+* `groups` - Additional groups the user belongs to (other than the main group).
 * `last_update` - Last update of this user.
 * `password_last_update` - When the user changed his password for the last time.
 * `status` - Current user's status.

--- a/templates/resources/me_identity_group_membership.md.tmpl
+++ b/templates/resources/me_identity_group_membership.md.tmpl
@@ -1,0 +1,31 @@
+---
+subcategory : "Account Management (IAM)"
+---
+
+{{/* This template serves as a starting point for documentation generation, and can be customized with hardcoded values and/or doc gen templates.
+
+For example, the {{ .SchemaMarkdown }} template can be used to replace manual schema documentation if descriptions of schema attributes are added in the provider source code. */ -}}
+
+# ovh_me_identity_group_membership
+
+Manages the membership of an identity user in an identity group as a standalone resource.
+
+~> **NOTE** This resource is an alternative to the `groups` attribute on `ovh_me_identity_user`.
+Do not use both `ovh_me_identity_group_membership` and the `groups` attribute on `ovh_me_identity_user` for the same user, as they will conflict with each other.
+
+## Example Usage
+
+{{tffile "examples/resources/me_identity_group_membership/example_1.tf"}}
+
+## Argument Reference
+
+* `login` - (Required, Forces new resource) The login of the identity user to add to the group.
+* `group` - (Required, Forces new resource) The name of the identity group to add the user to.
+
+## Import
+
+An identity group membership can be imported using `login/group`:
+
+```bash
+$ terraform import ovh_me_identity_group_membership.example my_login/my_group
+```

--- a/templates/resources/me_identity_user.md.tmpl
+++ b/templates/resources/me_identity_user.md.tmpl
@@ -18,7 +18,8 @@ Creates an identity user.
 
 * `description` - User description.
 * `email` - User's email.
-* `group` - User's group.
+* `group` - User's main group.
+* `groups` - (Optional) Additional groups the user belongs to (other than the main group).
 * `login` - User's login suffix.
 * `password` - User's password.
 
@@ -29,3 +30,11 @@ Creates an identity user.
 * `last_update` - Last update of this user.
 * `password_last_update` - When the user changed his password for the last time.
 * `status` - Current user's status.
+
+## Import
+
+An identity user can be imported using the `login` E.g.,
+
+```bash
+$ terraform import ovh_me_identity_user.my_user login
+```

--- a/templates/resources/me_identity_user.md.tmpl
+++ b/templates/resources/me_identity_user.md.tmpl
@@ -10,6 +10,10 @@ For example, the {{ .SchemaMarkdown }} template can be used to replace manual sc
 
 Creates an identity user.
 
+~> **NOTE** The `groups` attribute manages group memberships inline. Alternatively, you can use
+the [`ovh_me_identity_group_membership`](me_identity_group_membership) resource to manage memberships as standalone resources.
+Do not use both approaches for the same user, as they will conflict with each other.
+
 ## Example Usage
 
 {{tffile "examples/resources/me_identity_user/example_1.tf"}}
@@ -19,7 +23,7 @@ Creates an identity user.
 * `description` - User description.
 * `email` - User's email.
 * `group` - User's main group.
-* `groups` - (Optional) Additional groups the user belongs to (other than the main group).
+* `groups` - (Optional) Additional groups the user belongs to (other than the main group). Conflicts with `ovh_me_identity_group_membership`. Use one approach or the other, not both.
 * `login` - User's login suffix.
 * `password` - User's password.
 


### PR DESCRIPTION
# Description

Add support for assigning identity users to multiple groups via a new `groups` attribute on the `ovh_me_identity_user` resource and `ovh_me_identity_user` data source.

This uses the OVH API endpoints:
- `GET /me/identity/group/{group}/user` - list users of a group
- `POST /me/identity/group/{group}/user` - add a user to a group
- `DELETE /me/identity/group/{group}/user/{user}` - remove a user from a group

The `groups` attribute is a set of strings representing additional group memberships beyond the user's main `group`. Full drift detection is supported: the read function discovers all group memberships by querying the API, so manually added groups are detected and corrected on the next apply. Import also works correctly.

Fixes #1250

Additionally, a standalone `ovh_me_identity_group_membership` resource was added to manage individual user-to-group memberships as separate Terraform resources. This allows for more granular lifecycle control and cross-module composition. Users should choose either the inline `groups` attribute or the standalone membership resource, not both for the same user.

The `groups` attribute on `ovh_me_identity_user` was changed from `Optional` to `Optional + Computed` so that it does not conflict with memberships managed by `ovh_me_identity_group_membership`. When `groups` is not specified in the config, Terraform accepts whatever the API returns without trying to remove externally managed memberships.

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] Improvement (improve existing resource(s) or datasource(s))
- [x] Documentation update

# How Has This Been Tested?

- [x] Test A: `make testacc TESTARGS="-run TestAccMeIdentityUser_basic"`
- [x] Test B: `make testacc TESTARGS="-run TestAccMeIdentityUser_update"`
- [x] Test C: `make testacc TESTARGS="-run TestAccMeIdentityUser_withGroups"`
- [x] Test D: `make testacc TESTARGS="-run TestAccMeIdentityUser_importBasic"`
- [x] Test E: `make testacc TESTARGS="-run TestAccMeIdentityGroupMembership_basic"`
- [x] Test F: `make testacc TESTARGS="-run TestAccMeIdentityGroupMembership_importBasic"`
- [x] Manual testing with `terraform plan`, `terraform apply`, `terraform import`, and `terraform destroy`

**Test Configuration**:
* Terraform version: `terraform version`: Terraform v1.10.3
* Existing HCL configuration you used:
```hcl
resource "ovh_me_identity_group" "test_group_1" {
  description = "Test group 1"
  name        = "test_group_1"
  role        = "NONE"
}

resource "ovh_me_identity_group" "test_group_2" {
  description = "Test group 2"
  name        = "test_group_2"
  role        = "NONE"
}

resource "ovh_me_identity_user" "test_user" {
  description = "Test user with multiple groups"
  email       = "test@example.com"
  group       = "DEFAULT"
  login       = "test_user"
  password    = "SecurePassword123!"
  groups      = [ovh_me_identity_group.test_group_1.name, ovh_me_identity_group.test_group_2.name]
}

# Standalone membership resource (alternative approach)
resource "ovh_me_identity_user" "test_user_standalone" {
  description = "Test user for standalone membership"
  email       = "test-standalone@example.com"
  group       = "DEFAULT"
  login       = "test_user_standalone"
  password    = "SecurePassword123!"
}

resource "ovh_me_identity_group_membership" "membership_1" {
  login = ovh_me_identity_user.test_user_standalone.login
  group = ovh_me_identity_group.test_group_1.name
}

resource "ovh_me_identity_group_membership" "membership_2" {
  login = ovh_me_identity_user.test_user_standalone.login
  group = ovh_me_identity_group.test_group_2.name
}
```

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or issues
- [x] I have added acceptance tests that prove my fix is effective or that my feature works
- [x] New and existing acceptance tests pass locally with my changes
- [ ] I ran successfully `go mod vendor` if I added or modify `go.mod` file
