### PR TITLE
fix(cloud_project_database): make resource creation idempotent on 409/500 and persist id before READY wait

### DIFF
--- a/ovh/resource_cloud_project_database.go
+++ b/ovh/resource_cloud_project_database.go
@@ -299,14 +299,14 @@ func resourceCloudProjectDatabaseCreate(ctx context.Context, d *schema.ResourceD
 		return diag.Errorf("calling Post %s with params %+v:\n\t %q", endpoint, params, err)
 	}
 
+	d.SetId(res.ID)
+
 	log.Printf("[DEBUG] Waiting for database %s to be READY", res.ID)
 	err = waitForCloudProjectDatabaseReady(ctx, config.OVHClient, serviceName, engine, res.ID, d.Timeout(schema.TimeoutCreate))
 	if err != nil {
 		return diag.Errorf("timeout while waiting database %s to be READY: %s", res.ID, err.Error())
 	}
 	log.Printf("[DEBUG] database %s is READY", res.ID)
-
-	d.SetId(res.ID)
 
 	if (engine != "clickhouse" && engine != "mongodb" && len(d.Get("advanced_configuration").(map[string]interface{})) > 0) ||
 		(engine == "kafka" && d.Get("kafka_rest_api").(bool)) ||

--- a/ovh/resource_cloud_project_database_database.go
+++ b/ovh/resource_cloud_project_database_database.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/ovh/go-ovh/ovh"
 	"github.com/ovh/terraform-provider-ovh/v2/ovh/helpers"
 )
 
@@ -104,8 +105,24 @@ func resourceCloudProjectDatabaseDatabaseCreate(ctx context.Context, d *schema.R
 	log.Printf("[DEBUG] Will create database: %+v for cluster %s from project %s", params, clusterId, serviceName)
 	err := config.OVHClient.PostWithContext(ctx, endpoint, params, res)
 	if err != nil {
-		return diag.Errorf("calling Post %s with params %+v:\n\t %q", endpoint, params, err)
+		// Terraform-side hotfix until the API 500 root cause is found: on 409/500 the database
+		// may already exist, so recover it by name to stay idempotent.
+		errOvh, ok := err.(*ovh.APIError)
+		if !ok || (errOvh.Code != 409 && errOvh.Code != 500) {
+			return diag.Errorf("calling Post %s with params %+v:\n\t %q", endpoint, params, err)
+		}
+		recoveredId, rerr := findCloudProjectDatabaseDatabaseIDByName(ctx, config.OVHClient, serviceName, engine, clusterId, params.Name)
+		if rerr != nil {
+			return diag.Errorf("calling Post %s with params %+v returned %q; failed to recover the database by name: %s", endpoint, params, err, rerr.Error())
+		}
+		if recoveredId == "" {
+			return diag.Errorf("calling Post %s with params %+v:\n\t %q", endpoint, params, err)
+		}
+		log.Printf("[WARN] Post %s returned an error (%q) but database %q already exists with id %s; adopting it into the state", endpoint, err, params.Name, recoveredId)
+		res.Id = recoveredId
 	}
+
+	d.SetId(res.Id)
 
 	log.Printf("[DEBUG] Waiting for database %s to be READY", res.Id)
 	err = waitForCloudProjectDatabaseDatabaseReady(ctx, config.OVHClient, serviceName, engine, clusterId, res.Id, d.Timeout(schema.TimeoutCreate))
@@ -113,8 +130,6 @@ func resourceCloudProjectDatabaseDatabaseCreate(ctx context.Context, d *schema.R
 		return diag.Errorf("timeout while waiting database %s to be READY: %s", res.Id, err.Error())
 	}
 	log.Printf("[DEBUG] database %s is READY", res.Id)
-
-	d.SetId(res.Id)
 
 	return resourceCloudProjectDatabaseDatabaseRead(ctx, d, meta)
 }

--- a/ovh/resource_cloud_project_database_integration.go
+++ b/ovh/resource_cloud_project_database_integration.go
@@ -132,6 +132,8 @@ func resourceCloudProjectDatabaseIntegrationCreate(ctx context.Context, d *schem
 		return diag.Errorf("calling Post %s with params %+v:\n\t %q", endpoint, params, err)
 	}
 
+	d.SetId(res.Id)
+
 	log.Printf("[DEBUG] Waiting for integration %s to be READY", res.Id)
 	err = waitForCloudProjectDatabaseIntegrationReady(ctx, config.OVHClient, serviceName, engine, clusterId, res.Id, d.Timeout(schema.TimeoutCreate))
 	if err != nil {
@@ -139,7 +141,6 @@ func resourceCloudProjectDatabaseIntegrationCreate(ctx context.Context, d *schem
 	}
 	log.Printf("[DEBUG] integration %s is READY", res.Id)
 
-	d.SetId(res.Id)
 	return resourceCloudProjectDatabaseIntegrationRead(ctx, d, meta)
 }
 

--- a/ovh/resource_cloud_project_database_kafka_acl.go
+++ b/ovh/resource_cloud_project_database_kafka_acl.go
@@ -100,14 +100,14 @@ func resourceCloudProjectDatabaseKafkaAclCreate(ctx context.Context, d *schema.R
 		return diag.Errorf("calling Post %s with params %+v:\n\t %q", endpoint, params, err)
 	}
 
+	d.SetId(res.Id)
+
 	log.Printf("[DEBUG] Waiting for acl %s to be READY", res.Id)
 	err = waitForCloudProjectDatabaseKafkaAclReady(ctx, config.OVHClient, serviceName, clusterId, res.Id, d.Timeout(schema.TimeoutCreate))
 	if err != nil {
 		return diag.Errorf("timeout while waiting acl %s to be READY: %s", res.Id, err.Error())
 	}
 	log.Printf("[DEBUG] acl %s is READY", res.Id)
-
-	d.SetId(res.Id)
 
 	return resourceCloudProjectDatabaseKafkaAclRead(ctx, d, meta)
 }

--- a/ovh/resource_cloud_project_database_kafka_schemaregistryacl.go
+++ b/ovh/resource_cloud_project_database_kafka_schemaregistryacl.go
@@ -100,14 +100,14 @@ func resourceCloudProjectDatabaseKafkaSchemaRegistryAclCreate(ctx context.Contex
 		return diag.Errorf("calling Post %s with params %+v:\n\t %q", endpoint, params, err)
 	}
 
+	d.SetId(res.Id)
+
 	log.Printf("[DEBUG] Waiting for schema registry acl %s to be READY", res.Id)
 	err = waitForCloudProjectDatabaseKafkaSchemaRegistryAclReady(ctx, config.OVHClient, serviceName, clusterId, res.Id, d.Timeout(schema.TimeoutCreate))
 	if err != nil {
 		return diag.Errorf("timeout while waiting schema registry ACL %s to be READY: %s", res.Id, err.Error())
 	}
 	log.Printf("[DEBUG] schema registry acl %s is READY", res.Id)
-
-	d.SetId(res.Id)
 
 	return resourceCloudProjectDatabaseKafkaSchemaRegistryAclRead(ctx, d, meta)
 }

--- a/ovh/resource_cloud_project_database_kafka_topic.go
+++ b/ovh/resource_cloud_project_database_kafka_topic.go
@@ -137,6 +137,8 @@ func resourceCloudProjectDatabaseKafkaTopicCreate(ctx context.Context, d *schema
 					return retry.NonRetryableError(fmt.Errorf("calling Post %s with params %+v:\n\t %q", endpoint, params, err))
 				}
 
+				d.SetId(res.Id)
+
 				log.Printf("[DEBUG] Waiting for topic %s to be READY", res.Id)
 				err = waitForCloudProjectDatabaseKafkaTopicReady(ctx, config.OVHClient, serviceName, clusterId, res.Id, d.Timeout(schema.TimeoutCreate))
 				if err != nil {
@@ -144,7 +146,6 @@ func resourceCloudProjectDatabaseKafkaTopicCreate(ctx context.Context, d *schema
 				}
 				log.Printf("[DEBUG] topic %s is READY", res.Id)
 
-				d.SetId(res.Id)
 				readDiags := resourceCloudProjectDatabaseKafkaTopicRead(ctx, d, meta)
 				err = diagnosticsToError(readDiags)
 				if err != nil {

--- a/ovh/resource_cloud_project_database_opensearch_pattern.go
+++ b/ovh/resource_cloud_project_database_opensearch_pattern.go
@@ -94,14 +94,14 @@ func resourceCloudProjectDatabaseOpensearchPatternCreate(ctx context.Context, d 
 		return diag.Errorf("calling Post %s with params %+v:\n\t %q", endpoint, params, err)
 	}
 
+	d.SetId(res.Id)
+
 	log.Printf("[DEBUG] Waiting for topic %s to be READY", res.Id)
 	err = waitForCloudProjectDatabaseOpensearchPatternReady(ctx, config.OVHClient, serviceName, clusterId, res.Id, d.Timeout(schema.TimeoutCreate))
 	if err != nil {
 		return diag.Errorf("timeout while waiting topic %s to be READY: %s", res.Id, err.Error())
 	}
 	log.Printf("[DEBUG] topic %s is READY", res.Id)
-
-	d.SetId(res.Id)
 
 	return resourceCloudProjectDatabaseOpensearchPatternRead(ctx, d, meta)
 }

--- a/ovh/types_cloud_project_database.go
+++ b/ovh/types_cloud_project_database.go
@@ -779,7 +779,6 @@ func postCloudProjectDatabaseUser(ctx context.Context, d *schema.ResourceData, m
 		return diag.FromErr(err)
 	}
 
-	d.SetId(res.Id)
 	return readFunc(ctx, d, meta)
 }
 
@@ -792,7 +791,28 @@ func postFuncCloudProjectDatabaseUser(ctx context.Context, d *schema.ResourceDat
 		if errOvh, ok := err.(*ovh.APIError); engine == "mongodb" && ok && (errOvh.Code == 409) {
 			return err
 		}
-		return fmt.Errorf("calling Post %s with params %+v:\n\t %q", endpoint, params, err)
+
+		// Terraform-side hotfix until the API 500 root cause is found: on 409/500 the user
+		// may already exist, so recover it by name to stay idempotent.
+		errOvh, ok := err.(*ovh.APIError)
+		name := d.Get("name").(string)
+		if ok && (errOvh.Code == 409 || errOvh.Code == 500) && name != "" && strings.HasSuffix(endpoint, "/user") {
+			recoveredId, rerr := findCloudProjectDatabaseUserIDByName(ctx, config.OVHClient, serviceName, engine, clusterId, name)
+			if rerr != nil {
+				return fmt.Errorf("calling Post %s with params %+v returned %q; failed to recover the user by name: %w", endpoint, params, err, rerr)
+			}
+			if recoveredId == "" {
+				return fmt.Errorf("calling Post %s with params %+v:\n\t %q", endpoint, params, err)
+			}
+			log.Printf("[WARN] Post %s returned an error (%q) but user %q already exists with id %s; adopting it into the state", endpoint, err, name, recoveredId)
+			res.Id = recoveredId
+		} else {
+			return fmt.Errorf("calling Post %s with params %+v:\n\t %q", endpoint, params, err)
+		}
+	}
+
+	if strings.HasSuffix(endpoint, "/user") {
+		d.SetId(res.Id)
 	}
 
 	log.Printf("[DEBUG] Waiting for user %s to be READY", res.Id)
@@ -804,6 +824,37 @@ func postFuncCloudProjectDatabaseUser(ctx context.Context, d *schema.ResourceDat
 
 	d.Set("password", res.Password)
 	return nil
+}
+
+// findCloudProjectDatabaseUserIDByName returns the id of the user matching name, or "" if none.
+func findCloudProjectDatabaseUserIDByName(ctx context.Context, client *ovhwrap.Client, serviceName, engine, clusterId, name string) (string, error) {
+	listEndpoint := fmt.Sprintf("/cloud/project/%s/database/%s/%s/user",
+		url.PathEscape(serviceName),
+		url.PathEscape(engine),
+		url.PathEscape(clusterId),
+	)
+	ids := make([]string, 0)
+	if err := client.GetWithContext(ctx, listEndpoint, &ids); err != nil {
+		return "", fmt.Errorf("calling GET %s: %w", listEndpoint, err)
+	}
+
+	for _, id := range ids {
+		res := &CloudProjectDatabaseUserResponse{}
+		getEndpoint := fmt.Sprintf("/cloud/project/%s/database/%s/%s/user/%s",
+			url.PathEscape(serviceName),
+			url.PathEscape(engine),
+			url.PathEscape(clusterId),
+			url.PathEscape(id),
+		)
+		if err := client.GetWithContext(ctx, getEndpoint, res); err != nil {
+			return "", fmt.Errorf("calling GET %s: %w", getEndpoint, err)
+		}
+		if res.Username == name {
+			return res.Id, nil
+		}
+	}
+
+	return "", nil
 }
 
 func updateCloudProjectDatabaseUser(ctx context.Context, d *schema.ResourceData, meta interface{}, engine string, readFunc schema.ReadContextFunc, f func() interface{}) diag.Diagnostics {
@@ -974,6 +1025,37 @@ func (v CloudProjectDatabaseDatabaseResponse) ToMap() map[string]interface{} {
 	obj["name"] = v.Name
 
 	return obj
+}
+
+// findCloudProjectDatabaseDatabaseIDByName returns the id of the database matching name, or "" if none.
+func findCloudProjectDatabaseDatabaseIDByName(ctx context.Context, client *ovhwrap.Client, serviceName, engine, clusterId, name string) (string, error) {
+	listEndpoint := fmt.Sprintf("/cloud/project/%s/database/%s/%s/database",
+		url.PathEscape(serviceName),
+		url.PathEscape(engine),
+		url.PathEscape(clusterId),
+	)
+	ids := make([]string, 0)
+	if err := client.GetWithContext(ctx, listEndpoint, &ids); err != nil {
+		return "", fmt.Errorf("calling GET %s: %w", listEndpoint, err)
+	}
+
+	for _, id := range ids {
+		res := &CloudProjectDatabaseDatabaseResponse{}
+		getEndpoint := fmt.Sprintf("/cloud/project/%s/database/%s/%s/database/%s",
+			url.PathEscape(serviceName),
+			url.PathEscape(engine),
+			url.PathEscape(clusterId),
+			url.PathEscape(id),
+		)
+		if err := client.GetWithContext(ctx, getEndpoint, res); err != nil {
+			return "", fmt.Errorf("calling GET %s: %w", getEndpoint, err)
+		}
+		if res.Name == name {
+			return res.Id, nil
+		}
+	}
+
+	return "", nil
 }
 
 type CloudProjectDatabaseDatabaseCreateOpts struct {


### PR DESCRIPTION
# Description

Fixes #1306

When creating a PostgreSQL user (or a database) on a managed database cluster, the OVH
API sometimes returns an HTTP 500 *while the resource has actually been created* on the
backend. Because the provider returned the error without ever setting the resource id,
Terraform recorded nothing in the state. The resource was then orphaned: it existed on
the API but was absent from the state, so the next apply re-issued the `POST` and failed
permanently with an HTTP 409 (`PostgresUserAlreadyExist` / `DatabaseAlready`). This is
especially harmful in a reconcile loop (e.g. Crossplane), where it never converges.

This PR makes the creation of cloud project database resources resilient to this kind of
API inconsistency:

- **Idempotent create on 409/500**: when `POST` fails with a 409 or 500, the provider now
  looks the resource up by its name and, if it already exists, adopts it into the state
  instead of failing. This lets a reconcile loop converge instead of staying blocked.
  Applied to `ovh_cloud_project_database_*_user` (shared code path, all engines) and
  `ovh_cloud_project_database_database`.
- **Set the id before the READY wait**: the resource id is now persisted right after a
  successful `POST`, before waiting for the resource to become `READY`. If the wait times
  out, the resource stays tracked in the state (tainted) and can be reconciled instead of
  becoming orphaned. Applied across the whole database family (cluster, users, integration,
  kafka acl / schema registry acl / topic, opensearch pattern) — except `m3db_namespace`,
  which is deprecated and removed in a separate PR.

The root cause (API returning 500 on a successful creation) is being tracked separately
with OVH; the 409/500 handling here is a provider-side hotfix to stop a transient API
error from becoming a permanent state inconsistency.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Improvement (improve existing resource(s) or datasource(s))

# How Has This Been Tested?

The API 500 cannot be triggered on demand, but the 409 and 500 paths share the same
recovery code (`findCloudProjectDatabase*IDByName` + adoption), so both scenarios were
reproduced deterministically against the real `ovh-eu` API with a locally built provider.

**Setup**
1. Built and installed the provider locally
2. `terraform init`.

**Test 1 — idempotent create on conflict (409 recovery)**
1. `terraform apply` to create the cluster, a PostgreSQL user and a database.
2. `terraform state rm ovh_cloud_project_database_postgresql_user.user` and
   `terraform state rm ovh_cloud_project_database_database.db` to simulate the orphan
   (resource present on the API, absent from the state).
3. `terraform apply` again. The `POST` returns HTTP 409.
   - **Before the fix**: failed with `PostgresUserAlreadyExist` / `DatabaseAlready`.
   - **After the fix**: the provider recovers both resources by name, adopts them into the
     state with their original ids, and the apply completes (`0 to add`/clean).

**Test 2 — set id before wait (tainted instead of orphaned)**
1. Created a cluster with `timeouts { create = "60s" }`:

```
ovh_cloud_project_database.timeout_test: Still creating... [1m0s elapsed]
Error: timeout while waiting database <id> to be READY: context deadline exceeded
```

The error message contains the id, confirming the `POST` succeeded, the id was set, and
it is the wait (not the `POST`) that timed out.
2. Verified the resource is tracked, not orphaned:
- `terraform state list | grep timeout_test` → still lists the cluster.
- `terraform plan` → `# ... is tainted, so must be replaced` (`-/+`).

Without the fix this `state list` would be empty (orphaned cluster, billed and invisible
to Terraform).

**Test Configuration**:
* Terraform version: Terraform v1.8.1 (also reproduced via the Crossplane provider using TF v1.8.1 / OVH provider v2.13.1)
* HCL configuration used:
```hcl
locals {
service_name = "<public-cloud-project-id>"
}

# Cluster used by the 409/500 recovery test.
resource "ovh_cloud_project_database" "database" {
service_name = local.service_name
engine       = "postgresql"
description  = "test-1306-recover"
flavor       = "db1-7"
nodes {
 region = "GRA"
}
plan    = "essential"
version = "17"
}

# 409/500 recovery — user.
resource "ovh_cloud_project_database_postgresql_user" "user" {
service_name = ovh_cloud_project_database.database.service_name
cluster_id   = ovh_cloud_project_database.database.id
name         = "reader-recover-test"
roles        = []
}

# 409/500 recovery — database.
resource "ovh_cloud_project_database_database" "db" {
service_name = ovh_cloud_project_database.database.service_name
engine       = "postgresql"
cluster_id   = ovh_cloud_project_database.database.id
name         = "odb-recover-test"
}

# Set-id-before-wait — short create timeout so the POST succeeds but the READY
# wait times out, proving the resource stays tracked (tainted) instead of orphaned.
resource "ovh_cloud_project_database" "timeout_test" {
service_name = local.service_name
engine       = "postgresql"
description  = "test-1306-wait-timeout"
flavor       = "db1-7"
nodes {
 region = "GRA"
}
plan    = "essential"
version = "17"

timeouts {
 create = "60s"
}
}
