### PR TITLE
feat(VPS): add data sources for VPS images

### DIFF
--- a/ovh/data_vps_available_image.go
+++ b/ovh/data_vps_available_image.go
@@ -1,0 +1,47 @@
+package ovh
+
+import (
+	"fmt"
+	"net/url"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func dataSourceVPSAvailableImage() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceVPSAvailableImageRead,
+		Schema: map[string]*schema.Schema{
+			"service_name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"image_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+		},
+	}
+}
+
+func dataSourceVPSAvailableImageRead(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+	serviceName := d.Get("service_name").(string)
+	imageId := d.Get("image_id").(string)
+	image := &VPSImage{}
+	err := config.OVHClient.Get(
+		fmt.Sprintf(
+			"/vps/%s/images/available/%s",
+			url.PathEscape(serviceName),
+			url.PathEscape(imageId),
+		),
+		&image,
+	)
+
+	if err != nil {
+		return nil
+	}
+
+	d.Set("image", image)
+
+	return nil
+}

--- a/ovh/data_vps_available_image_test.go
+++ b/ovh/data_vps_available_image_test.go
@@ -1,0 +1,41 @@
+package ovh
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+func TestAccVPSAvailableImageDataSource_basic(t *testing.T) {
+	vps := os.Getenv("OVH_VPS")
+	config := fmt.Sprintf(testAccVPSAvailableImageDatasourceConfig_Basic, vps, vps)
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheckVPS(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(
+						"data.ovh_vps_available_images.available_images", "service_name", vps),
+					resource.TestCheckResourceAttrSet(
+						"data.ovh_vps_available_images.available_images", "image_ids.#"),
+				),
+			},
+		},
+	})
+}
+
+const testAccVPSAvailableImageDatasourceConfig_Basic = `
+data "ovh_vps_available_images" "available_images" {
+  service_name = "%s"
+}
+
+data "ovh_vps_available_image" "all_images" {
+  for_each     = toset(data.ovh_vps_available_images.available_images.image_ids)
+  service_name = "%s"
+  image_id     = each.value
+}
+`

--- a/ovh/data_vps_available_images.go
+++ b/ovh/data_vps_available_images.go
@@ -1,0 +1,45 @@
+package ovh
+
+import (
+	"fmt"
+	"net/url"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func dataSourceVPSAvailableImages() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceVPSAvailableImagesRead,
+		Schema: map[string]*schema.Schema{
+			"service_name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"image_ids": {
+				Type:     schema.TypeList,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func dataSourceVPSAvailableImagesRead(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+	serviceName := d.Get("service_name").(string)
+	imageIds := make([]string, 0)
+	err := config.OVHClient.Get(
+		fmt.Sprintf(
+			"/vps/%s/images/available",
+			url.PathEscape(serviceName),
+		),
+		&imageIds,
+	)
+
+	if err != nil {
+		return nil
+	}
+
+	d.Set("image_ids", imageIds)
+
+	return nil
+}

--- a/ovh/data_vps_available_images_test.go
+++ b/ovh/data_vps_available_images_test.go
@@ -1,0 +1,36 @@
+package ovh
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+func TestAccVPSAvailableImagesDataSource_basic(t *testing.T) {
+	vps := os.Getenv("OVH_VPS")
+	config := fmt.Sprintf(testAccVPSAvailableImagesDatasourceConfig_Basic, vps)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheckVPS(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(
+						"data.ovh_vps_available_images.available_images", "service_name", vps),
+					resource.TestCheckResourceAttrSet(
+						"data.ovh_vps_available_images.available_images", "image_ids"),
+				),
+			},
+		},
+	})
+}
+
+const testAccVPSAvailableImagesDatasourceConfig_Basic = `
+data "ovh_vps_available_images" "available_images" {
+  service_name  = "%s"
+}
+`

--- a/ovh/provider.go
+++ b/ovh/provider.go
@@ -211,6 +211,8 @@ func Provider() *schema.Provider {
 			"ovh_order_cart_product_options_plan":                            dataSourceOrderCartProductOptionsPlan(),
 			"ovh_order_cart_product_plan":                                    dataSourceOrderCartProductPlan(),
 			"ovh_vps":                                                        dataSourceVPS(),
+			"ovh_vps_available_images":                                       dataSourceVPSAvailableImages(),
+			"ovh_vps_available_image":                                        dataSourceVPSAvailableImage(),
 			"ovh_vpss":                                                       dataSourceVPSs(),
 			"ovh_vracks":                                                     dataSourceVracks(),
 		},

--- a/ovh/types_vps.go
+++ b/ovh/types_vps.go
@@ -41,6 +41,11 @@ type VPSProperties struct {
 	DisplayName    *string `json:"displayName"`
 }
 
+type VPSImage struct {
+	ID   string `json:"id"`
+	Name string `json:"name"`
+}
+
 func ovhvps_getType(offertype string, model_name string, model_version string) string {
 	var offertypeToOfferPrefix = make(map[string]string)
 	offertypeToOfferPrefix["cloud"] = "ceph-nvme"


### PR DESCRIPTION
# Description

This pull request introduces two new data sources to assist with the automation of creating VPS' with the OVH Terraform provider. 

These data sources include the following:

`ovh_vps_available_images` - returns the available image IDs for the given VPS
`ovh_vps_available_image` - returns the name of the given image ID

Whilst not ideal, a Terraform setup could look like the following:
```vps_create/main.tf
data "ovh_me" "my_account" {}

resource "ovh_vps" "my_vps" {
  display_name   = "dev_vps"
  ovh_subsidiary = data.ovh_me.my_account.ovh_subsidiary

  plan = [
    {
      duration     = "P1M"
      plan_code    = "vps-le-2-2-40"
      pricing_mode = "default"

      configuration = [
        {
          label = "vps_datacenter"
          value = "WAW"
        },
        {
          label = "vps_os"
          value = "Debian 13"
        }
      ]
    }
  ]
}

output "service_name" {
  value = ovh_vps.my_vps.service_name
}
```

```vps_install/main.tf
data "ovh_me" "my_account" {}

data "ovh_vps_available_images" "available_images" {
  service_name = var.service_name
}

data "ovh_vps_available_image" "all_images" {
  for_each     = toset(data.ovh_vps_available_images.available_images.image_ids)
  service_name = var.service_name
  image_id     = each.value
}

locals {
  matched_image = one(values({
    for id, image in data.ovh_vps_available_image.all_images :
    id => image
    if strcontains(image.name, "Debian 13")
  }))
}

resource "ovh_vps" "my_vps" {
  service_name   = var.service_name
  display_name   = "dev_vps"
  ovh_subsidiary = data.ovh_me.my_account.ovh_subsidiary
  image_id       = local.matched_image.id
  public_ssh_key = var.public_ssh_key

  plan = [
    {
      duration     = "P1M"
      plan_code    = "vps-le-2-2-40"
      pricing_mode = "default"

      configuration = [
        {
          label = "vps_datacenter"
          value = "WAW"
        },
        {
          label = "vps_os"
          value = "Debian 13"
        }
      ]
    }
  ]
}
```

Fixes #xx (issue)

## Type of change

Please delete options that are not relevant.
- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

Yet to perform tests, planning on doing so in the coming days.

- [ ] Test A: `make testacc TESTARGS="-run TestAccVPSAvailableImagesDataSource_basic"`
- [ ] Test B: `make testacc TESTARGS="-run TestAccVPSAvailableImageDataSource_basic"`

**Test Configuration**:
* Terraform version: `terraform version`: Terraform vx.y.z
* Existing HCL configuration you used: 
```hcl
resource "" "" {
 xx = "yy"
 zz = "aa"
}
```

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings or issues
- [ ] I have added acceptance tests that prove my fix is effective or that my feature works
- [ ] New and existing acceptance tests pass locally with my changes
- [ ] I ran successfully `go mod vendor` if I added or modify `go.mod` file
