### PR TITLE
fix(cloud_gateway): preserve configured external_gateway.model in state

### DIFF
--- a/ovh/resource_cloud_gateway_test.go
+++ b/ovh/resource_cloud_gateway_test.go
@@ -2,147 +2,26 @@ package ovh
 
 import (
 	"fmt"
+	"net/url"
 	"os"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/ovh/go-ovh/ovh"
 )
 
 const testAccResourceCloudGatewayNamePrefix = "tf-test-gateway-v2-"
 
-func TestAccCloudGateway_basic(t *testing.T) {
-	serviceName := os.Getenv("OVH_CLOUD_PROJECT_SERVICE_TEST")
-	region := os.Getenv("OVH_CLOUD_PROJECT_REGION_TEST")
-	gatewayModel := os.Getenv("OVH_CLOUD_GATEWAY_MODEL_TEST")
-	if gatewayModel == "" {
-		gatewayModel = "S"
-	}
-
-	gatewayName := acctest.RandomWithPrefix(testAccResourceCloudGatewayNamePrefix)
-
-	config := fmt.Sprintf(`
-resource "ovh_cloud_gateway" "test" {
-  service_name = "%s"
-  name         = "%s"
-  region       = "%s"
-
-  external_gateway {
-    enabled = true
-    model   = "%s"
-  }
-}
-`, serviceName, gatewayName, region, gatewayModel)
-
-	resource.Test(t, resource.TestCase{
-		PreCheck: func() {
-			testAccPreCheckCloudGateway(t)
-		},
-		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
-		Steps: []resource.TestStep{
-			{
-				Config: config,
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("ovh_cloud_gateway.test", "service_name", serviceName),
-					resource.TestCheckResourceAttr("ovh_cloud_gateway.test", "name", gatewayName),
-					resource.TestCheckResourceAttr("ovh_cloud_gateway.test", "external_gateway.enabled", "true"),
-					resource.TestCheckResourceAttr("ovh_cloud_gateway.test", "external_gateway.model", gatewayModel),
-					resource.TestCheckResourceAttr("ovh_cloud_gateway.test", "region", region),
-					resource.TestCheckResourceAttrSet("ovh_cloud_gateway.test", "id"),
-					resource.TestCheckResourceAttrSet("ovh_cloud_gateway.test", "checksum"),
-					resource.TestCheckResourceAttrSet("ovh_cloud_gateway.test", "created_at"),
-					resource.TestCheckResourceAttr("ovh_cloud_gateway.test", "resource_status", "READY"),
-					resource.TestCheckResourceAttrSet("ovh_cloud_gateway.test", "current_state.name"),
-					resource.TestCheckResourceAttr("ovh_cloud_gateway.test", "current_state.external_gateway.enabled", "true"),
-					resource.TestCheckResourceAttrSet("ovh_cloud_gateway.test", "current_state.status"),
-				),
-			},
-			// Test import
-			{
-				ResourceName:      "ovh_cloud_gateway.test",
-				ImportState:       true,
-				ImportStateVerify: true,
-				ImportStateIdFunc: testAccCloudGatewayImportStateIdFunc("ovh_cloud_gateway.test"),
-			},
-		},
-	})
-}
-
-func TestAccCloudGateway_update(t *testing.T) {
-	serviceName := os.Getenv("OVH_CLOUD_PROJECT_SERVICE_TEST")
-	region := os.Getenv("OVH_CLOUD_PROJECT_REGION_TEST")
-	gatewayModel := os.Getenv("OVH_CLOUD_GATEWAY_MODEL_TEST")
-	if gatewayModel == "" {
-		gatewayModel = "S"
-	}
-
-	gatewayName := acctest.RandomWithPrefix(testAccResourceCloudGatewayNamePrefix)
-	updatedName := acctest.RandomWithPrefix(testAccResourceCloudGatewayNamePrefix)
-
-	config := fmt.Sprintf(`
-resource "ovh_cloud_gateway" "test" {
-  service_name = "%s"
-  name         = "%s"
-  region       = "%s"
-  description  = "initial description"
-
-  external_gateway {
-    enabled = true
-    model   = "%s"
-  }
-}
-`, serviceName, gatewayName, region, gatewayModel)
-
-	updatedConfig := fmt.Sprintf(`
-resource "ovh_cloud_gateway" "test" {
-  service_name = "%s"
-  name         = "%s"
-  region       = "%s"
-  description  = "updated description"
-
-  external_gateway {
-    enabled = true
-    model   = "%s"
-  }
-}
-`, serviceName, updatedName, region, gatewayModel)
-
-	resource.Test(t, resource.TestCase{
-		PreCheck: func() {
-			testAccPreCheckCloudGateway(t)
-		},
-		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
-		Steps: []resource.TestStep{
-			{
-				Config: config,
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("ovh_cloud_gateway.test", "name", gatewayName),
-					resource.TestCheckResourceAttr("ovh_cloud_gateway.test", "description", "initial description"),
-					resource.TestCheckResourceAttr("ovh_cloud_gateway.test", "external_gateway.enabled", "true"),
-					resource.TestCheckResourceAttr("ovh_cloud_gateway.test", "external_gateway.model", gatewayModel),
-				),
-			},
-			{
-				Config: updatedConfig,
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("ovh_cloud_gateway.test", "name", updatedName),
-					resource.TestCheckResourceAttr("ovh_cloud_gateway.test", "description", "updated description"),
-					resource.TestCheckResourceAttrSet("ovh_cloud_gateway.test", "id"),
-					resource.TestCheckResourceAttrSet("ovh_cloud_gateway.test", "checksum"),
-				),
-			},
-		},
-	})
-}
-
 func testAccPreCheckCloudGateway(t *testing.T) {
 	testAccPreCheckCredentials(t)
 	if os.Getenv("OVH_CLOUD_PROJECT_SERVICE_TEST") == "" {
-		t.Skip("OVH_CLOUD_PROJECT_SERVICE_TEST not set")
+		t.Skip("OVH_CLOUD_PROJECT_SERVICE_TEST must be set for acceptance tests")
 	}
 	if os.Getenv("OVH_CLOUD_PROJECT_REGION_TEST") == "" {
-		t.Skip("OVH_CLOUD_PROJECT_REGION_TEST not set")
+		t.Skip("OVH_CLOUD_PROJECT_REGION_TEST must be set for acceptance tests")
 	}
 }
 
@@ -154,4 +33,230 @@ func testAccCloudGatewayImportStateIdFunc(resourceName string) resource.ImportSt
 		}
 		return fmt.Sprintf("%s/%s", rs.Primary.Attributes["service_name"], rs.Primary.Attributes["id"]), nil
 	}
+}
+
+// testAccCheckCloudGatewayDestroy verifies that every gateway managed by the
+// test has actually been removed from the API once the test completes (the GET
+// must return a 404).
+func testAccCheckCloudGatewayDestroy(s *terraform.State) error {
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "ovh_cloud_gateway" {
+			continue
+		}
+
+		serviceName := rs.Primary.Attributes["service_name"]
+		gatewayID := rs.Primary.Attributes["id"]
+
+		endpoint := "/v2/publicCloud/project/" + url.PathEscape(serviceName) + "/gateway/" + url.PathEscape(gatewayID)
+
+		err := testAccOVHClient.Get(endpoint, nil)
+		if err == nil {
+			return fmt.Errorf("cloud gateway %s still exists", gatewayID)
+		}
+		if errOvh, ok := err.(*ovh.APIError); ok && errOvh.Code == 404 {
+			continue
+		}
+		return fmt.Errorf("error checking that cloud gateway %s was destroyed: %w", gatewayID, err)
+	}
+
+	return nil
+}
+
+// testAccCloudGatewayConfig builds an HCL config that provisions a private
+// network + subnet and a gateway attached to that subnet.
+//
+// Note: the schema uses terraform-plugin-framework SingleNestedAttribute /
+// ListAttribute, so the HCL MUST use attribute assignment (external_gateway =
+// { ... }, subnet_ids = [ ... ]) rather than block syntax.
+func testAccCloudGatewayConfig(serviceName, region, networkName, subnetName, gatewayName, model string) string {
+	return fmt.Sprintf(`
+resource "ovh_cloud_network_private_vrack" "network" {
+  service_name = "%s"
+  name         = "%s"
+  region       = "%s"
+}
+
+resource "ovh_cloud_network_private_vrack_subnet" "subnet" {
+  service_name = ovh_cloud_network_private_vrack.network.service_name
+  network_id   = ovh_cloud_network_private_vrack.network.id
+  name         = "%s"
+  cidr         = "10.0.0.0/24"
+  region       = "%s"
+  dhcp_enabled = true
+}
+
+resource "ovh_cloud_gateway" "test" {
+  service_name = "%s"
+  name         = "%s"
+  region       = "%s"
+
+  external_gateway = {
+    enabled = true
+    model   = "%s"
+  }
+
+  subnet_ids = [ovh_cloud_network_private_vrack_subnet.subnet.id]
+}
+`, serviceName, networkName, region, subnetName, region, serviceName, gatewayName, region, model)
+}
+
+func TestAccCloudGateway_basic(t *testing.T) {
+	serviceName := os.Getenv("OVH_CLOUD_PROJECT_SERVICE_TEST")
+	region := os.Getenv("OVH_CLOUD_PROJECT_REGION_TEST")
+	gatewayModel := os.Getenv("OVH_CLOUD_GATEWAY_MODEL_TEST")
+	if gatewayModel == "" {
+		gatewayModel = "S"
+	}
+
+	networkName := acctest.RandomWithPrefix(testAccResourceCloudNetworkPrivateVrackNamePrefix)
+	subnetName := acctest.RandomWithPrefix(testAccResourceCloudNetworkPrivateVrackSubnetNamePrefix)
+	gatewayName := acctest.RandomWithPrefix(testAccResourceCloudGatewayNamePrefix)
+
+	config := testAccCloudGatewayConfig(serviceName, region, networkName, subnetName, gatewayName, gatewayModel)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheckCloudGateway(t)
+		},
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		CheckDestroy:             testAccCheckCloudGatewayDestroy,
+		Steps: []resource.TestStep{
+			// Step 1: create the gateway with external_gateway.model = "S".
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("ovh_cloud_gateway.test", "service_name", serviceName),
+					resource.TestCheckResourceAttr("ovh_cloud_gateway.test", "name", gatewayName),
+					resource.TestCheckResourceAttr("ovh_cloud_gateway.test", "region", region),
+					resource.TestCheckResourceAttr("ovh_cloud_gateway.test", "external_gateway.enabled", "true"),
+					resource.TestCheckResourceAttr("ovh_cloud_gateway.test", "external_gateway.model", gatewayModel),
+					resource.TestCheckResourceAttr("ovh_cloud_gateway.test", "subnet_ids.#", "1"),
+					resource.TestCheckResourceAttrSet("ovh_cloud_gateway.test", "id"),
+					resource.TestCheckResourceAttrSet("ovh_cloud_gateway.test", "checksum"),
+					resource.TestCheckResourceAttrSet("ovh_cloud_gateway.test", "created_at"),
+					resource.TestCheckResourceAttr("ovh_cloud_gateway.test", "resource_status", "READY"),
+					resource.TestCheckResourceAttrSet("ovh_cloud_gateway.test", "current_state.name"),
+					resource.TestCheckResourceAttr("ovh_cloud_gateway.test", "current_state.external_gateway.enabled", "true"),
+					resource.TestCheckResourceAttrSet("ovh_cloud_gateway.test", "current_state.status"),
+				),
+			},
+			// Step 2: REGRESSION GUARD for fix/cloud-gateway-model-perpetual-diff.
+			//
+			// Re-applying the SAME config (external_gateway.model = "S") must
+			// produce an EMPTY plan. Before the fix, MergeWith clobbered
+			// external_gateway.model to null because the API does not always
+			// echo the model back, which caused a perpetual diff and a gateway
+			// update on every apply. ExpectEmptyPlan locks the fix in.
+			{
+				Config: config,
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("ovh_cloud_gateway.test", "external_gateway.model", gatewayModel),
+				),
+			},
+			// Step 3: import.
+			{
+				ResourceName:      "ovh_cloud_gateway.test",
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testAccCloudGatewayImportStateIdFunc("ovh_cloud_gateway.test"),
+			},
+		},
+	})
+}
+
+// TestAccCloudGateway_noPerpetualDiff is a focused regression test for
+// fix/cloud-gateway-model-perpetual-diff. It creates the gateway then runs a
+// PlanOnly step on the identical config: a non-empty plan fails the step.
+// This proves external_gateway.model no longer drifts to null between applies.
+func TestAccCloudGateway_noPerpetualDiff(t *testing.T) {
+	serviceName := os.Getenv("OVH_CLOUD_PROJECT_SERVICE_TEST")
+	region := os.Getenv("OVH_CLOUD_PROJECT_REGION_TEST")
+	gatewayModel := os.Getenv("OVH_CLOUD_GATEWAY_MODEL_TEST")
+	if gatewayModel == "" {
+		gatewayModel = "S"
+	}
+
+	networkName := acctest.RandomWithPrefix(testAccResourceCloudNetworkPrivateVrackNamePrefix)
+	subnetName := acctest.RandomWithPrefix(testAccResourceCloudNetworkPrivateVrackSubnetNamePrefix)
+	gatewayName := acctest.RandomWithPrefix(testAccResourceCloudGatewayNamePrefix)
+
+	config := testAccCloudGatewayConfig(serviceName, region, networkName, subnetName, gatewayName, gatewayModel)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheckCloudGateway(t)
+		},
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		CheckDestroy:             testAccCheckCloudGatewayDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("ovh_cloud_gateway.test", "external_gateway.model", gatewayModel),
+					resource.TestCheckResourceAttr("ovh_cloud_gateway.test", "resource_status", "READY"),
+				),
+			},
+			{
+				// PlanOnly re-plans the identical config and fails if the plan
+				// is not empty — the canonical "no perpetual diff" assertion.
+				Config:             config,
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: false,
+			},
+		},
+	})
+}
+
+// TestAccCloudGateway_update renames the gateway in place (name is mutable) and
+// verifies the gateway stays READY and keeps the same id.
+func TestAccCloudGateway_update(t *testing.T) {
+	serviceName := os.Getenv("OVH_CLOUD_PROJECT_SERVICE_TEST")
+	region := os.Getenv("OVH_CLOUD_PROJECT_REGION_TEST")
+	gatewayModel := os.Getenv("OVH_CLOUD_GATEWAY_MODEL_TEST")
+	if gatewayModel == "" {
+		gatewayModel = "S"
+	}
+
+	networkName := acctest.RandomWithPrefix(testAccResourceCloudNetworkPrivateVrackNamePrefix)
+	subnetName := acctest.RandomWithPrefix(testAccResourceCloudNetworkPrivateVrackSubnetNamePrefix)
+	gatewayName := acctest.RandomWithPrefix(testAccResourceCloudGatewayNamePrefix)
+	updatedName := acctest.RandomWithPrefix(testAccResourceCloudGatewayNamePrefix)
+
+	config := testAccCloudGatewayConfig(serviceName, region, networkName, subnetName, gatewayName, gatewayModel)
+	updatedConfig := testAccCloudGatewayConfig(serviceName, region, networkName, subnetName, updatedName, gatewayModel)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheckCloudGateway(t)
+		},
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		CheckDestroy:             testAccCheckCloudGatewayDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("ovh_cloud_gateway.test", "name", gatewayName),
+					resource.TestCheckResourceAttr("ovh_cloud_gateway.test", "external_gateway.enabled", "true"),
+					resource.TestCheckResourceAttr("ovh_cloud_gateway.test", "external_gateway.model", gatewayModel),
+					resource.TestCheckResourceAttrSet("ovh_cloud_gateway.test", "id"),
+					resource.TestCheckResourceAttrSet("ovh_cloud_gateway.test", "checksum"),
+				),
+			},
+			{
+				Config: updatedConfig,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("ovh_cloud_gateway.test", "name", updatedName),
+					resource.TestCheckResourceAttr("ovh_cloud_gateway.test", "external_gateway.model", gatewayModel),
+					resource.TestCheckResourceAttr("ovh_cloud_gateway.test", "resource_status", "READY"),
+					resource.TestCheckResourceAttrSet("ovh_cloud_gateway.test", "id"),
+					resource.TestCheckResourceAttrSet("ovh_cloud_gateway.test", "checksum"),
+				),
+			},
+		},
+	})
 }

--- a/ovh/types_cloud_gateway.go
+++ b/ovh/types_cloud_gateway.go
@@ -319,6 +319,14 @@ func (m *CloudGatewayModel) MergeWith(ctx context.Context, response *CloudGatewa
 			modelVal := ovhtypes.TfStringValue{StringValue: types.StringNull()}
 			if response.TargetSpec.ExternalGateway.Model != "" {
 				modelVal = ovhtypes.TfStringValue{StringValue: types.StringValue(response.TargetSpec.ExternalGateway.Model)}
+			} else if !m.ExternalGateway.IsNull() && !m.ExternalGateway.IsUnknown() {
+				// The API may not echo back the model (e.g. on POST / early provisioning
+				// responses). Preserve the planned/prior model already in state so the
+				// configured value is not clobbered to null, which would otherwise cause
+				// a perpetual diff on external_gateway.model.
+				if priorModel, ok := m.ExternalGateway.Attributes()["model"].(ovhtypes.TfStringValue); ok && !priorModel.IsNull() && !priorModel.IsUnknown() {
+					modelVal = priorModel
+				}
 			}
 			m.ExternalGateway, _ = types.ObjectValue(
 				ExternalGatewayAttrTypes(),


### PR DESCRIPTION
MergeWith() rebuilt external_gateway from the API response and set model to null whenever the API echoed an empty model (POST / early provisioning), clobbering the configured value. That produced a perpetual plan diff that re-ran a gateway update on every apply. Preserve the planned/prior model when the API response is empty.

# Description

Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes #xx (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (improve existing resource(s) or datasource(s))
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A: `make testacc TESTARGS="-run TestAccDataSourceXxxxYyyyZzzzz_basic"`
- [ ] Test B: `make testacc TESTARGS="-run TestAccDataSourceXxxxYyyyZzzzz_basic"`

**Test Configuration**:
* Terraform version: `terraform version`: Terraform vx.y.z
* Existing HCL configuration you used: 
```hcl
resource "" "" {
 xx = "yy"
 zz = "aa"
}
```

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings or issues
- [ ] I have added acceptance tests that prove my fix is effective or that my feature works
- [ ] New and existing acceptance tests pass locally with my changes
- [ ] I ran successfully `go mod vendor` if I added or modify `go.mod` file
