### PR TITLE
fix: Retry calls to Logs Data Platform streams and aliases

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,7 @@ export OVH_DOMAIN_DS_RECORD_PUBLIC_KEY_TEST="..."
 export OVH_DOMAIN_DS_RECORD_TAG_TEST="..."
 export OVH_OKMS="..."
 export OVH_STORAGE_EFS_SERVICE_TEST="..."
+export OVH_DBAAS_LOGS_SERVICE_TEST="..."
 
 $ make testacc
 ```

--- a/ovh/dbaas_logs_operation.go
+++ b/ovh/dbaas_logs_operation.go
@@ -9,8 +9,11 @@ import (
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
+
 	"github.com/ovh/terraform-provider-ovh/v2/ovh/ovhwrap"
 )
+
+const DBAAS_LOGS_BUSY_ERROR = "Client::Forbidden::Busy"
 
 func waitForDbaasLogsOperation(ctx context.Context, c *ovhwrap.Client, serviceName, id string) (*DbaasLogsOperation, error) {
 	// Wait for operation status

--- a/ovh/resource_dbaas_logs_output_graylog_stream.go
+++ b/ovh/resource_dbaas_logs_output_graylog_stream.go
@@ -6,9 +6,13 @@ import (
 	"log"
 	"net/url"
 	"strings"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/ovh/go-ovh/ovh"
+
 	"github.com/ovh/terraform-provider-ovh/v2/ovh/helpers"
 )
 
@@ -235,8 +239,18 @@ func resourceDbaasLogsOutputGraylogStreamCreate(ctx context.Context, d *schema.R
 		"/dbaas/logs/%s/output/graylog/stream",
 		url.PathEscape(serviceName),
 	)
-	if err := config.OVHClient.Post(endpoint, opts, res); err != nil {
-		return diag.Errorf("Error calling post %s:\n\t %q", endpoint, err)
+	err := retry.Retry(d.Timeout(schema.TimeoutCreate)-time.Minute, func() *retry.RetryError {
+		err := config.OVHClient.Post(endpoint, opts, res)
+		if err != nil {
+			if errOvh, ok := err.(*ovh.APIError); ok && errOvh.Class == DBAAS_LOGS_BUSY_ERROR {
+				return retry.RetryableError(err)
+			}
+			return retry.NonRetryableError(err)
+		}
+		return nil
+	})
+	if err != nil {
+		return diag.Errorf("Error creating stream, calling POST %s:\n\t %q", endpoint, err)
 	}
 
 	// Wait for operation status
@@ -358,7 +372,17 @@ func resourceDbaasLogsOutputGraylogStreamDelete(ctx context.Context, d *schema.R
 		url.PathEscape(id),
 	)
 
-	if err := config.OVHClient.Delete(endpoint, res); err != nil {
+	err := retry.Retry(d.Timeout(schema.TimeoutDelete)-time.Minute, func() *retry.RetryError {
+		err := config.OVHClient.Delete(endpoint, res)
+		if err != nil {
+			if errOvh, ok := err.(*ovh.APIError); ok && errOvh.Class == DBAAS_LOGS_BUSY_ERROR {
+				return retry.RetryableError(err)
+			}
+			return retry.NonRetryableError(err)
+		}
+		return nil
+	})
+	if err != nil {
 		return diag.FromErr(helpers.CheckDeleted(d, err, endpoint))
 	}
 

--- a/ovh/resource_dbaas_logs_output_opensearch_alias.go
+++ b/ovh/resource_dbaas_logs_output_opensearch_alias.go
@@ -6,11 +6,15 @@ import (
 	"log"
 	"net/url"
 	"strings"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/ovh/terraform-provider-ovh/v2/ovh/helpers"
+	"github.com/ovh/go-ovh/ovh"
 	"golang.org/x/exp/slices"
+
+	"github.com/ovh/terraform-provider-ovh/v2/ovh/helpers"
 )
 
 func resourceDbaasLogsOutputOpensearchAlias() *schema.Resource {
@@ -130,8 +134,18 @@ func resourceDbaasLogsOutputOpensearchAliasCreate(ctx context.Context, d *schema
 		"/dbaas/logs/%s/output/opensearch/alias",
 		url.PathEscape(serviceName),
 	)
-	if err := config.OVHClient.Post(endpoint, opts, res); err != nil {
-		return diag.Errorf("Error calling post %s:\n\t %q", endpoint, err)
+	err := retry.Retry(d.Timeout(schema.TimeoutCreate)-time.Minute, func() *retry.RetryError {
+		err := config.OVHClient.Post(endpoint, opts, res)
+		if err != nil {
+			if errOvh, ok := err.(*ovh.APIError); ok && errOvh.Class == DBAAS_LOGS_BUSY_ERROR {
+				return retry.RetryableError(err)
+			}
+			return retry.NonRetryableError(err)
+		}
+		return nil
+	})
+	if err != nil {
+		return diag.Errorf("Error creating alias, calling POST %s:\n\t %q", endpoint, err)
 	}
 
 	// Wait for operation status
@@ -155,7 +169,7 @@ func resourceDbaasLogsOutputOpensearchAliasCreate(ctx context.Context, d *schema
 	}
 	streams := d.Get("streams").(*schema.Set)
 	for _, stream := range streams.List() {
-		if err = resourceDbaasLogsOutputOpensearchAliasAttachStream(ctx, config, serviceName, *id, stream.(string)); err != nil {
+		if err = resourceDbaasLogsOutputOpensearchAliasAttachStream(ctx, d, config, serviceName, *id, stream.(string)); err != nil {
 			return diag.FromErr(err)
 		}
 	}
@@ -219,14 +233,14 @@ func resourceDbaasLogsOutputOpensearchAliasUpdate(ctx context.Context, d *schema
 		newStreams := newStreamsSet.List()
 		for _, idx := range oldStreams {
 			if !slices.Contains(newStreams, idx) {
-				if err := resourceDbaasLogsOutputOpensearchAliasDetachStream(ctx, config, serviceName, id, idx.(string)); err != nil {
+				if err := resourceDbaasLogsOutputOpensearchAliasDetachStream(ctx, d, config, serviceName, id, idx.(string)); err != nil {
 					return diag.FromErr(err)
 				}
 			}
 		}
 		for _, idx := range newStreams {
 			if !slices.Contains(oldStreams, idx) {
-				if err := resourceDbaasLogsOutputOpensearchAliasAttachStream(ctx, config, serviceName, id, idx.(string)); err != nil {
+				if err := resourceDbaasLogsOutputOpensearchAliasAttachStream(ctx, d, config, serviceName, id, idx.(string)); err != nil {
 					return diag.FromErr(err)
 				}
 			}
@@ -291,7 +305,7 @@ func resourceDbaasLogsOutputOpensearchAliasDelete(ctx context.Context, d *schema
 	}
 	streams := d.Get("streams").(*schema.Set)
 	for _, stream := range streams.List() {
-		if err := resourceDbaasLogsOutputOpensearchAliasDetachStream(ctx, config, serviceName, id, stream.(string)); err != nil {
+		if err := resourceDbaasLogsOutputOpensearchAliasDetachStream(ctx, d, config, serviceName, id, stream.(string)); err != nil {
 			return diag.FromErr(err)
 		}
 	}
@@ -304,7 +318,18 @@ func resourceDbaasLogsOutputOpensearchAliasDelete(ctx context.Context, d *schema
 		url.PathEscape(id),
 	)
 
-	if err := config.OVHClient.Delete(endpoint, res); err != nil {
+	err := retry.Retry(d.Timeout(schema.TimeoutDelete)-time.Minute, func() *retry.RetryError {
+		err := config.OVHClient.Delete(endpoint, res)
+		if err != nil {
+			if errOvh, ok := err.(*ovh.APIError); ok && errOvh.Class == DBAAS_LOGS_BUSY_ERROR {
+				return retry.RetryableError(err)
+			}
+			return retry.NonRetryableError(err)
+		}
+		return nil
+	})
+
+	if err != nil {
 		return diag.FromErr(helpers.CheckDeleted(d, err, endpoint))
 	}
 
@@ -349,15 +374,25 @@ func resourceDbaasLogsOutputOpensearchAliasDetachIndex(ctx context.Context, conf
 	return nil
 }
 
-func resourceDbaasLogsOutputOpensearchAliasAttachStream(ctx context.Context, config *Config, serviceName, aliasID, streamId string) error {
+func resourceDbaasLogsOutputOpensearchAliasAttachStream(ctx context.Context, d *schema.ResourceData, config *Config, serviceName, aliasID, streamId string) error {
 	endpoint := fmt.Sprintf("/dbaas/logs/%s/output/opensearch/alias/%s/stream", url.PathEscape(serviceName), url.PathEscape(aliasID))
 	res := &DbaasLogsOperation{}
 
-	if err := config.OVHClient.Post(endpoint, &DbaasLogsOutputOpensearchAliasStreamCreate{StreamID: streamId}, &res); err != nil {
-		return fmt.Errorf("Error calling post %s:\n\t %q", endpoint, err)
+	err := retry.Retry(d.Timeout(schema.TimeoutCreate)-time.Minute, func() *retry.RetryError {
+		err := config.OVHClient.Post(endpoint, &DbaasLogsOutputOpensearchAliasStreamCreate{StreamID: streamId}, &res)
+		if err != nil {
+			if errOvh, ok := err.(*ovh.APIError); ok && errOvh.Class == DBAAS_LOGS_BUSY_ERROR {
+				return retry.RetryableError(err)
+			}
+			return retry.NonRetryableError(err)
+		}
+		return nil
+	})
+	if err != nil {
+		return fmt.Errorf("Error attaching stream, calling POST %s:\n\t %q", endpoint, err)
 	}
 
-	_, err := waitForDbaasLogsOperation(ctx, config.OVHClient, serviceName, res.OperationId)
+	_, err = waitForDbaasLogsOperation(ctx, config.OVHClient, serviceName, res.OperationId)
 	if err != nil {
 		return err
 	}
@@ -365,15 +400,26 @@ func resourceDbaasLogsOutputOpensearchAliasAttachStream(ctx context.Context, con
 	return nil
 }
 
-func resourceDbaasLogsOutputOpensearchAliasDetachStream(ctx context.Context, config *Config, serviceName, aliasID, streamId string) error {
+func resourceDbaasLogsOutputOpensearchAliasDetachStream(ctx context.Context, d *schema.ResourceData, config *Config, serviceName, aliasID, streamId string) error {
 	endpoint := fmt.Sprintf("/dbaas/logs/%s/output/opensearch/alias/%s/stream/%s", url.PathEscape(serviceName), url.PathEscape(aliasID), url.PathEscape(streamId))
 	res := &DbaasLogsOperation{}
 
-	if err := config.OVHClient.DeleteWithContext(ctx, endpoint, &res); err != nil {
-		return fmt.Errorf("Error calling delete %s:\n\t %q", endpoint, err)
+	err := retry.Retry(d.Timeout(schema.TimeoutDelete)-time.Minute, func() *retry.RetryError {
+		err := config.OVHClient.DeleteWithContext(ctx, endpoint, &res)
+		if err != nil {
+			if errOvh, ok := err.(*ovh.APIError); ok && errOvh.Class == DBAAS_LOGS_BUSY_ERROR {
+				return retry.RetryableError(err)
+			}
+			return retry.NonRetryableError(err)
+		}
+		return nil
+	})
+
+	if err != nil {
+		return fmt.Errorf("Error detaching stream, calling DELETE %s:\n\t %q", endpoint, err)
 	}
 
-	_, err := waitForDbaasLogsOperation(ctx, config.OVHClient, serviceName, res.OperationId)
+	_, err = waitForDbaasLogsOperation(ctx, config.OVHClient, serviceName, res.OperationId)
 	if err != nil {
 		return err
 	}

--- a/ovh/resource_dbaas_logs_output_opensearch_alias_test.go
+++ b/ovh/resource_dbaas_logs_output_opensearch_alias_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 )
 
 func init() {
@@ -128,7 +129,7 @@ func TestAccResourceDbaasLogsOutputOpensearchAlias_basic(t *testing.T) {
 		resource "ovh_dbaas_logs_output_opensearch_alias" "alias" {
 			service_name = "%s"
 			description  = "%s"
-			suffix        = "%s"
+			suffix       = "%s"
 		}
 		`,
 		serviceName,
@@ -164,14 +165,14 @@ func TestAccResourceDbaasLogsOutputOpensearchAlias_withIndex(t *testing.T) {
 		resource "ovh_dbaas_logs_output_opensearch_index" "idx" {
 			service_name = "%s"
 			description  = "%s"
-			suffix        = "%s"
-			nb_shard = 1
+			suffix       = "%s"
+			nb_shard     = 1
 		}
 
 		resource "ovh_dbaas_logs_output_opensearch_alias" "aliasWithIdx" {
 			service_name = "%s"
 			description  = "%s"
-			suffix        = "%s"
+			suffix       = "%s"
 			indexes = [ovh_dbaas_logs_output_opensearch_index.idx.index_id]
 		}
 		`,
@@ -221,7 +222,7 @@ func TestAccResourceDbaasLogsOutputOpensearchAlias_withStream(t *testing.T) {
 		resource "ovh_dbaas_logs_output_opensearch_alias" "aliasWithStream" {
 			service_name = "%s"
 			description  = "%s"
-			suffix        = "%s"
+			suffix       = "%s"
 			streams = [ovh_dbaas_logs_output_graylog_stream.stream.stream_id]
 		}
 		`,
@@ -251,6 +252,77 @@ func TestAccResourceDbaasLogsOutputOpensearchAlias_withStream(t *testing.T) {
 						"streams.#",
 					),
 				),
+			},
+		},
+	})
+}
+
+func TestAccResourceDbaasLogsOutputOpensearchAlias_withMultipleStreamsAndMultipleAliases(t *testing.T) {
+	serviceName := os.Getenv("OVH_DBAAS_LOGS_SERVICE_TEST")
+	desc := acctest.RandomWithPrefix(test_prefix)
+	title := acctest.RandomWithPrefix(test_prefix)
+	suffix := acctest.RandomWithPrefix(test_prefix)
+
+	config := fmt.Sprintf(`
+		resource "ovh_dbaas_logs_output_graylog_stream" "stream" {
+			count		 = 2
+			service_name = "%s"
+			description  = "%s-${count.index}"
+			title        = "%s-${count.index}"
+		}
+		resource "ovh_dbaas_logs_output_opensearch_alias" "alias" {
+			count        = length(ovh_dbaas_logs_output_graylog_stream.stream)
+			service_name = "%s"
+			description  = "%s-${count.index}"
+			suffix       = "%s-${count.index}"
+			streams = [ovh_dbaas_logs_output_graylog_stream.stream[count.index].id]
+		}
+		`,
+		serviceName,
+		desc,
+		title,
+		serviceName,
+		desc,
+		suffix,
+	)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() { testAccPreCheckDbaasLogs(t) },
+
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(
+						"ovh_dbaas_logs_output_opensearch_alias.alias.0",
+						"description",
+						desc+"-0",
+					),
+					resource.TestCheckResourceAttr(
+						"ovh_dbaas_logs_output_opensearch_alias.alias.0",
+						"streams.#",
+						"1",
+					),
+					resource.TestCheckResourceAttr(
+						"ovh_dbaas_logs_output_opensearch_alias.alias.1",
+						"description",
+						desc+"-1",
+					),
+					resource.TestCheckResourceAttr(
+						"ovh_dbaas_logs_output_opensearch_alias.alias.1",
+						"streams.#",
+						"1",
+					),
+				),
+			},
+			{
+				Config: config,
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
 			},
 		},
 	})


### PR DESCRIPTION
# Description

Calls to Logs Data Platform can return the following error:

```
OVHcloud API error (status code 403): Client::Forbidden::Busy: "An operation is already running for this service: uuid. Please retry later."
```

When this error is detected:

- Retry the creation and deletion of Graylog streams and OpenSearch aliases
- Retry the attach and detach of Gralog streams to OpenSearch aliases

Fixes #1285.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

```
$ make testacc TESTARGS="-run TestAccResourceDbaasLogsOutputOpensearchAlias_withMultipleStreamsAndMultipleAliases"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -run TestAccResourceDbaasLogsOutputOpensearchAlias_withMultipleStreamsAndMultipleAliases -timeout 600m -p 10
?       github.com/ovh/terraform-provider-ovh/v2        [no test files]
=== RUN   TestAccResourceDbaasLogsOutputOpensearchAlias_withMultipleStreamsAndMultipleAliases
--- PASS: TestAccResourceDbaasLogsOutputOpensearchAlias_withMultipleStreamsAndMultipleAliases (287.24s)
PASS
ok      github.com/ovh/terraform-provider-ovh/v2/ovh    287.255s
?       github.com/ovh/terraform-provider-ovh/v2/ovh/datasources/cloud_project_rancher  [no test files]
?       github.com/ovh/terraform-provider-ovh/v2/ovh/helpers    [no test files]
testing: warning: no tests to run
PASS
ok      github.com/ovh/terraform-provider-ovh/v2/ovh/helpers/hashcode   (cached) [no tests to run]
?       github.com/ovh/terraform-provider-ovh/v2/ovh/ovhwrap    [no test files]
?       github.com/ovh/terraform-provider-ovh/v2/ovh/resources/cloud_project_rancher    [no test files]
?       github.com/ovh/terraform-provider-ovh/v2/ovh/types      [no test files]
```

**Test Configuration**:
* Terraform version: `terraform version`: Terraform v1.14.7
* Existing HCL configuration you used: 
```hcl
data "ovh_dbaas_logs_cluster" "logs_cluster" {
  service_name = "ldp-xx-xxxxx"
}

resource "ovh_dbaas_logs_output_graylog_stream" "stream" {
  count        = 2
  service_name = data.ovh_dbaas_logs_cluster.logs_cluster.service_name
  title        = "stream-${count.index}"
  description  = "stream-${count.index}"
}

resource "ovh_dbaas_logs_output_opensearch_alias" "alias" {
  #count        = 0
  count        = length(ovh_dbaas_logs_output_graylog_stream.stream)
  service_name = data.ovh_dbaas_logs_cluster.logs_cluster.service_name
  description  = "alias for stream-${count.index}"
  suffix       = "stream-${count.index}"
  streams = [
    ovh_dbaas_logs_output_graylog_stream.stream[count.index].id
  ]
}
```

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or issues
- [x] I have added acceptance tests that prove my fix is effective or that my feature works
- [x] New and existing acceptance tests pass locally with my changes
- [x] I ran successfully `go mod vendor` if I added or modify `go.mod` file