### PR TITLE
fix: allow UPDATING as legit value when waiting for cluster to be ready.

### DIFF
--- a/ovh/resource_cloud_project_kube.go
+++ b/ovh/resource_cloud_project_kube.go
@@ -573,7 +573,7 @@ func resourceCloudProjectKubeUpdate(d *schema.ResourceData, meta interface{}) er
 		}
 
 		log.Printf("[DEBUG] Waiting for kube %s to be READY", d.Id())
-		if err := waitForCloudProjectKubeReady(config.OVHClient, serviceName, d.Id(), []string{"REDEPLOYING", "RESETTING"}, []string{"READY"}, d.Timeout(schema.TimeoutUpdate)); err != nil {
+		if err := waitForCloudProjectKubeReady(config.OVHClient, serviceName, d.Id(), []string{"UPDATING", "REDEPLOYING", "RESETTING"}, []string{"READY"}, d.Timeout(schema.TimeoutUpdate)); err != nil {
 			return fmt.Errorf("timeout while waiting kube %s to be READY: %w", d.Id(), err)
 		}
 


### PR DESCRIPTION
# Description

`UPDATING` becomes a legitimate value when waiting for the cluster to be ready
Fixes #1332 (issue)

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (improve existing resource(s) or datasource(s))
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings or issues
- [X] I have added acceptance tests that prove my fix is effective or that my feature works
- [X] New and existing acceptance tests pass locally with my changes
- [X] I ran successfully `go mod vendor` if I added or modify `go.mod` file
