### PR TITLE
feat(storage/efs): add ability to import EFS shares, snapshots and ACLs

### DIFF
--- a/docs/resources/storage_efs_share.md
+++ b/docs/resources/storage_efs_share.md
@@ -43,3 +43,25 @@ resource "ovh_storage_efs_share" "share" {
 - `created_at` (String) Share creation date
 - `id` (String) Share ID
 - `status` (String) Share status
+
+## Import
+
+An EFS share can be imported using its `service_name` and `id` fields.
+
+Using the following configuration:
+
+```terraform
+import {
+  to = ovh_storage_efs_share.share
+  id = "<service_name>/<id>"
+}
+```
+
+You can then run:
+
+```bash
+$ terraform plan -generate-config-out=share.tf
+$ terraform apply
+```
+
+The file `share.tf` will then contain the imported resource's configuration, that can be copied next to the `import` block above. See https://developer.hashicorp.com/terraform/language/import/generating-configuration for more details.

--- a/docs/resources/storage_efs_share_acl.md
+++ b/docs/resources/storage_efs_share_acl.md
@@ -49,3 +49,25 @@ resource "ovh_storage_efs_share_acl" "acl" {
 - `created_at` (String) Rule creation date
 - `id` (String) Rule ID
 - `status` (String) Rule status
+
+## Import
+
+An EFS share ACL can be imported using its `service_name`, `share_id` and `id` fields.
+
+Using the following configuration:
+
+```terraform
+import {
+  to = ovh_storage_efs_share_acl.acl
+  id = "<service_name>/<share_id>/<id>"
+}
+```
+
+You can then run:
+
+```bash
+$ terraform plan -generate-config-out=acl.tf
+$ terraform apply
+```
+
+The file `acl.tf` will then contain the imported resource's configuration, that can be copied next to the `import` block above. See https://developer.hashicorp.com/terraform/language/import/generating-configuration for more details.

--- a/docs/resources/storage_efs_share_snapshot.md
+++ b/docs/resources/storage_efs_share_snapshot.md
@@ -63,3 +63,25 @@ resource "time_sleep" "wait_10_seconds" {
 - `path` (String) Snapshot path
 - `status` (String) Snapshot status
 - `type` (String) Snapshot type
+
+## Import
+
+An EFS share snapshot can be imported using its `service_name`, `share_id` and `id` fields.
+
+Using the following configuration:
+
+```terraform
+import {
+  to = ovh_storage_efs_share_snapshot.snapshot
+  id = "<service_name>/<share_id>/<id>"
+}
+```
+
+You can then run:
+
+```bash
+$ terraform plan -generate-config-out=snapshot.tf
+$ terraform apply
+```
+
+The file `snapshot.tf` will then contain the imported resource's configuration, that can be copied next to the `import` block above. See https://developer.hashicorp.com/terraform/language/import/generating-configuration for more details.

--- a/examples/resources/storage_efs_share/import.tf
+++ b/examples/resources/storage_efs_share/import.tf
@@ -1,0 +1,4 @@
+import {
+  to = ovh_storage_efs_share.share
+  id = "<service_name>/<id>"
+}

--- a/examples/resources/storage_efs_share_acl/import.tf
+++ b/examples/resources/storage_efs_share_acl/import.tf
@@ -1,0 +1,4 @@
+import {
+  to = ovh_storage_efs_share_acl.acl
+  id = "<service_name>/<share_id>/<id>"
+}

--- a/examples/resources/storage_efs_share_snapshot/import.tf
+++ b/examples/resources/storage_efs_share_snapshot/import.tf
@@ -1,0 +1,4 @@
+import {
+  to = ovh_storage_efs_share_snapshot.snapshot
+  id = "<service_name>/<share_id>/<id>"
+}

--- a/ovh/resource_storage_efs_share.go
+++ b/ovh/resource_storage_efs_share.go
@@ -4,8 +4,10 @@ import (
 	"context"
 	"fmt"
 	"net/url"
+	"strings"
 	"time"
 
+	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/ovh/terraform-provider-ovh/v2/ovh/ovhwrap"
@@ -44,6 +46,20 @@ func (d *storageEfsShareResource) Configure(_ context.Context, req resource.Conf
 
 func (d *storageEfsShareResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
 	resp.Schema = StorageEfsShareResourceSchema(ctx)
+}
+
+func (r *storageEfsShareResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	parts := strings.Split(req.ID, "/")
+	if len(parts) != 2 {
+		resp.Diagnostics.AddError(
+			"Invalid Import ID",
+			fmt.Sprintf("Expected import ID in the format 'serviceName/shareId', got: %s", req.ID),
+		)
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("service_name"), parts[0])...)
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("id"), parts[1])...)
 }
 
 func (r *storageEfsShareResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {

--- a/ovh/resource_storage_efs_share_acl.go
+++ b/ovh/resource_storage_efs_share_acl.go
@@ -4,8 +4,10 @@ import (
 	"context"
 	"fmt"
 	"net/url"
+	"strings"
 	"time"
 
+	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/ovh/terraform-provider-ovh/v2/ovh/ovhwrap"
@@ -40,6 +42,21 @@ func (d *storageEfsShareAclResource) Configure(_ context.Context, req resource.C
 	}
 
 	d.config = config
+}
+
+func (r *storageEfsShareAclResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	parts := strings.Split(req.ID, "/")
+	if len(parts) != 3 {
+		resp.Diagnostics.AddError(
+			"Invalid Import ID",
+			fmt.Sprintf("Expected import ID in the format 'serviceName/shareId/acld', got: %s", req.ID),
+		)
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("service_name"), parts[0])...)
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("share_id"), parts[1])...)
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("id"), parts[2])...)
 }
 
 func (d *storageEfsShareAclResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {

--- a/ovh/resource_storage_efs_share_acl_test.go
+++ b/ovh/resource_storage_efs_share_acl_test.go
@@ -6,17 +6,10 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
 )
 
-func TestAccStorageEfsShareAcl_basic(t *testing.T) {
-	serviceName := os.Getenv("OVH_STORAGE_EFS_SERVICE_TEST")
-
-	resource.Test(t, resource.TestCase{
-		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
-		PreCheck:                 func() { testAccPreCheckStorageEfs(t); testAccCheckStorageEfsExists(t) },
-		Steps: []resource.TestStep{
-			{
-				Config: fmt.Sprintf(`
+const testAccStorageEfsShareAclConfig_basic = `
 resource "ovh_storage_efs_share" "share" {
   service_name = "%s"
   name         = "share"
@@ -31,7 +24,17 @@ resource "ovh_storage_efs_share_acl" "acl" {
   access_level = "rw"
   access_to = "10.0.0.1/32"
 }
-`,
+`
+
+func TestAccStorageEfsShareAcl_basic(t *testing.T) {
+	serviceName := os.Getenv("OVH_STORAGE_EFS_SERVICE_TEST")
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		PreCheck:                 func() { testAccPreCheckStorageEfs(t); testAccCheckStorageEfsExists(t) },
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(testAccStorageEfsShareAclConfig_basic,
 					serviceName,
 					serviceName,
 				),
@@ -49,4 +52,51 @@ resource "ovh_storage_efs_share_acl" "acl" {
 		},
 	})
 
+}
+
+func TestAccStorageEfsShareAcl_import(t *testing.T) {
+	serviceName := os.Getenv("OVH_STORAGE_EFS_SERVICE_TEST")
+	config := fmt.Sprintf(testAccStorageEfsShareAclConfig_basic, serviceName, serviceName)
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		PreCheck:                 func() { testAccPreCheckStorageEfs(t); testAccCheckStorageEfsExists(t) },
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("ovh_storage_efs_share_acl.acl", "service_name", serviceName),
+					resource.TestCheckResourceAttrSet("ovh_storage_efs_share_acl.acl", "id"),
+					resource.TestCheckResourceAttrSet("ovh_storage_efs_share_acl.acl", "share_id"),
+					resource.TestCheckResourceAttrSet("ovh_storage_efs_share_acl.acl", "created_at"),
+					resource.TestCheckResourceAttr("ovh_storage_efs_share_acl.acl", "access_level", "rw"),
+					resource.TestCheckResourceAttr("ovh_storage_efs_share_acl.acl", "access_to", "10.0.0.1/32"),
+					resource.TestCheckResourceAttr("ovh_storage_efs_share_acl.acl", "access_type", "ip"),
+					resource.TestCheckResourceAttr("ovh_storage_efs_share_acl.acl", "status", "active"),
+				),
+			},
+			{
+				ResourceName:            "ovh_storage_efs_share_acl.acl",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{},
+				ImportStateIdFunc:       testAccStorageEfsShareAclImportId("ovh_storage_efs_share_acl.acl"),
+			},
+		},
+	})
+}
+
+func testAccStorageEfsShareAclImportId(resourceName string) resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return "", fmt.Errorf("resource not found: %s", resourceName)
+		}
+		return fmt.Sprintf(
+			"%s/%s/%s",
+			rs.Primary.Attributes["service_name"],
+			rs.Primary.Attributes["share_id"],
+			rs.Primary.Attributes["id"],
+		), nil
+	}
 }

--- a/ovh/resource_storage_efs_share_snapshot.go
+++ b/ovh/resource_storage_efs_share_snapshot.go
@@ -4,8 +4,10 @@ import (
 	"context"
 	"fmt"
 	"net/url"
+	"strings"
 	"time"
 
+	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/ovh/terraform-provider-ovh/v2/ovh/ovhwrap"
@@ -44,6 +46,21 @@ func (d *storageEfsShareSnapshotResource) Configure(_ context.Context, req resou
 
 func (d *storageEfsShareSnapshotResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
 	resp.Schema = StorageEfsShareSnapshotResourceSchema(ctx)
+}
+
+func (r *storageEfsShareSnapshotResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	parts := strings.Split(req.ID, "/")
+	if len(parts) != 3 {
+		resp.Diagnostics.AddError(
+			"Invalid Import ID",
+			fmt.Sprintf("Expected import ID in the format 'serviceName/shareId/snapshotId', got: %s", req.ID),
+		)
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("service_name"), parts[0])...)
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("share_id"), parts[1])...)
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("id"), parts[2])...)
 }
 
 func (r *storageEfsShareSnapshotResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {

--- a/ovh/resource_storage_efs_share_snapshot_test.go
+++ b/ovh/resource_storage_efs_share_snapshot_test.go
@@ -6,23 +6,10 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
 )
 
-func TestAccStorageEfsShareSnapshot_basic(t *testing.T) {
-	serviceName := os.Getenv("OVH_STORAGE_EFS_SERVICE_TEST")
-
-	resource.Test(t, resource.TestCase{
-		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
-		ExternalProviders: map[string]resource.ExternalProvider{
-			"time": {
-				VersionConstraint: "0.13.1",
-				Source:            "registry.terraform.io/hashicorp/time",
-			},
-		},
-		PreCheck: func() { testAccPreCheckStorageEfs(t); testAccCheckStorageEfsExists(t) },
-		Steps: []resource.TestStep{
-			{
-				Config: fmt.Sprintf(`
+const testAccStorageEfsShareSnapshotConfig_basic = `
 resource "ovh_storage_efs_share" "share" {
   service_name = "%s"
   name         = "share"
@@ -44,7 +31,24 @@ resource "ovh_storage_efs_share_snapshot" "snapshot" {
   share_id = ovh_storage_efs_share.share.id
   name = "snapshot"
   description = "My snapshot"
-}`,
+}
+`
+
+func TestAccStorageEfsShareSnapshot_basic(t *testing.T) {
+	serviceName := os.Getenv("OVH_STORAGE_EFS_SERVICE_TEST")
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		ExternalProviders: map[string]resource.ExternalProvider{
+			"time": {
+				VersionConstraint: "0.13.1",
+				Source:            "registry.terraform.io/hashicorp/time",
+			},
+		},
+		PreCheck: func() { testAccPreCheckStorageEfs(t); testAccCheckStorageEfsExists(t) },
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(testAccStorageEfsShareSnapshotConfig_basic,
 					serviceName,
 					serviceName,
 				),
@@ -103,4 +107,58 @@ resource "ovh_storage_efs_share_snapshot" "snapshot" {
 		},
 	})
 
+}
+
+func TestAccStorageEfsShareSnapshot_import(t *testing.T) {
+	serviceName := os.Getenv("OVH_STORAGE_EFS_SERVICE_TEST")
+	config := fmt.Sprintf(testAccStorageEfsShareSnapshotConfig_basic, serviceName, serviceName)
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		ExternalProviders: map[string]resource.ExternalProvider{
+			"time": {
+				VersionConstraint: "0.13.1",
+				Source:            "registry.terraform.io/hashicorp/time",
+			},
+		},
+		PreCheck: func() { testAccPreCheckStorageEfs(t); testAccCheckStorageEfsExists(t) },
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("ovh_storage_efs_share.share", "service_name", serviceName),
+					resource.TestCheckResourceAttrSet("ovh_storage_efs_share_snapshot.snapshot", "id"),
+					resource.TestCheckResourceAttrSet("ovh_storage_efs_share_snapshot.snapshot", "share_id"),
+					resource.TestCheckResourceAttrSet("ovh_storage_efs_share_snapshot.snapshot", "created_at"),
+					resource.TestCheckResourceAttrSet("ovh_storage_efs_share_snapshot.snapshot", "path"),
+					resource.TestCheckResourceAttr("ovh_storage_efs_share_snapshot.snapshot", "name", "snapshot"),
+					resource.TestCheckResourceAttr("ovh_storage_efs_share_snapshot.snapshot", "description", "My snapshot"),
+					resource.TestCheckResourceAttr("ovh_storage_efs_share_snapshot.snapshot", "status", "available"),
+					resource.TestCheckResourceAttr("ovh_storage_efs_share_snapshot.snapshot", "type", "manual"),
+				),
+			},
+			{
+				ResourceName:            "ovh_storage_efs_share_snapshot.snapshot",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{},
+				ImportStateIdFunc:       testAccStorageEfsShareSnapshotImportId("ovh_storage_efs_share_snapshot.snapshot"),
+			},
+		},
+	})
+}
+
+func testAccStorageEfsShareSnapshotImportId(resourceName string) resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return "", fmt.Errorf("resource not found: %s", resourceName)
+		}
+		return fmt.Sprintf(
+			"%s/%s/%s",
+			rs.Primary.Attributes["service_name"],
+			rs.Primary.Attributes["share_id"],
+			rs.Primary.Attributes["id"],
+		), nil
+	}
 }

--- a/ovh/resource_storage_efs_share_test.go
+++ b/ovh/resource_storage_efs_share_test.go
@@ -6,7 +6,18 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
 )
+
+const testAccStorageEfsShareConfig_basic = `
+resource "ovh_storage_efs_share" "share" {
+  service_name = "%s"
+  name         = "share"
+  description  = "My share"
+  protocol     = "NFS"
+  size         = 100
+}
+`
 
 func TestAccStorageEfsShare_basic(t *testing.T) {
 	serviceName := os.Getenv("OVH_STORAGE_EFS_SERVICE_TEST")
@@ -16,14 +27,7 @@ func TestAccStorageEfsShare_basic(t *testing.T) {
 		PreCheck:                 func() { testAccPreCheckStorageEfs(t); testAccCheckStorageEfsExists(t) },
 		Steps: []resource.TestStep{
 			{
-				Config: fmt.Sprintf(`
-resource "ovh_storage_efs_share" "share" {
-  service_name = "%s"
-  name         = "share"
-  description  = "My share"
-  protocol     = "NFS"
-  size         = 100
-}`,
+				Config: fmt.Sprintf(testAccStorageEfsShareConfig_basic,
 					serviceName,
 				),
 				Check: resource.ComposeAggregateTestCheckFunc(
@@ -64,4 +68,51 @@ resource "ovh_storage_efs_share" "share" {
 		},
 	})
 
+}
+
+func TestAccStorageEfsShare_import(t *testing.T) {
+	serviceName := os.Getenv("OVH_STORAGE_EFS_SERVICE_TEST")
+	config := fmt.Sprintf(testAccStorageEfsShareConfig_basic, serviceName)
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		PreCheck:                 func() { testAccPreCheckStorageEfs(t); testAccCheckStorageEfsExists(t) },
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("ovh_storage_efs_share.share", "service_name", serviceName),
+					resource.TestCheckResourceAttrSet("ovh_storage_efs_share.share", "id"),
+					resource.TestCheckResourceAttrSet("ovh_storage_efs_share.share", "created_at"),
+					resource.TestCheckResourceAttr("ovh_storage_efs_share.share", "name", "share"),
+					resource.TestCheckResourceAttr("ovh_storage_efs_share.share", "description", "My share"),
+					resource.TestCheckResourceAttr("ovh_storage_efs_share.share", "protocol", "NFS"),
+					resource.TestCheckResourceAttr("ovh_storage_efs_share.share", "size", "100"),
+					resource.TestCheckResourceAttr("ovh_storage_efs_share.share", "status", "available"),
+					resource.TestCheckResourceAttr("ovh_storage_efs_share.share", "snapshot_id", ""),
+				),
+			},
+			{
+				ResourceName:            "ovh_storage_efs_share.share",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{},
+				ImportStateIdFunc:       testAccStorageEfsShareImportId("ovh_storage_efs_share.share"),
+			},
+		},
+	})
+}
+
+func testAccStorageEfsShareImportId(resourceName string) resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return "", fmt.Errorf("resource not found: %s", resourceName)
+		}
+		return fmt.Sprintf(
+			"%s/%s",
+			rs.Primary.Attributes["service_name"],
+			rs.Primary.Attributes["id"],
+		), nil
+	}
 }

--- a/templates/resources/storage_efs_share.md.tmpl
+++ b/templates/resources/storage_efs_share.md.tmpl
@@ -31,3 +31,20 @@ Creates a share for an EFS service.
 - `created_at` (String) Share creation date
 - `id` (String) Share ID
 - `status` (String) Share status
+
+## Import
+
+An EFS share can be imported using its `service_name` and `id` fields.
+
+Using the following configuration:
+
+{{tffile "examples/resources/storage_efs_share/import.tf"}}
+
+You can then run:
+
+```bash
+$ terraform plan -generate-config-out=share.tf
+$ terraform apply
+```
+
+The file `share.tf` will then contain the imported resource's configuration, that can be copied next to the `import` block above. See https://developer.hashicorp.com/terraform/language/import/generating-configuration for more details.

--- a/templates/resources/storage_efs_share_acl.md.tmpl
+++ b/templates/resources/storage_efs_share_acl.md.tmpl
@@ -30,3 +30,20 @@ Please take a look at the list of available `access_level` values in the `Requir
 - `created_at` (String) Rule creation date
 - `id` (String) Rule ID
 - `status` (String) Rule status
+
+## Import
+
+An EFS share ACL can be imported using its `service_name`, `share_id` and `id` fields.
+
+Using the following configuration:
+
+{{tffile "examples/resources/storage_efs_share_acl/import.tf"}}
+
+You can then run:
+
+```bash
+$ terraform plan -generate-config-out=acl.tf
+$ terraform apply
+```
+
+The file `acl.tf` will then contain the imported resource's configuration, that can be copied next to the `import` block above. See https://developer.hashicorp.com/terraform/language/import/generating-configuration for more details.

--- a/templates/resources/storage_efs_share_snapshot.md.tmpl
+++ b/templates/resources/storage_efs_share_snapshot.md.tmpl
@@ -34,3 +34,20 @@ Please note the `time_sleep` resource that was added as the `ovh_storage_efs_sha
 - `path` (String) Snapshot path
 - `status` (String) Snapshot status
 - `type` (String) Snapshot type
+
+## Import
+
+An EFS share snapshot can be imported using its `service_name`, `share_id` and `id` fields.
+
+Using the following configuration:
+
+{{tffile "examples/resources/storage_efs_share_snapshot/import.tf"}}
+
+You can then run:
+
+```bash
+$ terraform plan -generate-config-out=snapshot.tf
+$ terraform apply
+```
+
+The file `snapshot.tf` will then contain the imported resource's configuration, that can be copied next to the `import` block above. See https://developer.hashicorp.com/terraform/language/import/generating-configuration for more details.


### PR DESCRIPTION
# Description

Add ability to import EFS share, snapshot and ACL resources.

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

`OVH_STORAGE_EFS_SERVICE_TEST` variable needs to be set with an EFS service ID.

- [x] Test Share import: `make testacc TESTARGS="-run TestAccStorageEfsShare_import"`
- [x] Test Snapshot import: `make testacc TESTARGS="-run TestAccStorageEfsShareSnapshot_import"`
- [x] Test ACL import: `make testacc TESTARGS="-run TestAccStorageEfsShareAcl_import"`

**Test Configuration**:
* Terraform version: `terraform version`: Terraform v1.8.3


* Existing HCL configuration you used: 

Uncomment the import to test, fill in the EFS service name and ids, then run the import command.
 
```hcl
/*
import {
  to = ovh_storage_efs_share.share
  id = "<service_name>/<id>"
}
*/

/*
import {
  to = ovh_storage_efs_share_snapshot.snapshot
  id = "<service_name>/<share_id>/<id>"
}
*/

/*
import {
  to = ovh_storage_efs_share_acl.acl
  id = "<service_name>/<share_id>/<id>"
}
*/
```
```bash
$ terraform plan -generate-config-out=out.tf
$ terraform apply
```

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or issues
- [x] I have added acceptance tests that prove my fix is effective or that my feature works
- [x] New and existing acceptance tests pass locally with my changes
- [x] I ran successfully `go mod vendor` if I added or modify `go.mod` file