### PR TITLE
Dev/olivierdubo/flavor name

### DIFF
--- a/ovh/resource_cloud_loadbalancer.go
+++ b/ovh/resource_cloud_loadbalancer.go
@@ -7,11 +7,13 @@ import (
 	"strings"
 	"time"
 
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/ovh/go-ovh/ovh"
 	ovhtypes "github.com/ovh/terraform-provider-ovh/v2/ovh/types"
@@ -105,11 +107,19 @@ func (r *cloudLoadbalancerResource) Schema(ctx context.Context, req resource.Sch
 					stringplanmodifier.RequiresReplace(),
 				},
 			},
-			"flavor_id": schema.StringAttribute{
+			"flavor_name": schema.StringAttribute{
 				CustomType:          ovhtypes.TfStringType{},
 				Required:            true,
-				Description:         "ID of the loadbalancer flavor",
-				MarkdownDescription: "ID of the loadbalancer flavor",
+				Description:         "Loadbalancer flavor name",
+				MarkdownDescription: "Loadbalancer flavor name",
+				Validators: []validator.String{
+					stringvalidator.OneOf(
+						"small",
+						"medium",
+						"large",
+						"xl",
+					),
+				},
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.RequiresReplace(),
 				},
@@ -418,7 +428,7 @@ func (r *cloudLoadbalancerResource) Delete(ctx context.Context, req resource.Del
 			}
 			return res, res.ResourceStatus, nil
 		},
-		Timeout:    20 * time.Minute,
+		Timeout:    60 * time.Minute,
 		Delay:      10 * time.Second,
 		MinTimeout: 5 * time.Second,
 	}
@@ -444,7 +454,7 @@ func (r *cloudLoadbalancerResource) waitForLoadbalancerReady(ctx context.Context
 			}
 			return res, res.ResourceStatus, nil
 		},
-		Timeout:    20 * time.Minute,
+		Timeout:    60 * time.Minute,
 		Delay:      10 * time.Second,
 		MinTimeout: 5 * time.Second,
 	}

--- a/ovh/resource_cloud_loadbalancer_test.go
+++ b/ovh/resource_cloud_loadbalancer_test.go
@@ -17,7 +17,7 @@ func TestAccCloudLoadbalancer_basic(t *testing.T) {
 	region := os.Getenv("OVH_CLOUD_PROJECT_LOADBALANCER_REGION_TEST")
 	vipNetworkId := os.Getenv("OVH_CLOUD_PROJECT_LOADBALANCER_VIP_NETWORK_ID_TEST")
 	vipSubnetId := os.Getenv("OVH_CLOUD_PROJECT_LOADBALANCER_VIP_SUBNET_ID_TEST")
-	flavorId := os.Getenv("OVH_CLOUD_PROJECT_LOADBALANCER_FLAVOR_ID_TEST")
+	flavorName := os.Getenv("OVH_CLOUD_PROJECT_LOADBALANCER_FLAVOR_NAME_TEST")
 
 	lbName := acctest.RandomWithPrefix(testAccResourceCloudLoadbalancerNamePrefix)
 
@@ -28,9 +28,9 @@ resource "ovh_cloud_loadbalancer" "test" {
   region         = "%s"
   vip_network_id = "%s"
   vip_subnet_id  = "%s"
-  flavor_id      = "%s"
+  flavor_name    = "%s"
 }
-`, serviceName, lbName, region, vipNetworkId, vipSubnetId, flavorId)
+`, serviceName, lbName, region, vipNetworkId, vipSubnetId, flavorName)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
@@ -46,7 +46,7 @@ resource "ovh_cloud_loadbalancer" "test" {
 					resource.TestCheckResourceAttr("ovh_cloud_loadbalancer.test", "region", region),
 					resource.TestCheckResourceAttr("ovh_cloud_loadbalancer.test", "vip_network_id", vipNetworkId),
 					resource.TestCheckResourceAttr("ovh_cloud_loadbalancer.test", "vip_subnet_id", vipSubnetId),
-					resource.TestCheckResourceAttr("ovh_cloud_loadbalancer.test", "flavor_id", flavorId),
+					resource.TestCheckResourceAttr("ovh_cloud_loadbalancer.test", "flavor_name", flavorName),
 					resource.TestCheckResourceAttrSet("ovh_cloud_loadbalancer.test", "id"),
 					resource.TestCheckResourceAttrSet("ovh_cloud_loadbalancer.test", "checksum"),
 					resource.TestCheckResourceAttrSet("ovh_cloud_loadbalancer.test", "created_at"),
@@ -73,7 +73,7 @@ func TestAccCloudLoadbalancer_update(t *testing.T) {
 	region := os.Getenv("OVH_CLOUD_PROJECT_LOADBALANCER_REGION_TEST")
 	vipNetworkId := os.Getenv("OVH_CLOUD_PROJECT_LOADBALANCER_VIP_NETWORK_ID_TEST")
 	vipSubnetId := os.Getenv("OVH_CLOUD_PROJECT_LOADBALANCER_VIP_SUBNET_ID_TEST")
-	flavorId := os.Getenv("OVH_CLOUD_PROJECT_LOADBALANCER_FLAVOR_ID_TEST")
+	flavorName := os.Getenv("OVH_CLOUD_PROJECT_LOADBALANCER_FLAVOR_NAME_TEST")
 
 	lbName := acctest.RandomWithPrefix(testAccResourceCloudLoadbalancerNamePrefix)
 	updatedName := acctest.RandomWithPrefix(testAccResourceCloudLoadbalancerNamePrefix)
@@ -85,10 +85,10 @@ resource "ovh_cloud_loadbalancer" "test" {
   region         = "%s"
   vip_network_id = "%s"
   vip_subnet_id  = "%s"
-  flavor_id      = "%s"
+  flavor_name    = "%s"
   description    = "initial description"
 }
-`, serviceName, lbName, region, vipNetworkId, vipSubnetId, flavorId)
+`, serviceName, lbName, region, vipNetworkId, vipSubnetId, flavorName)
 
 	updatedConfig := fmt.Sprintf(`
 resource "ovh_cloud_loadbalancer" "test" {
@@ -97,10 +97,10 @@ resource "ovh_cloud_loadbalancer" "test" {
   region         = "%s"
   vip_network_id = "%s"
   vip_subnet_id  = "%s"
-  flavor_id      = "%s"
+  flavor_name    = "%s"
   description    = "updated description"
 }
-`, serviceName, updatedName, region, vipNetworkId, vipSubnetId, flavorId)
+`, serviceName, updatedName, region, vipNetworkId, vipSubnetId, flavorName)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
@@ -142,8 +142,8 @@ func testAccPreCheckCloudLoadbalancer(t *testing.T) {
 	if os.Getenv("OVH_CLOUD_PROJECT_LOADBALANCER_VIP_SUBNET_ID_TEST") == "" {
 		t.Skip("OVH_CLOUD_PROJECT_LOADBALANCER_VIP_SUBNET_ID_TEST not set")
 	}
-	if os.Getenv("OVH_CLOUD_PROJECT_LOADBALANCER_FLAVOR_ID_TEST") == "" {
-		t.Skip("OVH_CLOUD_PROJECT_LOADBALANCER_FLAVOR_ID_TEST not set")
+	if os.Getenv("OVH_CLOUD_PROJECT_LOADBALANCER_FLAVOR_NAME_TEST") == "" {
+		t.Skip("OVH_CLOUD_PROJECT_LOADBALANCER_FLAVOR_NAME_TEST not set")
 	}
 }
 

--- a/ovh/resource_cloud_loadbalancer_test.go
+++ b/ovh/resource_cloud_loadbalancer_test.go
@@ -17,7 +17,7 @@ func TestAccCloudLoadbalancer_basic(t *testing.T) {
 	region := os.Getenv("OVH_CLOUD_PROJECT_LOADBALANCER_REGION_TEST")
 	vipNetworkId := os.Getenv("OVH_CLOUD_PROJECT_LOADBALANCER_VIP_NETWORK_ID_TEST")
 	vipSubnetId := os.Getenv("OVH_CLOUD_PROJECT_LOADBALANCER_VIP_SUBNET_ID_TEST")
-	flavorName := os.Getenv("OVH_CLOUD_PROJECT_LOADBALANCER_FLAVOR_NAME_TEST")
+	flavorName := "small"
 
 	lbName := acctest.RandomWithPrefix(testAccResourceCloudLoadbalancerNamePrefix)
 
@@ -73,7 +73,7 @@ func TestAccCloudLoadbalancer_update(t *testing.T) {
 	region := os.Getenv("OVH_CLOUD_PROJECT_LOADBALANCER_REGION_TEST")
 	vipNetworkId := os.Getenv("OVH_CLOUD_PROJECT_LOADBALANCER_VIP_NETWORK_ID_TEST")
 	vipSubnetId := os.Getenv("OVH_CLOUD_PROJECT_LOADBALANCER_VIP_SUBNET_ID_TEST")
-	flavorName := os.Getenv("OVH_CLOUD_PROJECT_LOADBALANCER_FLAVOR_NAME_TEST")
+	flavorName := "small"
 
 	lbName := acctest.RandomWithPrefix(testAccResourceCloudLoadbalancerNamePrefix)
 	updatedName := acctest.RandomWithPrefix(testAccResourceCloudLoadbalancerNamePrefix)
@@ -141,9 +141,6 @@ func testAccPreCheckCloudLoadbalancer(t *testing.T) {
 	}
 	if os.Getenv("OVH_CLOUD_PROJECT_LOADBALANCER_VIP_SUBNET_ID_TEST") == "" {
 		t.Skip("OVH_CLOUD_PROJECT_LOADBALANCER_VIP_SUBNET_ID_TEST not set")
-	}
-	if os.Getenv("OVH_CLOUD_PROJECT_LOADBALANCER_FLAVOR_NAME_TEST") == "" {
-		t.Skip("OVH_CLOUD_PROJECT_LOADBALANCER_FLAVOR_NAME_TEST not set")
 	}
 }
 

--- a/ovh/types_cloud_loadbalancer.go
+++ b/ovh/types_cloud_loadbalancer.go
@@ -16,7 +16,7 @@ type CloudLoadbalancerModel struct {
 	Region       ovhtypes.TfStringValue `tfsdk:"region"`
 	VipNetworkId ovhtypes.TfStringValue `tfsdk:"vip_network_id"`
 	VipSubnetId  ovhtypes.TfStringValue `tfsdk:"vip_subnet_id"`
-	FlavorId     ovhtypes.TfStringValue `tfsdk:"flavor_id"`
+	FlavorName   ovhtypes.TfStringValue `tfsdk:"flavor_name"`
 
 	// Optional — immutable
 	AvailabilityZone ovhtypes.TfStringValue `tfsdk:"availability_zone"`
@@ -47,7 +47,7 @@ type CloudLoadbalancerAPISubnetRef struct {
 }
 
 type CloudLoadbalancerAPIFlavorRef struct {
-	ID string `json:"id"`
+	Name string `json:"name"`
 }
 
 type CloudLoadbalancerAPILocation struct {
@@ -116,7 +116,7 @@ func (m *CloudLoadbalancerModel) ToCreate() *CloudLoadbalancerCreatePayload {
 			ID: m.VipSubnetId.ValueString(),
 		},
 		Flavor: &CloudLoadbalancerAPIFlavorRef{
-			ID: m.FlavorId.ValueString(),
+			Name: m.FlavorName.ValueString(),
 		},
 	}
 
@@ -222,7 +222,7 @@ func buildLoadbalancerCurrentStateObject(ctx context.Context, state *CloudLoadba
 	// Build flavor object
 	var flavorVal basetypes.ObjectValue
 	if state.Flavor != nil {
-		flavorVal = buildLoadbalancerRefObject(state.Flavor.ID)
+		flavorVal = buildLoadbalancerRefObject(state.Flavor.Name)
 	} else {
 		flavorVal = types.ObjectNull(loadbalancerRefAttrTypes())
 	}
@@ -286,7 +286,7 @@ func (m *CloudLoadbalancerModel) MergeWith(ctx context.Context, response *CloudL
 			m.VipSubnetId = ovhtypes.TfStringValue{StringValue: types.StringValue(response.TargetSpec.VipSubnet.ID)}
 		}
 		if response.TargetSpec.Flavor != nil {
-			m.FlavorId = ovhtypes.TfStringValue{StringValue: types.StringValue(response.TargetSpec.Flavor.ID)}
+			m.FlavorName = ovhtypes.TfStringValue{StringValue: types.StringValue(response.TargetSpec.Flavor.Name)}
 		}
 	}
 }

--- a/ovh/types_cloud_loadbalancer_l7policy.go
+++ b/ovh/types_cloud_loadbalancer_l7policy.go
@@ -90,13 +90,13 @@ type CloudLoadbalancerL7PolicyAPICurrentState struct {
 }
 
 type CloudLoadbalancerL7PolicyAPIResponse struct {
-	Id             string                                     `json:"id"`
-	Checksum       string                                     `json:"checksum"`
-	CreatedAt      string                                     `json:"createdAt"`
-	UpdatedAt      string                                     `json:"updatedAt"`
-	ResourceStatus string                                     `json:"resourceStatus"`
-	CurrentState   *CloudLoadbalancerL7PolicyAPICurrentState  `json:"currentState,omitempty"`
-	TargetSpec     *CloudLoadbalancerL7PolicyAPITargetSpec    `json:"targetSpec,omitempty"`
+	Id             string                                    `json:"id"`
+	Checksum       string                                    `json:"checksum"`
+	CreatedAt      string                                    `json:"createdAt"`
+	UpdatedAt      string                                    `json:"updatedAt"`
+	ResourceStatus string                                    `json:"resourceStatus"`
+	CurrentState   *CloudLoadbalancerL7PolicyAPICurrentState `json:"currentState,omitempty"`
+	TargetSpec     *CloudLoadbalancerL7PolicyAPITargetSpec   `json:"targetSpec,omitempty"`
 }
 
 // Create payload
@@ -119,7 +119,7 @@ type CloudLoadbalancerL7PolicyUpdateTargetSpec struct {
 
 type CloudLoadbalancerL7PolicyUpdatePayload struct {
 	Checksum   string                                     `json:"checksum"`
-	TargetSpec *CloudLoadbalancerL7PolicyUpdateTargetSpec  `json:"targetSpec"`
+	TargetSpec *CloudLoadbalancerL7PolicyUpdateTargetSpec `json:"targetSpec"`
 }
 
 // l7PolicyRuleAttrTypes returns the attribute types for a single rule in the rules list.
@@ -143,14 +143,14 @@ func l7PolicyRuleElementType() attr.Type {
 // l7PolicyCurrentStateRuleAttrTypes returns the attribute types for a rule in current_state.
 func l7PolicyCurrentStateRuleAttrTypes() map[string]attr.Type {
 	return map[string]attr.Type{
-		"id":                   ovhtypes.TfStringType{},
-		"type":                 ovhtypes.TfStringType{},
-		"compare_type":         ovhtypes.TfStringType{},
-		"value":                ovhtypes.TfStringType{},
-		"key":                  ovhtypes.TfStringType{},
-		"invert":               types.BoolType,
-		"operating_status":     ovhtypes.TfStringType{},
-		"provisioning_status":  ovhtypes.TfStringType{},
+		"id":                  ovhtypes.TfStringType{},
+		"type":                ovhtypes.TfStringType{},
+		"compare_type":        ovhtypes.TfStringType{},
+		"value":               ovhtypes.TfStringType{},
+		"key":                 ovhtypes.TfStringType{},
+		"invert":              types.BoolType,
+		"operating_status":    ovhtypes.TfStringType{},
+		"provisioning_status": ovhtypes.TfStringType{},
 	}
 }
 

--- a/ovh/types_cloud_loadbalancer_pool.go
+++ b/ovh/types_cloud_loadbalancer_pool.go
@@ -20,10 +20,10 @@ type CloudLoadbalancerPoolModel struct {
 	Algorithm ovhtypes.TfStringValue `tfsdk:"algorithm"`
 
 	// Optional — mutable
-	Name           ovhtypes.TfStringValue `tfsdk:"name"`
-	Description    ovhtypes.TfStringValue `tfsdk:"description"`
-	Persistence    types.Object           `tfsdk:"persistence"`
-	HealthMonitor  types.Object           `tfsdk:"health_monitor"`
+	Name          ovhtypes.TfStringValue `tfsdk:"name"`
+	Description   ovhtypes.TfStringValue `tfsdk:"description"`
+	Persistence   types.Object           `tfsdk:"persistence"`
+	HealthMonitor types.Object           `tfsdk:"health_monitor"`
 
 	// Computed
 	Id             ovhtypes.TfStringValue `tfsdk:"id"`
@@ -73,13 +73,13 @@ type CloudLoadbalancerPoolAPIHealthMonitorCurrentState struct {
 }
 
 type CloudLoadbalancerPoolAPIResponse struct {
-	Id             string                                  `json:"id"`
-	Checksum       string                                  `json:"checksum"`
-	CreatedAt      string                                  `json:"createdAt"`
-	UpdatedAt      string                                  `json:"updatedAt"`
-	ResourceStatus string                                  `json:"resourceStatus"`
-	CurrentState   *CloudLoadbalancerPoolAPICurrentState   `json:"currentState,omitempty"`
-	TargetSpec     *CloudLoadbalancerPoolAPITargetSpec     `json:"targetSpec,omitempty"`
+	Id             string                                `json:"id"`
+	Checksum       string                                `json:"checksum"`
+	CreatedAt      string                                `json:"createdAt"`
+	UpdatedAt      string                                `json:"updatedAt"`
+	ResourceStatus string                                `json:"resourceStatus"`
+	CurrentState   *CloudLoadbalancerPoolAPICurrentState `json:"currentState,omitempty"`
+	TargetSpec     *CloudLoadbalancerPoolAPITargetSpec   `json:"targetSpec,omitempty"`
 }
 
 type CloudLoadbalancerPoolAPICurrentState struct {
@@ -87,17 +87,17 @@ type CloudLoadbalancerPoolAPICurrentState struct {
 	Description        string                                             `json:"description,omitempty"`
 	Protocol           string                                             `json:"protocol"`
 	Algorithm          string                                             `json:"algorithm"`
-	Persistence        *CloudLoadbalancerPoolAPISessionPersistence         `json:"persistence,omitempty"`
-	HealthMonitor      *CloudLoadbalancerPoolAPIHealthMonitorCurrentState  `json:"healthMonitor,omitempty"`
+	Persistence        *CloudLoadbalancerPoolAPISessionPersistence        `json:"persistence,omitempty"`
+	HealthMonitor      *CloudLoadbalancerPoolAPIHealthMonitorCurrentState `json:"healthMonitor,omitempty"`
 	OperatingStatus    string                                             `json:"operatingStatus,omitempty"`
 	ProvisioningStatus string                                             `json:"provisioningStatus,omitempty"`
 }
 
 type CloudLoadbalancerPoolAPITargetSpec struct {
-	Name          string                                     `json:"name,omitempty"`
-	Description   string                                     `json:"description"`
-	Protocol      string                                     `json:"protocol"`
-	Algorithm     string                                     `json:"algorithm"`
+	Name          string                                      `json:"name,omitempty"`
+	Description   string                                      `json:"description"`
+	Protocol      string                                      `json:"protocol"`
+	Algorithm     string                                      `json:"algorithm"`
 	Persistence   *CloudLoadbalancerPoolAPISessionPersistence `json:"persistence,omitempty"`
 	HealthMonitor *CloudLoadbalancerPoolAPIHealthMonitor      `json:"healthMonitor,omitempty"`
 }
@@ -109,15 +109,15 @@ type CloudLoadbalancerPoolCreatePayload struct {
 
 // Update payload — uses a separate struct without protocol (immutable)
 type CloudLoadbalancerPoolUpdateTargetSpec struct {
-	Name          string                                     `json:"name,omitempty"`
-	Description   string                                     `json:"description"`
-	Algorithm     string                                     `json:"algorithm"`
+	Name          string                                      `json:"name,omitempty"`
+	Description   string                                      `json:"description"`
+	Algorithm     string                                      `json:"algorithm"`
 	Persistence   *CloudLoadbalancerPoolAPISessionPersistence `json:"persistence,omitempty"`
 	HealthMonitor *CloudLoadbalancerPoolAPIHealthMonitor      `json:"healthMonitor,omitempty"`
 }
 
 type CloudLoadbalancerPoolUpdatePayload struct {
-	Checksum   string                                `json:"checksum"`
+	Checksum   string                                 `json:"checksum"`
 	TargetSpec *CloudLoadbalancerPoolUpdateTargetSpec `json:"targetSpec"`
 }
 
@@ -149,20 +149,20 @@ func healthMonitorAttrTypes() map[string]attr.Type {
 // healthMonitorCurrentStateAttrTypes returns the attribute types for the health_monitor in current_state
 func healthMonitorCurrentStateAttrTypes() map[string]attr.Type {
 	return map[string]attr.Type{
-		"id":                   ovhtypes.TfStringType{},
-		"type":                 ovhtypes.TfStringType{},
-		"delay":                types.Int64Type,
-		"timeout":              types.Int64Type,
-		"max_retries":          types.Int64Type,
-		"max_retries_down":     types.Int64Type,
-		"name":                 ovhtypes.TfStringType{},
-		"url_path":             ovhtypes.TfStringType{},
-		"http_method":          ovhtypes.TfStringType{},
-		"http_version":         ovhtypes.TfStringType{},
-		"expected_codes":       ovhtypes.TfStringType{},
-		"domain_name":          ovhtypes.TfStringType{},
-		"operating_status":     ovhtypes.TfStringType{},
-		"provisioning_status":  ovhtypes.TfStringType{},
+		"id":                  ovhtypes.TfStringType{},
+		"type":                ovhtypes.TfStringType{},
+		"delay":               types.Int64Type,
+		"timeout":             types.Int64Type,
+		"max_retries":         types.Int64Type,
+		"max_retries_down":    types.Int64Type,
+		"name":                ovhtypes.TfStringType{},
+		"url_path":            ovhtypes.TfStringType{},
+		"http_method":         ovhtypes.TfStringType{},
+		"http_version":        ovhtypes.TfStringType{},
+		"expected_codes":      ovhtypes.TfStringType{},
+		"domain_name":         ovhtypes.TfStringType{},
+		"operating_status":    ovhtypes.TfStringType{},
+		"provisioning_status": ovhtypes.TfStringType{},
 	}
 }
 
@@ -335,20 +335,20 @@ func buildHealthMonitorCurrentStateObject(hm *CloudLoadbalancerPoolAPIHealthMoni
 	obj, _ := types.ObjectValue(
 		healthMonitorCurrentStateAttrTypes(),
 		map[string]attr.Value{
-			"id":                   ovhtypes.TfStringValue{StringValue: types.StringValue(hm.ID)},
-			"type":                 ovhtypes.TfStringValue{StringValue: types.StringValue(hm.Type)},
-			"delay":                types.Int64Value(int64(hm.Delay)),
-			"timeout":              types.Int64Value(int64(hm.Timeout)),
-			"max_retries":          types.Int64Value(int64(hm.MaxRetries)),
-			"max_retries_down":     types.Int64Value(int64(hm.MaxRetriesDown)),
-			"name":                 nameVal,
-			"url_path":             urlPathVal,
-			"http_method":          httpMethodVal,
-			"http_version":         httpVersionVal,
-			"expected_codes":       expectedCodesVal,
-			"domain_name":          domainNameVal,
-			"operating_status":     ovhtypes.TfStringValue{StringValue: types.StringValue(hm.OperatingStatus)},
-			"provisioning_status":  ovhtypes.TfStringValue{StringValue: types.StringValue(hm.ProvisioningStatus)},
+			"id":                  ovhtypes.TfStringValue{StringValue: types.StringValue(hm.ID)},
+			"type":                ovhtypes.TfStringValue{StringValue: types.StringValue(hm.Type)},
+			"delay":               types.Int64Value(int64(hm.Delay)),
+			"timeout":             types.Int64Value(int64(hm.Timeout)),
+			"max_retries":         types.Int64Value(int64(hm.MaxRetries)),
+			"max_retries_down":    types.Int64Value(int64(hm.MaxRetriesDown)),
+			"name":                nameVal,
+			"url_path":            urlPathVal,
+			"http_method":         httpMethodVal,
+			"http_version":        httpVersionVal,
+			"expected_codes":      expectedCodesVal,
+			"domain_name":         domainNameVal,
+			"operating_status":    ovhtypes.TfStringValue{StringValue: types.StringValue(hm.OperatingStatus)},
+			"provisioning_status": ovhtypes.TfStringValue{StringValue: types.StringValue(hm.ProvisioningStatus)},
 		},
 	)
 	return obj

--- a/ovh/types_cloud_loadbalancer_pool_member.go
+++ b/ovh/types_cloud_loadbalancer_pool_member.go
@@ -48,36 +48,36 @@ type CloudLoadbalancerPoolMemberAPISubnetRef struct {
 }
 
 type CloudLoadbalancerPoolMemberAPIResponse struct {
-	Id             string                                        `json:"id"`
-	Checksum       string                                        `json:"checksum"`
-	CreatedAt      string                                        `json:"createdAt"`
-	UpdatedAt      string                                        `json:"updatedAt"`
-	ResourceStatus string                                        `json:"resourceStatus"`
-	CurrentState   *CloudLoadbalancerPoolMemberAPICurrentState   `json:"currentState,omitempty"`
-	TargetSpec     *CloudLoadbalancerPoolMemberAPITargetSpec     `json:"targetSpec,omitempty"`
+	Id             string                                      `json:"id"`
+	Checksum       string                                      `json:"checksum"`
+	CreatedAt      string                                      `json:"createdAt"`
+	UpdatedAt      string                                      `json:"updatedAt"`
+	ResourceStatus string                                      `json:"resourceStatus"`
+	CurrentState   *CloudLoadbalancerPoolMemberAPICurrentState `json:"currentState,omitempty"`
+	TargetSpec     *CloudLoadbalancerPoolMemberAPITargetSpec   `json:"targetSpec,omitempty"`
 }
 
 type CloudLoadbalancerPoolMemberAPICurrentState struct {
-	Name               string                                    `json:"name,omitempty"`
-	Address            string                                    `json:"address"`
-	ProtocolPort       int64                                     `json:"protocolPort"`
-	Weight             int64                                     `json:"weight"`
-	Subnet             *CloudLoadbalancerPoolMemberAPISubnetRef  `json:"subnet,omitempty"`
-	OperatingStatus    string                                    `json:"operatingStatus,omitempty"`
-	ProvisioningStatus string                                    `json:"provisioningStatus,omitempty"`
-	Backup             bool                                      `json:"backup,omitempty"`
-	Monitor            *CloudLoadbalancerPoolMemberAPIMonitor    `json:"monitor,omitempty"`
+	Name               string                                   `json:"name,omitempty"`
+	Address            string                                   `json:"address"`
+	ProtocolPort       int64                                    `json:"protocolPort"`
+	Weight             int64                                    `json:"weight"`
+	Subnet             *CloudLoadbalancerPoolMemberAPISubnetRef `json:"subnet,omitempty"`
+	OperatingStatus    string                                   `json:"operatingStatus,omitempty"`
+	ProvisioningStatus string                                   `json:"provisioningStatus,omitempty"`
+	Backup             bool                                     `json:"backup,omitempty"`
+	Monitor            *CloudLoadbalancerPoolMemberAPIMonitor   `json:"monitor,omitempty"`
 }
 
 // TargetSpec for POST (all fields including immutable)
 type CloudLoadbalancerPoolMemberAPITargetSpec struct {
-	Name         string                                  `json:"name,omitempty"`
-	Address      string                                  `json:"address"`
-	ProtocolPort int64                                   `json:"protocolPort"`
-	Weight       *int64                                  `json:"weight,omitempty"`
+	Name         string                                   `json:"name,omitempty"`
+	Address      string                                   `json:"address"`
+	ProtocolPort int64                                    `json:"protocolPort"`
+	Weight       *int64                                   `json:"weight,omitempty"`
 	Subnet       *CloudLoadbalancerPoolMemberAPISubnetRef `json:"subnet,omitempty"`
-	Monitor      *CloudLoadbalancerPoolMemberAPIMonitor  `json:"monitor,omitempty"`
-	Backup       *bool                                   `json:"backup,omitempty"`
+	Monitor      *CloudLoadbalancerPoolMemberAPIMonitor   `json:"monitor,omitempty"`
+	Backup       *bool                                    `json:"backup,omitempty"`
 }
 
 // UpdateTargetSpec for PUT (only mutable fields — no address, no protocolPort, no subnet)
@@ -95,7 +95,7 @@ type CloudLoadbalancerPoolMemberCreatePayload struct {
 
 // Update payload
 type CloudLoadbalancerPoolMemberUpdatePayload struct {
-	Checksum   string                                        `json:"checksum"`
+	Checksum   string                                          `json:"checksum"`
 	TargetSpec *CloudLoadbalancerPoolMemberAPIUpdateTargetSpec `json:"targetSpec"`
 }
 


### PR DESCRIPTION
# Description

This PR migrates the `ovh_cloud_loadbalancer` resource from using `flavor_id` (OpenStack UUID) to `flavor_name` (string enum) to align with API v2 conventions and improve user experience.


## Changes

- **Breaking change**: Replace `flavor_id` attribute with `flavor_name` in `ovh_cloud_loadbalancer` resource
- Add validator to restrict `flavor_name` to valid values: `small`, `medium`, `large`, `xl`
- Increase timeout for loadbalancer operations from 20 minutes to 60 minutes (delete and ready state polling)
- Update all type definitions and tests to use `flavor_name` instead of `flavor_id`

Fixes #xx (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Improvement (improve existing resource(s) or datasource(s))
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

# How Has This Been Tested?

- [x] Manual test with Terraform configuration using `flavor_name = "xl"`
- [x] Verified loadbalancer creation succeeds with API v2 backend
- [x] Tested all 4 flavor sizes: small, medium, large, xl


**Test Configuration**:
* Terraform version: `terraform version`: Terraform v2..7.0

resource "ovh_cloud_loadbalancer" "lb" {
  service_name     = "SERVICE_NAME"
  region           = "REGION"
  vip_network_id   = ovh_cloud_network_private_vrack.vrack.id
  vip_subnet_id    = ovh_cloud_network_private_vrack_subnet.subnet.id
  flavor_name      = "xl"
  name             = "test-lb-flavor-name"
  description      = "Test loadbalancer with flavor_name"
}

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings or issues
- [ ] I have added acceptance tests that prove my fix is effective or that my feature works
- [X] New and existing acceptance tests pass locally with my changes
- [ ] I ran successfully `go mod vendor` if I added or modify `go.mod` file
