### PR TITLE
feat: park IP when deleting ip_move resource

### DIFF
--- a/ovh/resource_ip_move.go
+++ b/ovh/resource_ip_move.go
@@ -292,9 +292,18 @@ func resourceIpRead(d *schema.ResourceData, meta interface{}) error {
 	return resourceIpReadByIp(d, ip, config)
 }
 
-// resourceIpMoveDelete is an empty implementation as move do not actually create API objects but rather updates the underlying ip spec (by modifying its routed_to service)
+// resourceIpMoveDelete parks the IP when the resource is deleted by setting an empty service_name and calling update
+// it marks the IP as avialable on manager
 func resourceIpMoveDelete(d *schema.ResourceData, meta interface{}) error {
-	return nil
+	err := d.Set("routed_to", []interface{}{
+		map[string]interface{}{
+			"service_name": "",
+		},
+	})
+	if err != nil {
+		return err
+	}
+	return resourceIpMoveUpdate(d, meta)
 }
 
 func resourceIpReadByIp(d *schema.ResourceData, ip string, config *Config) error {

--- a/ovh/resource_ip_move_test.go
+++ b/ovh/resource_ip_move_test.go
@@ -2,10 +2,12 @@ package ovh
 
 import (
 	"fmt"
+	"net/url"
 	"os"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
 )
 
 var testAccIpMoveConfig = `
@@ -45,6 +47,32 @@ resource "ovh_ip_move" "move" {
 }
 `
 
+func testAccCheckIpMoveDestroy(s *terraform.State) error {
+	client := testAccProvider.Meta().(*Config).OVHClient
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "ovh_ip_move" {
+			continue
+		}
+
+		ip := rs.Primary.Attributes["ip"]
+		endpoint := fmt.Sprintf("/ip/%s", url.PathEscape(ip))
+
+		var r Ip
+		if err := client.Get(endpoint, &r); err != nil {
+			// If we get an error (e.g. 404), it might be that the whole IP block was deleted
+			// That's acceptable in a destroy phase for the parent ovh_ip_service.
+			continue
+		}
+
+		if len(r.RoutedTo) > 0 && r.RoutedTo[0].ServiceName != "" {
+			return fmt.Errorf("IP %s still routed to a service: %s", ip, r.RoutedTo[0].ServiceName)
+		}
+	}
+
+	return nil
+}
+
 func TestAccIpMove_basic(t *testing.T) {
 	routedToServiceName := os.Getenv("OVH_IP_MOVE_SERVICE_NAME_TEST")
 
@@ -52,8 +80,9 @@ func TestAccIpMove_basic(t *testing.T) {
 	parkConfig := fmt.Sprintf(testAccIpMoveConfig, "")
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheckIpMove(t) },
-		Providers: testAccProviders,
+		PreCheck:     func() { testAccPreCheckIpMove(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckIpMoveDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: moveConfig,
@@ -76,8 +105,9 @@ func TestAccIpMove_block(t *testing.T) {
 	routedToServiceName := os.Getenv("OVH_IP_MOVE_SERVICE_NAME_TEST")
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheckIpMove(t) },
-		Providers: testAccProviders,
+		PreCheck:     func() { testAccPreCheckIpMove(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckIpMoveDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: fmt.Sprintf(`


### PR DESCRIPTION
# Description

When deleting a ip_move resource, the current provider do nothing. so the IP is still marked as routed to the resource on the manager and internal tools.
I suggest to move to parking when deleting a ip_move resource, by setting the service_name as empty and calling the move method, that will call the /ip/{ip}/park route on APIv6.
If the IP is already parked, it will do nothing as the service_name will be the same as the one in the API.

## Type of change

Please delete options that are not relevant.

- [x] Improvement (improve existing resource(s) or datasource(s))

# How Has This Been Tested?

Create a resource using ip_move, route it to a service, and delete the resource. The IP is now routed to the parking (visible on the manager)

**Test Configuration**:
```hcl
resource "ovh_ip_move" "move_ip_to_load_balancer_xxxxx" {
  ip = "1.2.3.4"
  routed_to {
    service_name = "loadbalancer-XXXXX"
  }
}
```

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or issues
- [x] I have added acceptance tests that prove my fix is effective or that my feature works
- [x] New and existing acceptance tests pass locally with my changes
- [ ] I ran successfully `go mod vendor` if I added or modify `go.mod` file
