### PR TITLE
fix(blockstorage): stop spurious replacements on update + plan-time v…

### DIFF
--- a/ovh/resource_cloud_storage_block_volume.go
+++ b/ovh/resource_cloud_storage_block_volume.go
@@ -7,6 +7,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
@@ -14,6 +16,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/ovh/go-ovh/ovh"
 	ovhtypes "github.com/ovh/terraform-provider-ovh/v2/ovh/types"
@@ -77,11 +80,17 @@ func (r *cloudStorageBlockVolumeResource) Schema(ctx context.Context, req resour
 				Required:            true,
 				Description:         "Volume name",
 				MarkdownDescription: "Volume name",
+				Validators: []validator.String{
+					stringvalidator.LengthAtLeast(1),
+				},
 			},
 			"size": schema.Int64Attribute{
 				Required:            true,
 				Description:         "Size of the volume in GB",
 				MarkdownDescription: "Size of the volume in GB",
+				Validators: []validator.Int64{
+					int64validator.AtLeast(1),
+				},
 			},
 			"region": schema.StringAttribute{
 				CustomType:          ovhtypes.TfStringType{},
@@ -97,6 +106,9 @@ func (r *cloudStorageBlockVolumeResource) Schema(ctx context.Context, req resour
 				Required:            true,
 				Description:         "Volume type (CLASSIC, HIGH_SPEED, HIGH_SPEED_GEN2). Can be changed after creation (triggers online retype).",
 				MarkdownDescription: "Volume type (`CLASSIC`, `HIGH_SPEED`, `HIGH_SPEED_GEN2`). Can be changed after creation (triggers online retype).",
+				Validators: []validator.String{
+					stringvalidator.OneOf("CLASSIC", "HIGH_SPEED", "HIGH_SPEED_GEN2"),
+				},
 			},
 			"encryption": schema.SingleNestedAttribute{
 				Optional:            true,
@@ -104,6 +116,11 @@ func (r *cloudStorageBlockVolumeResource) Schema(ctx context.Context, req resour
 				Description:         "Encryption configuration for the volume. Changing this value recreates the resource.",
 				MarkdownDescription: "Encryption configuration for the volume. **Changing this value recreates the resource.**",
 				PlanModifiers: []planmodifier.Object{
+					// UseStateForUnknown MUST run before RequiresReplace: when the
+					// config omits `encryption`, the framework marks this computed
+					// attribute unknown on every plan with changes, and RequiresReplace
+					// would otherwise see unknown != state and force a spurious replace.
+					objectplanmodifier.UseStateForUnknown(),
 					objectplanmodifier.RequiresReplace(),
 				},
 				Attributes: map[string]schema.Attribute{
@@ -113,6 +130,7 @@ func (r *cloudStorageBlockVolumeResource) Schema(ctx context.Context, req resour
 						Description:         "Whether the volume is encrypted at rest with LUKS",
 						MarkdownDescription: "Whether the volume is encrypted at rest with LUKS",
 						PlanModifiers: []planmodifier.Bool{
+							boolplanmodifier.UseStateForUnknown(),
 							boolplanmodifier.RequiresReplace(),
 						},
 					},
@@ -131,6 +149,14 @@ func (r *cloudStorageBlockVolumeResource) Schema(ctx context.Context, req resour
 						Optional:            true,
 						Description:         "Identifier of a backup to restore the volume from",
 						MarkdownDescription: "Identifier of a backup to restore the volume from",
+						Validators: []validator.String{
+							// Exactly one source must be set when create_from is present.
+							// The validated attribute (backup_id) is implicitly included.
+							stringvalidator.ExactlyOneOf(
+								path.MatchRelative().AtParent().AtName("snapshot_id"),
+								path.MatchRelative().AtParent().AtName("image_id"),
+							),
+						},
 					},
 					"snapshot_id": schema.StringAttribute{
 						CustomType:          ovhtypes.TfStringType{},
@@ -151,6 +177,13 @@ func (r *cloudStorageBlockVolumeResource) Schema(ctx context.Context, req resour
 				Computed:            true,
 				Description:         "Volume ID",
 				MarkdownDescription: "Volume ID",
+				PlanModifiers: []planmodifier.String{
+					// An ID never changes once created. Without this, the framework
+					// marks `id` unknown on every in-place update, which cascades a
+					// spurious replacement to dependent resources referencing it
+					// (e.g. backups/snapshots via volume_id, which is RequiresReplace).
+					stringplanmodifier.UseStateForUnknown(),
+				},
 			},
 			"checksum": schema.StringAttribute{
 				CustomType:          ovhtypes.TfStringType{},
@@ -166,6 +199,10 @@ func (r *cloudStorageBlockVolumeResource) Schema(ctx context.Context, req resour
 				Computed:            true,
 				Description:         "Creation date of the volume",
 				MarkdownDescription: "Creation date of the volume",
+				PlanModifiers: []planmodifier.String{
+					// Creation date never changes after create.
+					stringplanmodifier.UseStateForUnknown(),
+				},
 			},
 			"updated_at": schema.StringAttribute{
 				CustomType:          ovhtypes.TfStringType{},

--- a/ovh/resource_cloud_storage_block_volume_backup.go
+++ b/ovh/resource_cloud_storage_block_volume_backup.go
@@ -7,11 +7,13 @@ import (
 	"strings"
 	"time"
 
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/ovh/go-ovh/ovh"
 	ovhtypes "github.com/ovh/terraform-provider-ovh/v2/ovh/types"
@@ -74,6 +76,9 @@ func (r *cloudStorageBlockVolumeBackupResource) Schema(ctx context.Context, req 
 				Required:            true,
 				Description:         "Backup name",
 				MarkdownDescription: "Backup name",
+				Validators: []validator.String{
+					stringvalidator.LengthAtLeast(1),
+				},
 			},
 			"description": schema.StringAttribute{
 				CustomType:          ovhtypes.TfStringType{},
@@ -105,6 +110,11 @@ func (r *cloudStorageBlockVolumeBackupResource) Schema(ctx context.Context, req 
 				Computed:            true,
 				Description:         "Backup ID",
 				MarkdownDescription: "Backup ID",
+				PlanModifiers: []planmodifier.String{
+					// An ID never changes once created; keep it known during updates
+					// so dependent resources are not spuriously replaced.
+					stringplanmodifier.UseStateForUnknown(),
+				},
 			},
 			"checksum": schema.StringAttribute{
 				CustomType:          ovhtypes.TfStringType{},
@@ -120,6 +130,10 @@ func (r *cloudStorageBlockVolumeBackupResource) Schema(ctx context.Context, req 
 				Computed:            true,
 				Description:         "Creation date of the backup",
 				MarkdownDescription: "Creation date of the backup",
+				PlanModifiers: []planmodifier.String{
+					// Creation date never changes after create.
+					stringplanmodifier.UseStateForUnknown(),
+				},
 			},
 			"updated_at": schema.StringAttribute{
 				CustomType:          ovhtypes.TfStringType{},

--- a/ovh/resource_cloud_storage_block_volume_snapshot.go
+++ b/ovh/resource_cloud_storage_block_volume_snapshot.go
@@ -7,11 +7,13 @@ import (
 	"strings"
 	"time"
 
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/ovh/go-ovh/ovh"
 	ovhtypes "github.com/ovh/terraform-provider-ovh/v2/ovh/types"
@@ -74,6 +76,9 @@ func (r *cloudStorageBlockVolumeSnapshotResource) Schema(ctx context.Context, re
 				Required:            true,
 				Description:         "Snapshot name",
 				MarkdownDescription: "Snapshot name",
+				Validators: []validator.String{
+					stringvalidator.LengthAtLeast(1),
+				},
 			},
 			"description": schema.StringAttribute{
 				CustomType:          ovhtypes.TfStringType{},
@@ -105,6 +110,11 @@ func (r *cloudStorageBlockVolumeSnapshotResource) Schema(ctx context.Context, re
 				Computed:            true,
 				Description:         "Snapshot ID",
 				MarkdownDescription: "Snapshot ID",
+				PlanModifiers: []planmodifier.String{
+					// An ID never changes once created; keep it known during updates
+					// so dependent resources are not spuriously replaced.
+					stringplanmodifier.UseStateForUnknown(),
+				},
 			},
 			"checksum": schema.StringAttribute{
 				CustomType:          ovhtypes.TfStringType{},
@@ -120,6 +130,10 @@ func (r *cloudStorageBlockVolumeSnapshotResource) Schema(ctx context.Context, re
 				Computed:            true,
 				Description:         "Creation date of the snapshot",
 				MarkdownDescription: "Creation date of the snapshot",
+				PlanModifiers: []planmodifier.String{
+					// Creation date never changes after create.
+					stringplanmodifier.UseStateForUnknown(),
+				},
 			},
 			"updated_at": schema.StringAttribute{
 				CustomType:          ovhtypes.TfStringType{},

--- a/ovh/types_cloud_storage_block_volume.go
+++ b/ovh/types_cloud_storage_block_volume.go
@@ -276,6 +276,19 @@ func (m *CloudStorageBlockVolumeModel) MergeWith(ctx context.Context, response *
 				},
 			)
 			m.Encryption = encryptionObj
+		} else if response.CurrentState != nil && response.CurrentState.Encryption != nil {
+			// Defensive backfill: encryption is immutable at the OpenStack level,
+			// so currentState.encryption is authoritative when targetSpec omits it.
+			// Keeping the root attribute populated (instead of null) lets
+			// UseStateForUnknown stabilize plans for volumes created without an
+			// encryption block, avoiding spurious RequiresReplace diffs.
+			encryptionObj, _ := types.ObjectValue(
+				BlockVolumeEncryptionAttrTypes(),
+				map[string]attr.Value{
+					"enabled": types.BoolValue(response.CurrentState.Encryption.Enabled),
+				},
+			)
+			m.Encryption = encryptionObj
 		} else if m.Encryption.IsUnknown() {
 			m.Encryption = types.ObjectNull(BlockVolumeEncryptionAttrTypes())
 		}

--- a/ovh/types_cloud_storage_block_volume_test.go
+++ b/ovh/types_cloud_storage_block_volume_test.go
@@ -5,8 +5,13 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/boolplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	ovhtypes "github.com/ovh/terraform-provider-ovh/v2/ovh/types"
 )
@@ -55,18 +60,31 @@ func TestCloudStorageBlockVolumeToUpdate_DoesNotIncludeEncryption(t *testing.T) 
 }
 
 func TestCloudStorageBlockVolumeSchema_EncryptionEnabledRequiresReplace(t *testing.T) {
+	ctx := context.Background()
 	r := &cloudStorageBlockVolumeResource{}
 	var resp resource.SchemaResponse
 
-	r.Schema(context.Background(), resource.SchemaRequest{}, &resp)
+	r.Schema(ctx, resource.SchemaRequest{}, &resp)
 
 	encryptionAttr, ok := resp.Schema.Attributes["encryption"].(schema.SingleNestedAttribute)
 	if !ok {
 		t.Fatalf("expected encryption attribute to be SingleNestedAttribute, got %T", resp.Schema.Attributes["encryption"])
 	}
 
-	if len(encryptionAttr.PlanModifiers) == 0 {
-		t.Fatal("expected encryption object attribute to have replace plan modifier")
+	// UseStateForUnknown MUST come before RequiresReplace: it restores the
+	// state value when the framework marks the unconfigured computed attribute
+	// unknown, so RequiresReplace no longer sees a spurious diff.
+	useStateDesc := objectplanmodifier.UseStateForUnknown().Description(ctx)
+	replaceDesc := objectplanmodifier.RequiresReplace().Description(ctx)
+
+	if len(encryptionAttr.PlanModifiers) != 2 {
+		t.Fatalf("expected encryption to have exactly 2 plan modifiers (UseStateForUnknown, RequiresReplace), got %d", len(encryptionAttr.PlanModifiers))
+	}
+	if got := encryptionAttr.PlanModifiers[0].Description(ctx); got != useStateDesc {
+		t.Fatalf("expected encryption plan modifier #0 to be UseStateForUnknown, got %q", got)
+	}
+	if got := encryptionAttr.PlanModifiers[1].Description(ctx); got != replaceDesc {
+		t.Fatalf("expected encryption plan modifier #1 to be RequiresReplace, got %q", got)
 	}
 
 	enabledAttr, ok := encryptionAttr.Attributes["enabled"].(schema.BoolAttribute)
@@ -74,7 +92,206 @@ func TestCloudStorageBlockVolumeSchema_EncryptionEnabledRequiresReplace(t *testi
 		t.Fatalf("expected encryption.enabled attribute to be BoolAttribute, got %T", encryptionAttr.Attributes["enabled"])
 	}
 
-	if len(enabledAttr.PlanModifiers) == 0 {
-		t.Fatal("expected encryption.enabled to have RequiresReplace plan modifier")
+	boolUseStateDesc := boolplanmodifier.UseStateForUnknown().Description(ctx)
+	boolReplaceDesc := boolplanmodifier.RequiresReplace().Description(ctx)
+
+	if len(enabledAttr.PlanModifiers) != 2 {
+		t.Fatalf("expected encryption.enabled to have exactly 2 plan modifiers (UseStateForUnknown, RequiresReplace), got %d", len(enabledAttr.PlanModifiers))
+	}
+	if got := enabledAttr.PlanModifiers[0].Description(ctx); got != boolUseStateDesc {
+		t.Fatalf("expected encryption.enabled plan modifier #0 to be UseStateForUnknown, got %q", got)
+	}
+	if got := enabledAttr.PlanModifiers[1].Description(ctx); got != boolReplaceDesc {
+		t.Fatalf("expected encryption.enabled plan modifier #1 to be RequiresReplace, got %q", got)
+	}
+}
+
+// blockStorageResourceSchemas returns the schemas of the three block storage
+// resources, keyed by a short name for test reporting.
+func blockStorageResourceSchemas(ctx context.Context, t *testing.T) map[string]schema.Schema {
+	t.Helper()
+
+	schemas := map[string]schema.Schema{}
+
+	var volumeResp resource.SchemaResponse
+	(&cloudStorageBlockVolumeResource{}).Schema(ctx, resource.SchemaRequest{}, &volumeResp)
+	schemas["volume"] = volumeResp.Schema
+
+	var backupResp resource.SchemaResponse
+	(&cloudStorageBlockVolumeBackupResource{}).Schema(ctx, resource.SchemaRequest{}, &backupResp)
+	schemas["backup"] = backupResp.Schema
+
+	var snapshotResp resource.SchemaResponse
+	(&cloudStorageBlockVolumeSnapshotResource{}).Schema(ctx, resource.SchemaRequest{}, &snapshotResp)
+	schemas["snapshot"] = snapshotResp.Schema
+
+	return schemas
+}
+
+// stringAttrHasUseStateForUnknown checks that a string attribute carries the
+// UseStateForUnknown plan modifier.
+func stringAttrHasUseStateForUnknown(ctx context.Context, t *testing.T, s schema.Schema, name string) bool {
+	t.Helper()
+
+	a, ok := s.Attributes[name].(schema.StringAttribute)
+	if !ok {
+		t.Fatalf("expected %q attribute to be StringAttribute, got %T", name, s.Attributes[name])
+	}
+
+	useStateDesc := stringplanmodifier.UseStateForUnknown().Description(ctx)
+	for _, pm := range a.PlanModifiers {
+		if pm.Description(ctx) == useStateDesc {
+			return true
+		}
+	}
+	return false
+}
+
+// TestCloudStorageBlockSchemas_IDAndCreatedAtUseStateForUnknown ensures the
+// computed id and created_at attributes keep their known state value during
+// updates. Without UseStateForUnknown on id, an in-place volume update marks
+// id as unknown, which cascades a spurious replacement to backups/snapshots
+// referencing it through their RequiresReplace volume_id attribute.
+func TestCloudStorageBlockSchemas_IDAndCreatedAtUseStateForUnknown(t *testing.T) {
+	ctx := context.Background()
+
+	for resName, s := range blockStorageResourceSchemas(ctx, t) {
+		for _, attrName := range []string{"id", "created_at"} {
+			if !stringAttrHasUseStateForUnknown(ctx, t, s, attrName) {
+				t.Errorf("%s: expected %q to have UseStateForUnknown plan modifier", resName, attrName)
+			}
+		}
+	}
+}
+
+// TestCloudStorageBlockSchemas_MutableComputedAttrsDoNotPinState ensures the
+// attributes that legitimately change on update do NOT carry UseStateForUnknown.
+func TestCloudStorageBlockSchemas_MutableComputedAttrsDoNotPinState(t *testing.T) {
+	ctx := context.Background()
+
+	for resName, s := range blockStorageResourceSchemas(ctx, t) {
+		for _, attrName := range []string{"checksum", "updated_at", "resource_status"} {
+			if stringAttrHasUseStateForUnknown(ctx, t, s, attrName) {
+				t.Errorf("%s: %q legitimately changes on update and must not have UseStateForUnknown", resName, attrName)
+			}
+		}
+	}
+}
+
+func runStringValidators(ctx context.Context, validators []validator.String, p path.Path, value types.String) *validator.StringResponse {
+	req := validator.StringRequest{
+		Path:           p,
+		PathExpression: path.MatchRoot(p.String()),
+		ConfigValue:    value,
+	}
+	resp := &validator.StringResponse{}
+	for _, v := range validators {
+		v.ValidateString(ctx, req, resp)
+	}
+	return resp
+}
+
+func TestCloudStorageBlockVolumeSchema_VolumeTypeValidator(t *testing.T) {
+	ctx := context.Background()
+	s := blockStorageResourceSchemas(ctx, t)["volume"]
+
+	a, ok := s.Attributes["volume_type"].(schema.StringAttribute)
+	if !ok {
+		t.Fatalf("expected volume_type to be StringAttribute, got %T", s.Attributes["volume_type"])
+	}
+	if len(a.Validators) == 0 {
+		t.Fatal("expected volume_type to have a OneOf validator")
+	}
+
+	for _, valid := range []string{"CLASSIC", "HIGH_SPEED", "HIGH_SPEED_GEN2"} {
+		resp := runStringValidators(ctx, a.Validators, path.Root("volume_type"), types.StringValue(valid))
+		if resp.Diagnostics.HasError() {
+			t.Errorf("expected %q to be a valid volume_type, got: %v", valid, resp.Diagnostics)
+		}
+	}
+
+	resp := runStringValidators(ctx, a.Validators, path.Root("volume_type"), types.StringValue("NOT_A_VOLUME_TYPE"))
+	if !resp.Diagnostics.HasError() {
+		t.Error("expected an invalid volume_type to be rejected at plan time")
+	}
+}
+
+func TestCloudStorageBlockVolumeSchema_SizeValidator(t *testing.T) {
+	ctx := context.Background()
+	s := blockStorageResourceSchemas(ctx, t)["volume"]
+
+	a, ok := s.Attributes["size"].(schema.Int64Attribute)
+	if !ok {
+		t.Fatalf("expected size to be Int64Attribute, got %T", s.Attributes["size"])
+	}
+	if len(a.Validators) == 0 {
+		t.Fatal("expected size to have an AtLeast validator")
+	}
+
+	for _, tc := range []struct {
+		value     int64
+		expectErr bool
+	}{
+		{0, true},
+		{-1, true},
+		{1, false},
+		{100, false},
+	} {
+		req := validator.Int64Request{
+			Path:           path.Root("size"),
+			PathExpression: path.MatchRoot("size"),
+			ConfigValue:    types.Int64Value(tc.value),
+		}
+		resp := &validator.Int64Response{}
+		for _, v := range a.Validators {
+			v.ValidateInt64(ctx, req, resp)
+		}
+		if resp.Diagnostics.HasError() != tc.expectErr {
+			t.Errorf("size=%d: expected error=%t, got diagnostics: %v", tc.value, tc.expectErr, resp.Diagnostics)
+		}
+	}
+}
+
+func TestCloudStorageBlockSchemas_NameValidator(t *testing.T) {
+	ctx := context.Background()
+
+	for resName, s := range blockStorageResourceSchemas(ctx, t) {
+		a, ok := s.Attributes["name"].(schema.StringAttribute)
+		if !ok {
+			t.Fatalf("%s: expected name to be StringAttribute, got %T", resName, s.Attributes["name"])
+		}
+		if len(a.Validators) == 0 {
+			t.Fatalf("%s: expected name to have a LengthAtLeast validator", resName)
+		}
+
+		resp := runStringValidators(ctx, a.Validators, path.Root("name"), types.StringValue(""))
+		if !resp.Diagnostics.HasError() {
+			t.Errorf("%s: expected an empty name to be rejected at plan time", resName)
+		}
+
+		resp = runStringValidators(ctx, a.Validators, path.Root("name"), types.StringValue("valid-name"))
+		if resp.Diagnostics.HasError() {
+			t.Errorf("%s: expected a non-empty name to be accepted, got: %v", resName, resp.Diagnostics)
+		}
+	}
+}
+
+func TestCloudStorageBlockVolumeSchema_CreateFromExactlyOneOf(t *testing.T) {
+	ctx := context.Background()
+	s := blockStorageResourceSchemas(ctx, t)["volume"]
+
+	createFromAttr, ok := s.Attributes["create_from"].(schema.SingleNestedAttribute)
+	if !ok {
+		t.Fatalf("expected create_from to be SingleNestedAttribute, got %T", s.Attributes["create_from"])
+	}
+
+	backupIDAttr, ok := createFromAttr.Attributes["backup_id"].(schema.StringAttribute)
+	if !ok {
+		t.Fatalf("expected create_from.backup_id to be StringAttribute, got %T", createFromAttr.Attributes["backup_id"])
+	}
+
+	// ExactlyOneOf needs a full config to run, so only assert its presence.
+	if len(backupIDAttr.Validators) == 0 {
+		t.Fatal("expected create_from.backup_id to have an ExactlyOneOf validator covering backup_id/snapshot_id/image_id")
 	}
 }

--- a/ovh/types_cloud_storage_block_volume_test.go
+++ b/ovh/types_cloud_storage_block_volume_test.go
@@ -59,6 +59,120 @@ func TestCloudStorageBlockVolumeToUpdate_DoesNotIncludeEncryption(t *testing.T) 
 	}
 }
 
+// blockVolumeAPIResponse builds a minimal API response for MergeWith tests.
+// targetEncryption and currentEncryption may be nil; currentState is omitted
+// entirely when withCurrentState is false.
+func blockVolumeAPIResponse(withCurrentState bool, targetEncryption, currentEncryption *CloudStorageBlockVolumeEncryption) *CloudStorageBlockVolumeAPIResponse {
+	response := &CloudStorageBlockVolumeAPIResponse{
+		Id:             "volume-id",
+		Checksum:       "checksum-123",
+		CreatedAt:      "2026-01-01T00:00:00Z",
+		UpdatedAt:      "2026-01-01T00:00:00Z",
+		ResourceStatus: "READY",
+		TargetSpec: &CloudStorageBlockVolumeTarget{
+			Location:   &CloudStorageBlockVolumeLocation{Region: "GRA9"},
+			Name:       "test-volume",
+			Size:       20,
+			VolumeType: "CLASSIC",
+			Encryption: targetEncryption,
+		},
+	}
+
+	if withCurrentState {
+		response.CurrentState = &CloudStorageBlockVolumeCurrentState{
+			Location:   &CloudStorageBlockVolumeLocation{Region: "GRA9"},
+			Name:       "test-volume",
+			Size:       20,
+			VolumeType: "CLASSIC",
+			Status:     "available",
+			Encryption: currentEncryption,
+		}
+	}
+
+	return response
+}
+
+func encryptionObjectValue(t *testing.T, enabled bool) types.Object {
+	t.Helper()
+	return types.ObjectValueMust(
+		BlockVolumeEncryptionAttrTypes(),
+		map[string]attr.Value{
+			"enabled": types.BoolValue(enabled),
+		},
+	)
+}
+
+// TestCloudStorageBlockVolumeMergeWith_EncryptionBackfillFromCurrentState
+// covers the defensive backfill: when the API GET omits targetSpec.encryption,
+// the root encryption attribute must be filled from currentState.encryption so
+// that UseStateForUnknown keeps plans stable for volumes created without an
+// encryption block.
+func TestCloudStorageBlockVolumeMergeWith_EncryptionBackfillFromCurrentState(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("targetSpec encryption nil, currentState encryption set", func(t *testing.T) {
+		model := CloudStorageBlockVolumeModel{
+			Encryption: types.ObjectNull(BlockVolumeEncryptionAttrTypes()),
+		}
+		model.MergeWith(ctx, blockVolumeAPIResponse(true, nil, &CloudStorageBlockVolumeEncryption{Enabled: false}))
+
+		want := encryptionObjectValue(t, false)
+		if !model.Encryption.Equal(want) {
+			t.Fatalf("expected encryption to be backfilled from currentState (%s), got %s", want, model.Encryption)
+		}
+	})
+
+	t.Run("targetSpec encryption set wins over currentState", func(t *testing.T) {
+		model := CloudStorageBlockVolumeModel{
+			Encryption: types.ObjectUnknown(BlockVolumeEncryptionAttrTypes()),
+		}
+		model.MergeWith(ctx, blockVolumeAPIResponse(true,
+			&CloudStorageBlockVolumeEncryption{Enabled: true},
+			&CloudStorageBlockVolumeEncryption{Enabled: false},
+		))
+
+		want := encryptionObjectValue(t, true)
+		if !model.Encryption.Equal(want) {
+			t.Fatalf("expected encryption to come from targetSpec (%s), got %s", want, model.Encryption)
+		}
+	})
+
+	t.Run("both targetSpec and currentState encryption absent leaves value as-is", func(t *testing.T) {
+		prior := encryptionObjectValue(t, true)
+		model := CloudStorageBlockVolumeModel{
+			Encryption: prior,
+		}
+		model.MergeWith(ctx, blockVolumeAPIResponse(true, nil, nil))
+
+		if !model.Encryption.Equal(prior) {
+			t.Fatalf("expected encryption to be left untouched (%s), got %s", prior, model.Encryption)
+		}
+	})
+
+	t.Run("currentState absent entirely leaves value as-is", func(t *testing.T) {
+		prior := types.ObjectNull(BlockVolumeEncryptionAttrTypes())
+		model := CloudStorageBlockVolumeModel{
+			Encryption: prior,
+		}
+		model.MergeWith(ctx, blockVolumeAPIResponse(false, nil, nil))
+
+		if !model.Encryption.Equal(prior) {
+			t.Fatalf("expected encryption to be left untouched (%s), got %s", prior, model.Encryption)
+		}
+	})
+
+	t.Run("both absent with unknown value falls back to null", func(t *testing.T) {
+		model := CloudStorageBlockVolumeModel{
+			Encryption: types.ObjectUnknown(BlockVolumeEncryptionAttrTypes()),
+		}
+		model.MergeWith(ctx, blockVolumeAPIResponse(true, nil, nil))
+
+		if !model.Encryption.IsNull() {
+			t.Fatalf("expected unknown encryption to be resolved to null, got %s", model.Encryption)
+		}
+	})
+}
+
 func TestCloudStorageBlockVolumeSchema_EncryptionEnabledRequiresReplace(t *testing.T) {
 	ctx := context.Background()
 	r := &cloudStorageBlockVolumeResource{}


### PR DESCRIPTION
…alidators

Two plan bugs on the apiv2 block storage resources, both caused by the framework marking unconfigured Computed attributes as unknown on every plan that contains any change:

- encryption (Optional+Computed, RequiresReplace): when the config omits the block, any unrelated change (resize, rename, retype) turned it into "(known after apply)" and RequiresReplace forced a destroy/create of the volume. UseStateForUnknown is now applied BEFORE RequiresReplace (on the object and its nested enabled bool) so the prior state value is restored and a real user-driven encryption change still replaces.

- id (Computed): marked unknown on every in-place volume update, which cascaded into replacing dependent backups/snapshots through their RequiresReplace volume_id. UseStateForUnknown is now set on id and created_at of volume, backup and snapshot (values that can never change without a replace). checksum/updated_at/current_state/resource_status are intentionally left untouched as they legitimately change on update.

Also adds plan-time validators that previously only failed at apply:
- volume.create_from: ExactlyOneOf(backup_id, snapshot_id, image_id)
- volume.volume_type: OneOf(CLASSIC, HIGH_SPEED, HIGH_SPEED_GEN2)
- volume.size: AtLeast(1)
- name: LengthAtLeast(1) on volume, backup and snapshot

Unit tests cover modifier presence/ordering and validator behavior.

# Description

Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes #xx (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (improve existing resource(s) or datasource(s))
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A: `make testacc TESTARGS="-run TestAccDataSourceXxxxYyyyZzzzz_basic"`
- [ ] Test B: `make testacc TESTARGS="-run TestAccDataSourceXxxxYyyyZzzzz_basic"`

**Test Configuration**:
* Terraform version: `terraform version`: Terraform vx.y.z
* Existing HCL configuration you used: 
```hcl
resource "" "" {
 xx = "yy"
 zz = "aa"
}
```

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings or issues
- [ ] I have added acceptance tests that prove my fix is effective or that my feature works
- [ ] New and existing acceptance tests pass locally with my changes
- [ ] I ran successfully `go mod vendor` if I added or modify `go.mod` file
