### PR TITLE
Fix(cloud_project_database): scale nodes in place, keep region/network ForceNew

### DIFF
--- a/ovh/resource_cloud_project_database.go
+++ b/ovh/resource_cloud_project_database.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/ovh/terraform-provider-ovh/v2/ovh/helpers"
 	"golang.org/x/exp/slices"
@@ -109,13 +110,11 @@ func resourceCloudProjectDatabase() *schema.Resource {
 						"network_id": {
 							Type:        schema.TypeString,
 							Description: "Private network ID in which the node is. It's the regional openstackId of the private network.",
-							ForceNew:    true,
 							Optional:    true,
 						},
 						"region": {
 							Type:        schema.TypeString,
 							Description: "Region of the node",
-							ForceNew:    true,
 							Required:    true,
 						},
 						"subnet_id": {
@@ -256,6 +255,27 @@ func resourceCloudProjectDatabase() *schema.Resource {
 				Computed:    true,
 			},
 		},
+
+		// Manage adding or removing
+		CustomizeDiff: customdiff.ForceNewIfChange("nodes", func(ctx context.Context, old, new, meta interface{}) bool {
+			oldNodes := old.([]interface{})
+			newNodes := new.([]interface{})
+
+			minLen := len(oldNodes)
+			if len(newNodes) < minLen {
+				minLen = len(newNodes)
+			}
+
+			for i := 0; i < minLen; i++ {
+				o := oldNodes[i].(map[string]interface{})
+				n := newNodes[i].(map[string]interface{})
+				if o["region"] != n["region"] || o["network_id"] != n["network_id"] {
+					return true
+				}
+			}
+
+			return false
+		}),
 	}
 }
 

--- a/ovh/resource_cloud_project_database_test.go
+++ b/ovh/resource_cloud_project_database_test.go
@@ -11,8 +11,13 @@ import (
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
+	"github.com/hashicorp/terraform-plugin-testing/compare"
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
+	"github.com/hashicorp/terraform-plugin-testing/statecheck"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
 )
 
 func init() {
@@ -162,6 +167,85 @@ func TestAccCloudProjectDatabase_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"ovh_cloud_project_database.db", "maintenance_time", "01:00:00"),
 				),
+			},
+		},
+	})
+}
+
+func testAccCloudProjectDatabasePlanUpgradeConfig(serviceName, description, engine, version, region, flavor, plan string, nbNodes int) string {
+	nodes := strings.Repeat(fmt.Sprintf(`
+	nodes {
+		region = "%s"
+	}`, region), nbNodes)
+
+	return fmt.Sprintf(`
+resource "ovh_cloud_project_database" "db" {
+	service_name = "%s"
+	description  = "%s"
+	engine       = "%s"
+	version      = "%s"
+	plan         = "%s"
+	flavor       = "%s"%s
+}
+`, serviceName, description, engine, version, plan, flavor, nodes)
+}
+
+func TestAccCloudProjectDatabase_planUpgradeNoReplace(t *testing.T) {
+	serviceName := os.Getenv("OVH_CLOUD_PROJECT_SERVICE_TEST")
+	engine := os.Getenv("OVH_CLOUD_PROJECT_DATABASE_ENGINE_TEST")
+	version := os.Getenv("OVH_CLOUD_PROJECT_DATABASE_VERSION_TEST")
+	region := os.Getenv("OVH_CLOUD_PROJECT_DATABASE_REGION_TEST")
+	flavor := os.Getenv("OVH_CLOUD_PROJECT_DATABASE_FLAVOR_TEST")
+	description := acctest.RandomWithPrefix(test_prefix)
+
+	configEssential := testAccCloudProjectDatabasePlanUpgradeConfig(serviceName, description, engine, version, region, flavor, "essential", 1)
+	configBusiness := testAccCloudProjectDatabasePlanUpgradeConfig(serviceName, description, engine, version, region, flavor, "business", 2)
+
+	compareIDSame := statecheck.CompareValue(compare.ValuesSame())
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheckCloudDatabase(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: configEssential,
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(
+						"ovh_cloud_project_database.db",
+						tfjsonpath.New("plan"),
+						knownvalue.StringExact("essential")),
+					statecheck.ExpectKnownValue(
+						"ovh_cloud_project_database.db",
+						tfjsonpath.New("nodes"),
+						knownvalue.ListSizeExact(1)),
+					compareIDSame.AddStateValue(
+						"ovh_cloud_project_database.db",
+						tfjsonpath.New("id")),
+				},
+			},
+			{
+				Config: configBusiness,
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(
+							"ovh_cloud_project_database.db",
+							plancheck.ResourceActionUpdate),
+					},
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(
+						"ovh_cloud_project_database.db",
+						tfjsonpath.New("plan"),
+						knownvalue.StringExact("business")),
+					statecheck.ExpectKnownValue(
+						"ovh_cloud_project_database.db",
+						tfjsonpath.New("nodes"),
+						knownvalue.ListSizeExact(2)),
+					// Same id as step 1 => updated in place, not recreated.
+					compareIDSame.AddStateValue(
+						"ovh_cloud_project_database.db",
+						tfjsonpath.New("id")),
+				},
 			},
 		},
 	})


### PR DESCRIPTION
# Description

Fix https://github.com/ovh/terraform-provider-ovh/issues/1327

Changing the `plan` of a `ovh_cloud_project_database` (e.g. `essential` -> `business`)
also changes the number of `nodes`. Because the `region` and `network_id`
fields of the `nodes` block were marked `ForceNew`, adding/removing a node in
the list triggered a full destroy/recreate of the cluster instead of an
in-place update.

This PR removes the static `ForceNew` from `nodes.region` / `nodes.network_id`
and replaces it with a `CustomizeDiff` (`customdiff.ForceNewIfChange`) that:
- allows adding or removing nodes as an in-place update (the node scaling is
  driven by the `plan` and handled API-side);
- still forces a replacement when the region or network of an existing node
  changes, since that cannot be done in place.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [X] Acceptance test added: `make testacc TESTARGS="-run TestAccCloudProjectDatabase_planUpgradeNoReplace"`
  Two steps: create with `plan = "essential"` (1 node), then update to
  `plan = "business"` (2 nodes). Asserts the plan action is an in-place
  `Update` (not a replace) and that the resource `id` is unchanged between steps.
- [X] Manual test with Terraform: applied an `essential` cluster, then switched
  `plan` and node count to `business`. `terraform plan` showed `~ update in-place`
  (no `# forces replacement`), `terraform apply` reported `0 destroyed`, and a
  subsequent `terraform plan` showed `No changes` (no residual drift).

**Test Configuration**:
* Existing HCL configuration you used:
```hcl
locals {
  plan_nodes = {
    essential = 1
    business  = 2
  }
}

resource "ovh_cloud_project_database" "ovh-managed-postgresql" {
  service_name = "<public_cloud_project_id>"
  description  = "pgsql-01-eu-ovh-test"
  engine       = "postgresql"
  version      = "15"
  flavor       = "db1-4"
  plan         = "essential" # -> "business"
  disk_size    = 80

  dynamic "nodes" {
    for_each = range(local.plan_nodes["essential"]) # -> ["business"]
    content {
      region = "GRA"
    }
  }

  ip_restrictions {
    ip = "0.0.0.0/0"
  }
}
