### PR TITLE
Fix: Populate network_id and subnet_id in gateway Read function

### DIFF
--- a/docs/resources/cloud_project_gateway.md
+++ b/docs/resources/cloud_project_gateway.md
@@ -73,8 +73,6 @@ The following attributes are exported:
 ## Import
 
 A gateway can be imported using the `service_name`, `region` and `id` (identifier of the gateway) properties, separated by a `/`.
-However, please note that in the case of a gateway import, `network_id` and `subnet_id` values used at gateway creation are not injected back in the state.
-If you want to define these properties on your imported resource, you have to add an "ignore_changes" lifecycle argument in order not to trigger a recreation, as suggested in the following example. 
 
 ```terraform
 resource "ovh_cloud_project_gateway" "imported_gateway" {
@@ -84,9 +82,6 @@ resource "ovh_cloud_project_gateway" "imported_gateway" {
   region       = "<my-region>"
   network_id   = "<my-imported-gateway-network-id>"
   subnet_id    = "<my-imported-gateway-subnet-id>"
-  lifecycle {
-    ignore_changes = [network_id, subnet_id]
-  }
 }
 
 import {

--- a/ovh/resource_cloud_project_gateway.go
+++ b/ovh/resource_cloud_project_gateway.go
@@ -225,6 +225,13 @@ func resourceCloudProjectGatewayRead(d *schema.ResourceData, meta interface{}) e
 	d.SetId(r.Id)
 	d.Set("service_name", serviceName)
 
+	// Set network_id and subnet_id from the first interface (private network)
+	// These are ForceNew fields that must be tracked in state for proper lifecycle management
+	if len(r.Interfaces) > 0 {
+		d.Set("network_id", r.Interfaces[0].NetworkId)
+		d.Set("subnet_id", r.Interfaces[0].SubnetId)
+	}
+
 	externalInfos := make([]map[string]interface{}, 0)
 	if r.ExternalInformation != nil {
 		externalInfo := make(map[string]interface{})

--- a/ovh/resource_cloud_project_gateway_test.go
+++ b/ovh/resource_cloud_project_gateway_test.go
@@ -84,11 +84,10 @@ func TestAccCloudProjectGateway(t *testing.T) {
 				),
 			},
 			{
-				ResourceName:            "ovh_cloud_project_gateway.gateway",
-				ImportState:             true,
-				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"network_id", "subnet_id"},
-				ImportStateIdFunc:       testAccCloudProjectGatewayImportId("ovh_cloud_project_gateway.gateway"),
+				ResourceName:      "ovh_cloud_project_gateway.gateway",
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testAccCloudProjectGatewayImportId("ovh_cloud_project_gateway.gateway"),
 			},
 			{
 				Config: config,


### PR DESCRIPTION
# Fix: Populate network_id and subnet_id in gateway Read function

## Description

This PR fixes an issue where `network_id` and `subnet_id` fields were not being populated in the Terraform state for `ovh_cloud_project_gateway` resources, causing drift detection and unnecessary resource replacements.

Fixes #1273

## Changes

### 1. Resource Implementation (`ovh/resource_cloud_project_gateway.go`)

Added code to extract and set `network_id` and `subnet_id` from the gateway's interfaces array in the Read function:

```go
// Set network_id and subnet_id from the first interface (private network)
// These are ForceNew fields that must be tracked in state for proper lifecycle management
if len(r.Interfaces) > 0 {
    d.Set("network_id", r.Interfaces[0].NetworkId)
    d.Set("subnet_id", r.Interfaces[0].SubnetId)
}
```

**Why this works:**
- The OVH API returns gateway information with an `interfaces` array
- The first interface (index 0) contains the private network connection details
- `network_id` and `subnet_id` are available in `interfaces[0]`
- These values match what was provided during creation

### 2. Documentation (`docs/resources/cloud_project_gateway.md`)

Removed the `ignore_changes` workaround from the import documentation, as it's no longer necessary.

**Before:**
```hcl
lifecycle {
  ignore_changes = [network_id, subnet_id]
}
```

**After:** No lifecycle block needed! ✅

### 3. Tests (`ovh/resource_cloud_project_gateway_test.go`)

Removed `ImportStateVerifyIgnore` for `network_id` and `subnet_id`, as these fields are now correctly populated during import and can be verified.

**Before:**
```go
ImportStateVerifyIgnore: []string{"network_id", "subnet_id"},
```

**After:** Full state verification enabled! ✅

## Testing

### ✅ Acceptance Tests

```bash
$ TF_ACC=1 go test -v -run TestAccCloudProjectGateway ./ovh -timeout 30m
=== RUN   TestAccCloudProjectGateway
--- PASS: TestAccCloudProjectGateway (100.52s)
PASS
```

The acceptance test validates:
- Gateway creation with network_id and subnet_id properly set
- Import functionality with full state verification
- No drift detection after creation or import

### ✅ Manual Testing

Tested with Terraform configuration:

1. **Create test**: Gateway created successfully, network_id and subnet_id populated in state
2. **Drift test**: Subsequent `terraform plan` shows "No changes"
3. **Import test**: Gateway imported successfully, fields populated, no drift detected

## Impact

### Before this fix:
- ❌ `network_id` and `subnet_id` not in state
- ❌ Terraform detects drift on every plan
- ❌ Users forced to use `ignore_changes` workaround
- ❌ Actual drift cannot be detected
- ❌ Import requires manual lookup and workarounds

### After this fix:
- ✅ `network_id` and `subnet_id` correctly populated
- ✅ No false drift detection
- ✅ No `ignore_changes` workaround needed
- ✅ Actual drift can be detected
- ✅ Clean import experience

## Breaking Changes

None. This is a bug fix that makes the resource work as originally intended. The `ignore_changes` workaround in user configurations will continue to work but is no longer necessary.

## Migration Guide

If you're currently using the `ignore_changes` workaround:

```hcl
resource "ovh_cloud_project_gateway" "example" {
  # ... configuration ...

  lifecycle {
    ignore_changes = [network_id, subnet_id]  # ← Can be removed!
  }
}
```

You can safely remove the lifecycle block after upgrading to this version. The fields will now be properly tracked in state.

## Checklist

- [x] Code changes implemented
- [x] Documentation updated
- [x] Acceptance tests pass
- [x] Manual testing completed
- [x] Import functionality verified
- [x] No breaking changes introduced