### PR TITLE
fix: Retry calls to Logs Data Platform inputs

### DIFF
--- a/ovh/provider_test.go
+++ b/ovh/provider_test.go
@@ -212,7 +212,6 @@ func testAccPreCheckDbaasLogs(t *testing.T) {
 func testAccPreCheckDbaasLogsInput(t *testing.T) {
 	testAccPreCheckCredentials(t)
 	checkEnvOrSkip(t, "OVH_DBAAS_LOGS_SERVICE_TEST")
-	checkEnvOrSkip(t, "OVH_DBAAS_LOGS_LOGSTASH_VERSION_TEST")
 }
 
 func testAccPreCheckDbaasLogsCluster(t *testing.T) {

--- a/ovh/resource_dbaas_logs_input.go
+++ b/ovh/resource_dbaas_logs_input.go
@@ -6,9 +6,13 @@ import (
 	"log"
 	"net/url"
 	"strings"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/ovh/go-ovh/ovh"
 	"github.com/ovh/terraform-provider-ovh/v2/ovh/helpers"
 )
 
@@ -23,6 +27,14 @@ func resourceDbaasLogsInput() *schema.Resource {
 		},
 
 		Schema: resourceDbaasLogsInputSchema(),
+
+		// Inputs can be very long to process (10 minutes by input)
+		// They are processed sequentially
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(60 * time.Minute),
+			Update: schema.DefaultTimeout(60 * time.Minute),
+			Delete: schema.DefaultTimeout(60 * time.Minute),
+		},
 	}
 }
 
@@ -256,8 +268,19 @@ func resourceDbaasLogsInputCreate(ctx context.Context, d *schema.ResourceData, m
 		"/dbaas/logs/%s/input",
 		url.PathEscape(serviceName),
 	)
-	if err := config.OVHClient.Post(endpoint, opts, res); err != nil {
-		return diag.Errorf("Error calling post %s:\n\t %q", endpoint, err)
+
+	err := retry.Retry(d.Timeout(schema.TimeoutCreate)-time.Minute, func() *retry.RetryError {
+		err := config.OVHClient.Post(endpoint, opts, res)
+		if err != nil {
+			if errOvh, ok := err.(*ovh.APIError); ok && errOvh.Class == DBAAS_LOGS_BUSY_ERROR {
+				return retry.RetryableError(err)
+			}
+			return retry.NonRetryableError(err)
+		}
+		return nil
+	})
+	if err != nil {
+		return diag.Errorf("Error creating input, calling POST %s:\n\t %q", endpoint, err)
 	}
 
 	// Wait for operation status
@@ -300,8 +323,18 @@ func resourceDbaasLogsInputUpdate(ctx context.Context, d *schema.ResourceData, m
 		url.PathEscape(serviceName),
 		url.PathEscape(id),
 	)
-	if err := config.OVHClient.Put(endpoint, opts, res); err != nil {
-		return diag.Errorf("Error calling Put %s:\n\t %q", endpoint, err)
+	err := retry.Retry(d.Timeout(schema.TimeoutUpdate)-time.Minute, func() *retry.RetryError {
+		err := config.OVHClient.Put(endpoint, opts, res)
+		if err != nil {
+			if errOvh, ok := err.(*ovh.APIError); ok && errOvh.Class == DBAAS_LOGS_BUSY_ERROR {
+				return retry.RetryableError(err)
+			}
+			return retry.NonRetryableError(err)
+		}
+		return nil
+	})
+	if err != nil {
+		return diag.Errorf("Error updating input, calling PUT %s:\n\t %q", endpoint, err)
 	}
 
 	// Wait for operation status
@@ -326,9 +359,11 @@ func resourceDbaasLogsInputRead(ctx context.Context, d *schema.ResourceData, met
 		return diag.FromErr(err)
 	}
 
-	for k, v := range res.ToMap() {
-		if k != "id" {
-			d.Set(k, v)
+	if res != nil {
+		for k, v := range res.ToMap() {
+			if k != "id" {
+				d.Set(k, v)
+			}
 		}
 	}
 
@@ -377,7 +412,18 @@ func resourceDbaasLogsInputDelete(ctx context.Context, d *schema.ResourceData, m
 		url.PathEscape(id),
 	)
 
-	if err := config.OVHClient.Delete(endpoint, res); err != nil {
+	err := retry.Retry(d.Timeout(schema.TimeoutDelete)-time.Minute, func() *retry.RetryError {
+		err := config.OVHClient.DeleteWithContext(ctx, endpoint, &res)
+		if err != nil {
+			if errOvh, ok := err.(*ovh.APIError); ok && errOvh.Class == DBAAS_LOGS_BUSY_ERROR {
+				return retry.RetryableError(err)
+			}
+			return retry.NonRetryableError(err)
+		}
+		return nil
+	})
+
+	if err != nil {
 		return diag.FromErr(helpers.CheckDeleted(d, err, endpoint))
 	}
 
@@ -407,8 +453,18 @@ func dbaasLogsInputConfigurationUpdate(ctx context.Context, d *schema.ResourceDa
 			url.PathEscape(serviceName),
 			url.PathEscape(id),
 		)
-		if err := config.OVHClient.Put(endpoint, flowggerOpts, res); err != nil {
-			return fmt.Errorf("error calling Put %s:\n\t %q", endpoint, err)
+		err := retry.Retry(d.Timeout(schema.TimeoutUpdate)-time.Minute, func() *retry.RetryError {
+			err := config.OVHClient.Put(endpoint, flowggerOpts, res)
+			if err != nil {
+				if errOvh, ok := err.(*ovh.APIError); ok && errOvh.Class == DBAAS_LOGS_BUSY_ERROR {
+					return retry.RetryableError(err)
+				}
+				return retry.NonRetryableError(err)
+			}
+			return nil
+		})
+		if err != nil {
+			return fmt.Errorf("Error updating input configuration flowgger, calling PUT %s:\n\t %q", endpoint, err)
 		}
 	}
 
@@ -421,8 +477,18 @@ func dbaasLogsInputConfigurationUpdate(ctx context.Context, d *schema.ResourceDa
 			url.PathEscape(serviceName),
 			url.PathEscape(id),
 		)
-		if err := config.OVHClient.Put(endpoint, logstashOpts, res); err != nil {
-			return fmt.Errorf("error calling Put %s:\n\t %q", endpoint, err)
+		err := retry.Retry(d.Timeout(schema.TimeoutUpdate)-time.Minute, func() *retry.RetryError {
+			err := config.OVHClient.Put(endpoint, logstashOpts, res)
+			if err != nil {
+				if errOvh, ok := err.(*ovh.APIError); ok && errOvh.Class == DBAAS_LOGS_BUSY_ERROR {
+					return retry.RetryableError(err)
+				}
+				return retry.NonRetryableError(err)
+			}
+			return nil
+		})
+		if err != nil {
+			return fmt.Errorf("Error updating input configuration logstash, calling PUT %s:\n\t %q", endpoint, err)
 		}
 	}
 
@@ -506,8 +572,18 @@ func dbaasLogsInputStart(ctx context.Context, d *schema.ResourceData, meta inter
 			url.PathEscape(serviceName),
 			url.PathEscape(id),
 		)
-		if err := config.OVHClient.Post(endpoint, nil, res); err != nil {
-			return fmt.Errorf("error calling Put %s:\n\t %q", endpoint, err)
+		err := retry.Retry(d.Timeout(schema.TimeoutCreate)-time.Minute, func() *retry.RetryError {
+			err := config.OVHClient.Post(endpoint, nil, res)
+			if err != nil {
+				if errOvh, ok := err.(*ovh.APIError); ok && errOvh.Class == DBAAS_LOGS_BUSY_ERROR {
+					return retry.RetryableError(err)
+				}
+				return retry.NonRetryableError(err)
+			}
+			return nil
+		})
+		if err != nil {
+			return fmt.Errorf("Error restarting input, calling POST %s:\n\t %q", endpoint, err)
 		}
 	}
 
@@ -517,8 +593,18 @@ func dbaasLogsInputStart(ctx context.Context, d *schema.ResourceData, meta inter
 			url.PathEscape(serviceName),
 			url.PathEscape(id),
 		)
-		if err := config.OVHClient.Post(endpoint, nil, res); err != nil {
-			return fmt.Errorf("error calling Put %s:\n\t %q", endpoint, err)
+		err := retry.Retry(d.Timeout(schema.TimeoutCreate)-time.Minute, func() *retry.RetryError {
+			err := config.OVHClient.Post(endpoint, nil, res)
+			if err != nil {
+				if errOvh, ok := err.(*ovh.APIError); ok && errOvh.Class == DBAAS_LOGS_BUSY_ERROR {
+					return retry.RetryableError(err)
+				}
+				return retry.NonRetryableError(err)
+			}
+			return nil
+		})
+		if err != nil {
+			return fmt.Errorf("Error starting input, calling POST %s:\n\t %q", endpoint, err)
 		}
 	}
 
@@ -558,8 +644,18 @@ func dbaasLogsInputEnd(ctx context.Context, d *schema.ResourceData, meta interfa
 		url.PathEscape(serviceName),
 		url.PathEscape(id),
 	)
-	if err := config.OVHClient.Post(endpoint, nil, res); err != nil {
-		return fmt.Errorf("error calling Put %s:\n\t %q", endpoint, err)
+	err = retry.Retry(d.Timeout(schema.TimeoutDelete)-time.Minute, func() *retry.RetryError {
+		err := config.OVHClient.Post(endpoint, nil, res)
+		if err != nil {
+			if errOvh, ok := err.(*ovh.APIError); ok && errOvh.Class == DBAAS_LOGS_BUSY_ERROR {
+				return retry.RetryableError(err)
+			}
+			return retry.NonRetryableError(err)
+		}
+		return nil
+	})
+	if err != nil {
+		return fmt.Errorf("Error ending input, calling POST %s:\n\t %q", endpoint, err)
 	}
 
 	// Wait for operation status

--- a/ovh/resource_dbaas_logs_input_test.go
+++ b/ovh/resource_dbaas_logs_input_test.go
@@ -13,13 +13,14 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 )
 
 const testAccResourceDbaasLogsInput_basic = `
 data "ovh_dbaas_logs_input_engine" "logstash" {	
 	service_name  = "%s"
 	name          = "%s"
-	version       = "%s"
+	version       = "9.x"
 }
 
 resource "ovh_dbaas_logs_output_graylog_stream" "stream" {
@@ -58,7 +59,7 @@ const testAccResourceDbaasLogsInput_updated = `
 data "ovh_dbaas_logs_input_engine" "logstash" {
 	service_name  = "%s"
 	name          = "%s"
-	version       = "%s"
+	version       = "9.x"
 }
 
 resource "ovh_dbaas_logs_output_graylog_stream" "stream" {
@@ -99,7 +100,7 @@ const testAccResourceDbaasLogsInput_noNetwork = `
 data "ovh_dbaas_logs_input_engine" "logstash" {
 	service_name  = "%s"
 	name          = "%s"
-	version       = "%s"
+	version       = "9.x"
 }
 
 resource "ovh_dbaas_logs_output_graylog_stream" "stream" {
@@ -120,6 +121,47 @@ resource "ovh_dbaas_logs_input" "input" {
 	autoscale          = true
 	min_scale_instance = 2
 	max_scale_instance = 4
+
+	configuration {
+		logstash {
+			input_section = <<EOF
+				beats {
+					port => 6514
+					ssl_enabled => true
+					ssl_certificate => "/etc/ssl/private/server.crt"
+					ssl_key => "/etc/ssl/private/server.key"
+				}
+			EOF
+		}
+	}
+}
+`
+
+const testAccResourceDbaasLogsInput_multiple = `
+data "ovh_dbaas_logs_input_engine" "logstash" {
+	service_name  = "%s"
+	name          = "%s"
+	version       = "9.x"
+}
+
+resource "ovh_dbaas_logs_output_graylog_stream" "stream" {
+	count        = 2
+	service_name = "%s"
+	title        = "%s-${count.index}"
+	description  = "%s-${count.index}"
+}
+
+resource "ovh_dbaas_logs_input" "input" {
+	count        = 2
+	service_name = ovh_dbaas_logs_output_graylog_stream.stream[count.index].service_name
+	description  = ovh_dbaas_logs_output_graylog_stream.stream[count.index].description
+	title        = ovh_dbaas_logs_output_graylog_stream.stream[count.index].title
+	engine_id    = data.ovh_dbaas_logs_input_engine.logstash.id
+	stream_id    = ovh_dbaas_logs_output_graylog_stream.stream[count.index].id
+
+	allowed_networks = ["10.0.0.0/16"]
+	exposed_port     = "6154"
+	nb_instance      = %d
 
 	configuration {
 		logstash {
@@ -238,18 +280,17 @@ func testSweepDbaasInput(region string) error {
 func TestAccResourceDbaasLogsInput_basic(t *testing.T) {
 	serviceName := os.Getenv("OVH_DBAAS_LOGS_SERVICE_TEST")
 	name := "LOGSTASH"
-	version := os.Getenv("OVH_DBAAS_LOGS_LOGSTASH_VERSION_TEST")
 	title := acctest.RandomWithPrefix(test_prefix)
 	desc := acctest.RandomWithPrefix(test_prefix)
 
 	config := fmt.Sprintf(testAccResourceDbaasLogsInput_basic,
-		serviceName, name, version, serviceName, title, desc, 2)
+		serviceName, name, serviceName, title, desc, 2)
 	configWithMoreInstances := fmt.Sprintf(testAccResourceDbaasLogsInput_basic,
-		serviceName, name, version, serviceName, title, desc, 4)
+		serviceName, name, serviceName, title, desc, 4)
 	configUpdated := fmt.Sprintf(testAccResourceDbaasLogsInput_updated,
-		serviceName, name, version, serviceName, title, desc)
+		serviceName, name, serviceName, title, desc)
 	configNoNetwork := fmt.Sprintf(testAccResourceDbaasLogsInput_noNetwork,
-		serviceName, name, version, serviceName, title, desc)
+		serviceName, name, serviceName, title, desc)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() { testAccPreCheckDbaasLogsInput(t) },
@@ -359,6 +400,57 @@ func TestAccResourceDbaasLogsInput_basic(t *testing.T) {
 			{
 				Config: configNoNetwork,
 				Check:  resource.TestCheckResourceAttr("ovh_dbaas_logs_input.input", "allowed_networks.#", "0"),
+			},
+		},
+	})
+}
+
+func TestAccResourceDbaasLogsInput_multiple(t *testing.T) {
+	serviceName := os.Getenv("OVH_DBAAS_LOGS_SERVICE_TEST")
+	name := "LOGSTASH"
+	title := acctest.RandomWithPrefix(test_prefix)
+	desc := acctest.RandomWithPrefix(test_prefix)
+
+	config := fmt.Sprintf(testAccResourceDbaasLogsInput_multiple,
+		serviceName, name, serviceName, title, desc, 1)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() { testAccPreCheckDbaasLogsInput(t) },
+
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(
+						"ovh_dbaas_logs_input.input.0",
+						"description",
+						desc+"-0",
+					),
+					resource.TestCheckResourceAttr(
+						"ovh_dbaas_logs_input.input.0",
+						"title",
+						title+"-0",
+					),
+					resource.TestCheckResourceAttr(
+						"ovh_dbaas_logs_input.input.1",
+						"description",
+						desc+"-1",
+					),
+					resource.TestCheckResourceAttr(
+						"ovh_dbaas_logs_input.input.1",
+						"title",
+						title+"-1",
+					),
+				),
+			},
+			{
+				Config: config,
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
 			},
 		},
 	})


### PR DESCRIPTION
# Description

Calls to Logs Data Platform can return the following error:

```
OVHcloud API error (status code 403): Client::Forbidden::Busy: "An operation is already running for this service: uuid. Please retry later."
```

Retry calls to process inputs when this error is detected.

Remove the OVH_DBAAS_LOGS_LOGSTASH_VERSION_TEST environment variable from the inputs tests because the version is tighly coupled with the input configuration which is not variable.
    
Fix a panic in resourceDbaasLogsInputRead when res is null.

Fixes #781.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

```
$ make testacc TESTARGS="-run TestAccResourceDbaasLogsInput_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -run TestAccResourceDbaasLogsInput_basic -timeout 600m -p 10
?       github.com/ovh/terraform-provider-ovh/v2        [no test files]
=== RUN   TestAccResourceDbaasLogsInput_basic
--- PASS: TestAccResourceDbaasLogsInput_basic (1908.19s)
PASS
ok      github.com/ovh/terraform-provider-ovh/v2/ovh    1908.199s
?       github.com/ovh/terraform-provider-ovh/v2/ovh/datasources/cloud_project_rancher  [no test files]
?       github.com/ovh/terraform-provider-ovh/v2/ovh/helpers    [no test files]
testing: warning: no tests to run
PASS
ok      github.com/ovh/terraform-provider-ovh/v2/ovh/helpers/hashcode   (cached) [no tests to run]
?       github.com/ovh/terraform-provider-ovh/v2/ovh/ovhwrap    [no test files]
?       github.com/ovh/terraform-provider-ovh/v2/ovh/resources/cloud_project_rancher    [no test files]
?       github.com/ovh/terraform-provider-ovh/v2/ovh/types      [no test files]
```

```
$ make testacc TESTARGS="-run TestAccResourceDbaasLogsInput_multiple"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -run TestAccResourceDbaasLogsInput_multiple -timeout 600m -p 10
?       github.com/ovh/terraform-provider-ovh/v2        [no test files]
=== RUN   TestAccResourceDbaasLogsInput_multiple
--- PASS: TestAccResourceDbaasLogsInput_multiple (1722.41s)
PASS
ok      github.com/ovh/terraform-provider-ovh/v2/ovh    1722.418s
?       github.com/ovh/terraform-provider-ovh/v2/ovh/datasources/cloud_project_rancher  [no test files]
?       github.com/ovh/terraform-provider-ovh/v2/ovh/helpers    [no test files]
testing: warning: no tests to run
PASS
ok      github.com/ovh/terraform-provider-ovh/v2/ovh/helpers/hashcode   (cached) [no tests to run]
?       github.com/ovh/terraform-provider-ovh/v2/ovh/ovhwrap    [no test files]
?       github.com/ovh/terraform-provider-ovh/v2/ovh/resources/cloud_project_rancher    [no test files]
?       github.com/ovh/terraform-provider-ovh/v2/ovh/types      [no test files]
```

**Test Configuration**:
* Terraform version: `terraform version`: Terraform v1.14.7
* Existing HCL configuration you used: 
```hcl
data "ovh_dbaas_logs_input_engine" "logstash" {
  service_name = "ldp-xx-xxxxx"
  name         = "LOGSTASH"
  version      = "9.x"
}

resource "ovh_dbaas_logs_output_graylog_stream" "stream" {
  count        = 2
  service_name = "ldp-xx-xxxxx"
  title        = "%s-${count.index}"
  description  = "%s-${count.index}"
}

resource "ovh_dbaas_logs_input" "input" {
  count        = 2
  service_name = ovh_dbaas_logs_output_graylog_stream.stream[count.index].service_name
  description  = ovh_dbaas_logs_output_graylog_stream.stream[count.index].description
  title        = ovh_dbaas_logs_output_graylog_stream.stream[count.index].title
  engine_id    = data.ovh_dbaas_logs_input_engine.logstash.id
  stream_id    = ovh_dbaas_logs_output_graylog_stream.stream[count.index].id

  allowed_networks = ["10.0.0.0/16"]
  exposed_port     = "6154"
  nb_instance      = 1

  configuration {
    logstash {
      input_section = <<EOF
        beats {
          port => 6514
          ssl_enabled => true
          ssl_certificate => "/etc/ssl/private/server.crt"
          ssl_key => "/etc/ssl/private/server.key"
        }
      EOF
    }
  }
}
```

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or issues
- [x] I have added acceptance tests that prove my fix is effective or that my feature works
- [x] New and existing acceptance tests pass locally with my changes
- [x] I ran successfully `go mod vendor` if I added or modify `go.mod` file