### PR TITLE
fix(ovh_cloud_project): Make sure project is really delivered after order

### DIFF
--- a/ovh/resource_cloud_project.go
+++ b/ovh/resource_cloud_project.go
@@ -5,6 +5,7 @@ import (
 	"log"
 	"net/url"
 	"regexp"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/ovh/go-ovh/ovh"
@@ -91,6 +92,13 @@ func resourceCloudProjectCreate(d *schema.ResourceData, meta interface{}) error 
 
 	d.SetId(serviceName)
 	d.Set("project_id", serviceName)
+
+	// After order delivery, the project may not be immediately available in the API.
+	// Retry the GET for up to 10 minutes to avoid a spurious 404 error.
+	endpoint := fmt.Sprintf("/cloud/project/%s", url.PathEscape(serviceName))
+	if err := helpers.WaitAvailable(config.OVHClient, endpoint, 10*time.Minute); err != nil {
+		return fmt.Errorf("waiting for cloud project %s to become available: %q", serviceName, err)
+	}
 
 	return resourceCloudProjectUpdate(d, meta)
 }


### PR DESCRIPTION
# Description

Fixes a 404 after cloud project delivery by adding retries until it's available in the API.

Fixes #1288 (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] Test A: `make testacc TESTARGS="-run TestAccResourceCloudProject_basic"`

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or issues
- [x] I have added acceptance tests that prove my fix is effective or that my feature works
- [x] New and existing acceptance tests pass locally with my changes
- [x] I ran successfully `go mod vendor` if I added or modify `go.mod` file
