### PR TITLE
feat: Inject schemas version header to /v2 API requests

### DIFF
--- a/ovh/config.go
+++ b/ovh/config.go
@@ -162,7 +162,9 @@ func (c *Config) load() error {
 		targetClient.Client.Transport = cleanhttp.DefaultTransport()
 	}
 
-	httpClient.Transport = logging.NewTransport("OVH", httpClient.Transport)
+	// Chain transports: schemasVersion (adds X-Schemas-Version for /v2/ paths)
+	// → logging (logs request/response) → original transport (sends over the wire).
+	httpClient.Transport = newSchemasVersionTransport(logging.NewTransport("OVH", httpClient.Transport))
 	c.OVHClient = ovhwrap.NewClient(targetClient, c.ApiRateLimit)
 	return nil
 }

--- a/ovh/schemas_version_transport.go
+++ b/ovh/schemas_version_transport.go
@@ -1,0 +1,38 @@
+package ovh
+
+import (
+	"net/http"
+	"strings"
+)
+
+// schemasVersionHeader is the HTTP header to select a specific
+// API schema version when processing the request.
+const schemasVersionHeader = "X-Schemas-Version"
+
+// schemasVersion is the schema version requested by this client.
+// Bump this value when a new schema version is released and the provider
+// has been updated to match.
+const schemasVersion = "1.0"
+
+// schemasVersionTransport is an http.RoundTripper middleware that injects the
+// X-Schemas-Version header on every request whose path starts with "/v2/".
+// Requests targeting v1 endpoints are left untouched because v1 instances do
+// not support multi-version schemas.
+type schemasVersionTransport struct {
+	next http.RoundTripper
+}
+
+func (t *schemasVersionTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	if strings.HasPrefix(req.URL.Path, "/v2/") {
+		// Clone the request so we don't mutate the caller's original.
+		req = req.Clone(req.Context())
+		req.Header.Set(schemasVersionHeader, schemasVersion)
+	}
+	return t.next.RoundTrip(req)
+}
+
+// newSchemasVersionTransport wraps the given RoundTripper with schema version
+// header injection for v2 API calls.
+func newSchemasVersionTransport(next http.RoundTripper) http.RoundTripper {
+	return &schemasVersionTransport{next: next}
+}

--- a/ovh/schemas_version_transport.go
+++ b/ovh/schemas_version_transport.go
@@ -12,7 +12,7 @@ const schemasVersionHeader = "X-Schemas-Version"
 // schemasVersion is the schema version requested by this client.
 // Bump this value when a new schema version is released and the provider
 // has been updated to match.
-const schemasVersion = "1.0"
+const schemasVersion = "0.0"
 
 // schemasVersionTransport is an http.RoundTripper middleware that injects the
 // X-Schemas-Version header on every request whose path starts with "/v2/".


### PR DESCRIPTION
# Description

Add an `X-Schemas-Version` HTTP header to all `/v2/` API requests made by the provider.

OVHcloud API v2 is introducing multi-version schemas. Clients must send an `X-Schemas-Version` header so the API returns responses matching the schema version the client was built against. Without this header, future schema changes could silently break existing provider behavior.

This PR introduces a new `http.RoundTripper` middleware (`schemasVersionTransport`) that:
- Injects `X-Schemas-Version: 0.0` on every request whose path starts with `/v2/`
- Leaves v1 requests untouched (v1 does not support multi-version schemas)
- Clones the request before mutation to avoid side effects

The transport is chained in `config.go`: `schemasVersion → logging → base transport`.

## Type of change

Please delete options that are not relevant.

- [X] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?
N/A 

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added acceptance tests that prove my fix is effective or that my feature works
- [ ] New and existing acceptance tests pass locally with my changes