### PR TITLE
feat: Add cloud region datasources

### DIFF
--- a/docs/data-sources/cloud_region.md
+++ b/docs/data-sources/cloud_region.md
@@ -1,0 +1,32 @@
+---
+subcategory : "Cloud Project"
+---
+
+# ovh_cloud_region (Data Source)
+
+Use this data source to retrieve information about a single region of a public cloud project, using the OVHcloud API v2.
+
+## Example Usage
+
+```terraform
+data "ovh_cloud_region" "region" {
+  service_name = "<public cloud project ID>"
+  name         = "GRA11"
+}
+```
+
+## Argument Reference
+
+* `service_name` - (Required) The id of the public cloud project.
+* `name`         - (Required) The name of the region (e.g. `GRA11`).
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `status`             - Region status (`ENABLED`, `DISABLED` or `MAINTENANCE`).
+* `continent`          - Continent code of the region.
+* `country`            - Country code of the region.
+* `datacenter_name`    - Display name of the datacenter hosting the region.
+* `availability_zones` - Availability zones available in the region.
+* `services`           - Available OpenStack services in the region.

--- a/docs/data-sources/cloud_regions.md
+++ b/docs/data-sources/cloud_regions.md
@@ -1,0 +1,36 @@
+---
+subcategory : "Cloud Project"
+---
+
+# ovh_cloud_regions (Data Source)
+
+Use this data source to list the regions available for a public cloud project, using the OVHcloud API v2. All pages are fetched, so the full list of regions is returned.
+
+## Example Usage
+
+```terraform
+data "ovh_cloud_regions" "regions" {
+  service_name = "<public cloud project ID>"
+}
+
+output "regions" {
+  value = data.ovh_cloud_regions.regions.regions
+}
+```
+
+## Argument Reference
+
+* `service_name` - (Required) The id of the public cloud project.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `regions` - The list of regions available for the project. Each region exports:
+  * `name`               - Name of the region (e.g. `GRA11`).
+  * `status`             - Region status (`ENABLED`, `DISABLED` or `MAINTENANCE`).
+  * `continent`          - Continent code of the region.
+  * `country`            - Country code of the region.
+  * `datacenter_name`    - Display name of the datacenter hosting the region.
+  * `availability_zones` - Availability zones available in the region.
+  * `services`           - Available OpenStack services in the region.

--- a/examples/data-sources/cloud_region/example_1.tf
+++ b/examples/data-sources/cloud_region/example_1.tf
@@ -1,0 +1,4 @@
+data "ovh_cloud_region" "region" {
+  service_name = "<public cloud project ID>"
+  name         = "GRA11"
+}

--- a/examples/data-sources/cloud_regions/example_1.tf
+++ b/examples/data-sources/cloud_regions/example_1.tf
@@ -1,0 +1,7 @@
+data "ovh_cloud_regions" "regions" {
+  service_name = "<public cloud project ID>"
+}
+
+output "regions" {
+  value = data.ovh_cloud_regions.regions.regions
+}

--- a/ovh/data_cloud_region.go
+++ b/ovh/data_cloud_region.go
@@ -1,0 +1,92 @@
+package ovh
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	ovhtypes "github.com/ovh/terraform-provider-ovh/v2/ovh/types"
+)
+
+var _ datasource.DataSourceWithConfigure = (*cloudRegionDataSource)(nil)
+
+func NewCloudRegionDataSource() datasource.DataSource {
+	return &cloudRegionDataSource{}
+}
+
+type cloudRegionDataSource struct {
+	config *Config
+}
+
+func (d *cloudRegionDataSource) Metadata(_ context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_cloud_region"
+}
+
+func (d *cloudRegionDataSource) Configure(_ context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+
+	config, ok := req.ProviderData.(*Config)
+	if !ok {
+		resp.Diagnostics.AddError(
+			"Unexpected Data Source Configure Type",
+			fmt.Sprintf("Expected *Config, got: %T. Please report this issue to the provider developers.", req.ProviderData),
+		)
+		return
+	}
+
+	d.config = config
+}
+
+func (d *cloudRegionDataSource) Schema(_ context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	attributes := cloudRegionDetailAttributes()
+	attributes["service_name"] = schema.StringAttribute{
+		CustomType:          ovhtypes.TfStringType{},
+		Required:            true,
+		Description:         "Service name of the resource representing the id of the cloud project",
+		MarkdownDescription: "Service name of the resource representing the id of the cloud project",
+	}
+	attributes["name"] = schema.StringAttribute{
+		CustomType:          ovhtypes.TfStringType{},
+		Required:            true,
+		Description:         "Name of the region (e.g. GRA11)",
+		MarkdownDescription: "Name of the region (e.g. GRA11)",
+	}
+
+	resp.Schema = schema.Schema{
+		Description:         "Retrieve information about a single region of a public cloud project.",
+		MarkdownDescription: "Retrieve information about a single region of a public cloud project.",
+		Attributes:          attributes,
+	}
+}
+
+func (d *cloudRegionDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+	var data cloudRegionDataSourceModel
+
+	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	endpoint := "/v2/publicCloud/project/" + url.PathEscape(data.ServiceName.ValueString()) +
+		"/reference/region/" + url.PathEscape(data.Name.ValueString())
+
+	var region CloudRegion
+	if err := d.config.OVHClient.GetWithContext(ctx, endpoint, &region); err != nil {
+		resp.Diagnostics.AddError(
+			fmt.Sprintf("Error calling Get %s", endpoint),
+			err.Error(),
+		)
+		return
+	}
+
+	resp.Diagnostics.Append(data.MergeWith(ctx, &region)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}

--- a/ovh/data_cloud_region_test.go
+++ b/ovh/data_cloud_region_test.go
@@ -1,0 +1,36 @@
+package ovh
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+func TestAccCloudRegionDataSource_basic(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheckCloudRegion(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(`
+					data "ovh_cloud_region" "region" {
+						service_name = "%s"
+						name         = "%s"
+					}
+				`,
+					os.Getenv("OVH_CLOUD_PROJECT_SERVICE_TEST"),
+					os.Getenv("OVH_CLOUD_PROJECT_REGION_TEST"),
+				),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(
+						"data.ovh_cloud_region.region", "name", os.Getenv("OVH_CLOUD_PROJECT_REGION_TEST")),
+					resource.TestCheckResourceAttrSet("data.ovh_cloud_region.region", "status"),
+					resource.TestCheckResourceAttrSet("data.ovh_cloud_region.region", "continent"),
+					resource.TestCheckResourceAttrSet("data.ovh_cloud_region.region", "services.#"),
+				),
+			},
+		},
+	})
+}

--- a/ovh/data_cloud_regions.go
+++ b/ovh/data_cloud_regions.go
@@ -1,0 +1,118 @@
+package ovh
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/ovh/terraform-provider-ovh/v2/ovh/helpers"
+	ovhtypes "github.com/ovh/terraform-provider-ovh/v2/ovh/types"
+)
+
+var _ datasource.DataSourceWithConfigure = (*cloudRegionsDataSource)(nil)
+
+func NewCloudRegionsDataSource() datasource.DataSource {
+	return &cloudRegionsDataSource{}
+}
+
+type cloudRegionsDataSource struct {
+	config *Config
+}
+
+func (d *cloudRegionsDataSource) Metadata(_ context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_cloud_regions"
+}
+
+func (d *cloudRegionsDataSource) Configure(_ context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+
+	config, ok := req.ProviderData.(*Config)
+	if !ok {
+		resp.Diagnostics.AddError(
+			"Unexpected Data Source Configure Type",
+			fmt.Sprintf("Expected *Config, got: %T. Please report this issue to the provider developers.", req.ProviderData),
+		)
+		return
+	}
+
+	d.config = config
+}
+
+func (d *cloudRegionsDataSource) Schema(_ context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	regionAttributes := cloudRegionDetailAttributes()
+	regionAttributes["name"] = schema.StringAttribute{
+		CustomType:          ovhtypes.TfStringType{},
+		Computed:            true,
+		Description:         "Name of the region (e.g. GRA11)",
+		MarkdownDescription: "Name of the region (e.g. GRA11)",
+	}
+
+	resp.Schema = schema.Schema{
+		Description:         "List the regions available for a public cloud project.",
+		MarkdownDescription: "List the regions available for a public cloud project.",
+		Attributes: map[string]schema.Attribute{
+			"service_name": schema.StringAttribute{
+				CustomType:          ovhtypes.TfStringType{},
+				Required:            true,
+				Description:         "Service name of the resource representing the id of the cloud project",
+				MarkdownDescription: "Service name of the resource representing the id of the cloud project",
+			},
+			"regions": schema.ListNestedAttribute{
+				Computed:            true,
+				Description:         "List of regions available for the cloud project",
+				MarkdownDescription: "List of regions available for the cloud project",
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: regionAttributes,
+				},
+			},
+		},
+	}
+}
+
+func (d *cloudRegionsDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+	var data cloudRegionsDataSourceModel
+
+	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	endpoint := "/v2/publicCloud/project/" + url.PathEscape(data.ServiceName.ValueString()) + "/reference/region"
+
+	regions, err := helpers.GetAllPagesV2[CloudRegion](ctx, d.config.OVHClient, endpoint)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			fmt.Sprintf("Error calling Get %s", endpoint),
+			err.Error(),
+		)
+		return
+	}
+
+	regionObjs := make([]attr.Value, 0, len(regions))
+	for _, region := range regions {
+		obj, diags := cloudRegionToObject(ctx, region)
+		resp.Diagnostics.Append(diags...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+		regionObjs = append(regionObjs, obj)
+	}
+
+	regionList, diags := types.ListValue(
+		types.ObjectType{AttrTypes: cloudRegionObjectAttrTypes()},
+		regionObjs,
+	)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	data.Regions = regionList
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}

--- a/ovh/data_cloud_regions_test.go
+++ b/ovh/data_cloud_regions_test.go
@@ -1,0 +1,30 @@
+package ovh
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+func TestAccCloudRegionsDataSource_basic(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheckCloud(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(`
+					data "ovh_cloud_regions" "regions" {
+						service_name = "%s"
+					}
+				`, os.Getenv("OVH_CLOUD_PROJECT_SERVICE_TEST")),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet("data.ovh_cloud_regions.regions", "regions.#"),
+					resource.TestCheckResourceAttrSet("data.ovh_cloud_regions.regions", "regions.0.name"),
+					resource.TestCheckResourceAttrSet("data.ovh_cloud_regions.regions", "regions.0.status"),
+				),
+			},
+		},
+	})
+}

--- a/ovh/helpers/apiv2.go
+++ b/ovh/helpers/apiv2.go
@@ -16,6 +16,64 @@ type GenericAPIv2Resource struct {
 	ResourceStatus string `json:"resourceStatus"`
 }
 
+const (
+	// paginationCursorHeader is the request header used to ask for a specific page
+	// of a cursor-paginated OVHcloud API v2 list endpoint.
+	paginationCursorHeader = "X-Pagination-Cursor"
+	// paginationCursorNextHeader is the response header carrying the cursor of the
+	// next page. Its absence means the last page has been reached.
+	paginationCursorNextHeader = "X-Pagination-Cursor-Next"
+)
+
+// GetAllPagesV2 retrieves every page of a cursor-paginated OVHcloud API v2 list endpoint.
+//
+// OVHcloud API v2 list endpoints paginate using cursors: each response may include an
+// "X-Pagination-Cursor-Next" header whose value must be sent back as the "X-Pagination-Cursor"
+// request header to fetch the following page. When that header is absent from a response, the
+// last page has been reached.
+//
+// The standard client Get helper only unmarshals the response body and does not expose response
+// headers, so this helper drives the request manually through NewRequest/Do/UnmarshalResponse
+// while preserving the client rate limiter. Items from every page are accumulated and returned.
+func GetAllPagesV2[T any](ctx context.Context, c *ovhwrap.Client, path string) ([]T, error) {
+	if c == nil {
+		return nil, fmt.Errorf("OVH API client is not initialized, check your provider credentials configuration")
+	}
+
+	var all []T
+	cursor := ""
+
+	for {
+		req, err := c.NewRequest(http.MethodGet, path, nil, true)
+		if err != nil {
+			return nil, fmt.Errorf("failed to build request for %q: %w", path, err)
+		}
+		req = req.WithContext(ctx)
+		if cursor != "" {
+			req.Header.Set(paginationCursorHeader, cursor)
+		}
+
+		c.RateLimiter.Take()
+		resp, err := c.Do(req)
+		if err != nil {
+			return nil, fmt.Errorf("call to %q failed: %w", path, err)
+		}
+
+		var page []T
+		if err := c.UnmarshalResponse(resp, &page); err != nil {
+			return nil, err
+		}
+		all = append(all, page...)
+
+		cursor = resp.Header.Get(paginationCursorNextHeader)
+		if cursor == "" {
+			break
+		}
+	}
+
+	return all, nil
+}
+
 // WaitForAPIv2ResourceStatusReady retries a GET on the given URL until the fetched resource
 // is in state "READY". It expects the given URL to target a route that fetches an asynchronous
 // resource on APIv2.

--- a/ovh/helpers/apiv2_test.go
+++ b/ovh/helpers/apiv2_test.go
@@ -1,0 +1,119 @@
+package helpers
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+
+	"github.com/ovh/go-ovh/ovh"
+	"github.com/ovh/terraform-provider-ovh/v2/ovh/ovhwrap"
+	"go.uber.org/ratelimit"
+)
+
+type paginationTestItem struct {
+	Name string `json:"name"`
+}
+
+// newTestClient returns an ovhwrap client pointed at the given test server URL.
+// Dummy credentials are provided so the go-ovh client signs requests (which also
+// triggers a call to /auth/time, served by the test server) without reading any
+// ambient OVH configuration.
+func newTestClient(t *testing.T, serverURL string) *ovhwrap.Client {
+	t.Helper()
+	client, err := ovh.NewClient(serverURL, "appKey", "appSecret", "consumerKey")
+	if err != nil {
+		t.Fatalf("failed to create go-ovh client: %s", err)
+	}
+	return ovhwrap.NewClient(client, ratelimit.NewUnlimited())
+}
+
+func TestGetAllPagesV2_MultiplePages(t *testing.T) {
+	const regionPath = "/v2/test/region"
+	var regionCalls int32
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/auth/time":
+			fmt.Fprint(w, "1700000000")
+		case regionPath:
+			atomic.AddInt32(&regionCalls, 1)
+			switch r.Header.Get("X-Pagination-Cursor") {
+			case "":
+				// First page: announce a next cursor.
+				w.Header().Set("X-Pagination-Cursor-Next", "page2")
+				fmt.Fprint(w, `[{"name":"GRA11"},{"name":"SBG5"}]`)
+			case "page2":
+				// Last page: no next cursor header.
+				fmt.Fprint(w, `[{"name":"DE1"}]`)
+			default:
+				t.Errorf("unexpected cursor: %q", r.Header.Get("X-Pagination-Cursor"))
+				w.WriteHeader(http.StatusBadRequest)
+			}
+		default:
+			t.Errorf("unexpected request path: %q", r.URL.Path)
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+
+	c := newTestClient(t, server.URL)
+
+	got, err := GetAllPagesV2[paginationTestItem](context.Background(), c, regionPath)
+	if err != nil {
+		t.Fatalf("GetAllPagesV2 returned an error: %s", err)
+	}
+
+	want := []string{"GRA11", "SBG5", "DE1"}
+	if len(got) != len(want) {
+		t.Fatalf("expected %d items, got %d: %+v", len(want), len(got), got)
+	}
+	for i, name := range want {
+		if got[i].Name != name {
+			t.Errorf("item %d: expected %q, got %q", i, name, got[i].Name)
+		}
+	}
+
+	if regionCalls != 2 {
+		t.Errorf("expected 2 page requests, got %d", regionCalls)
+	}
+}
+
+func TestGetAllPagesV2_SinglePage(t *testing.T) {
+	const regionPath = "/v2/test/region"
+	var regionCalls int32
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/auth/time":
+			fmt.Fprint(w, "1700000000")
+		case regionPath:
+			atomic.AddInt32(&regionCalls, 1)
+			if cursor := r.Header.Get("X-Pagination-Cursor"); cursor != "" {
+				t.Errorf("unexpected cursor on single page: %q", cursor)
+			}
+			// No next cursor header => last (and only) page.
+			fmt.Fprint(w, `[{"name":"GRA11"}]`)
+		default:
+			t.Errorf("unexpected request path: %q", r.URL.Path)
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+
+	c := newTestClient(t, server.URL)
+
+	got, err := GetAllPagesV2[paginationTestItem](context.Background(), c, regionPath)
+	if err != nil {
+		t.Fatalf("GetAllPagesV2 returned an error: %s", err)
+	}
+
+	if len(got) != 1 || got[0].Name != "GRA11" {
+		t.Fatalf("expected single item GRA11, got %+v", got)
+	}
+	if regionCalls != 1 {
+		t.Errorf("expected exactly 1 page request, got %d", regionCalls)
+	}
+}

--- a/ovh/provider_new.go
+++ b/ovh/provider_new.go
@@ -285,6 +285,8 @@ func (p *OvhProvider) DataSources(_ context.Context) []func() datasource.DataSou
 		NewCloudStorageBlockVolumeBackupsDataSource,
 		NewCloudStorageBlockVolumeDataSource,
 		NewCloudStorageBlockVolumesDataSource,
+		NewCloudRegionDataSource,
+		NewCloudRegionsDataSource,
 		NewOvhcloudConnectDatacentersDataSource,
 		NewOvhcloudConnectConfigPopDatacenterExtrasDataSource,
 		NewOvhcloudConnectConfigPopDatacentersDataSource,

--- a/ovh/types_cloud_region.go
+++ b/ovh/types_cloud_region.go
@@ -1,0 +1,155 @@
+package ovh
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	ovhtypes "github.com/ovh/terraform-provider-ovh/v2/ovh/types"
+)
+
+// CloudRegion is the API response for publicCloud.reference.Region (OVHcloud API v2),
+// returned by GET /v2/publicCloud/project/{serviceName}/reference/region[/{name}].
+type CloudRegion struct {
+	Name              string   `json:"name"`
+	Status            string   `json:"status"`
+	Continent         string   `json:"continent"`
+	Country           string   `json:"country"`
+	DatacenterName    string   `json:"datacenterName"`
+	AvailabilityZones []string `json:"availabilityZones"`
+	Services          []string `json:"services"`
+}
+
+// cloudRegionDataSourceModel is the Terraform model for the singular ovh_cloud_region data source.
+type cloudRegionDataSourceModel struct {
+	ServiceName       ovhtypes.TfStringValue `tfsdk:"service_name"`
+	Name              ovhtypes.TfStringValue `tfsdk:"name"`
+	Status            ovhtypes.TfStringValue `tfsdk:"status"`
+	Continent         ovhtypes.TfStringValue `tfsdk:"continent"`
+	Country           ovhtypes.TfStringValue `tfsdk:"country"`
+	DatacenterName    ovhtypes.TfStringValue `tfsdk:"datacenter_name"`
+	AvailabilityZones types.List             `tfsdk:"availability_zones"`
+	Services          types.List             `tfsdk:"services"`
+}
+
+// cloudRegionsDataSourceModel is the Terraform model for the plural ovh_cloud_regions data source.
+type cloudRegionsDataSourceModel struct {
+	ServiceName ovhtypes.TfStringValue `tfsdk:"service_name"`
+	Regions     types.List             `tfsdk:"regions"`
+}
+
+// cloudRegionDetailAttributes returns the computed schema attributes describing a single
+// region. It is shared between the singular data source and the plural data source's nested
+// "regions" objects. The "name" attribute is intentionally excluded so each data source can
+// declare it as required (singular input) or computed (plural list item).
+func cloudRegionDetailAttributes() map[string]schema.Attribute {
+	return map[string]schema.Attribute{
+		"status": schema.StringAttribute{
+			CustomType:          ovhtypes.TfStringType{},
+			Computed:            true,
+			Description:         "Region status (ENABLED, DISABLED or MAINTENANCE)",
+			MarkdownDescription: "Region status (ENABLED, DISABLED or MAINTENANCE)",
+		},
+		"continent": schema.StringAttribute{
+			CustomType:          ovhtypes.TfStringType{},
+			Computed:            true,
+			Description:         "Continent code of the region",
+			MarkdownDescription: "Continent code of the region",
+		},
+		"country": schema.StringAttribute{
+			CustomType:          ovhtypes.TfStringType{},
+			Computed:            true,
+			Description:         "Country code of the region",
+			MarkdownDescription: "Country code of the region",
+		},
+		"datacenter_name": schema.StringAttribute{
+			CustomType:          ovhtypes.TfStringType{},
+			Computed:            true,
+			Description:         "Display name of the datacenter hosting the region",
+			MarkdownDescription: "Display name of the datacenter hosting the region",
+		},
+		"availability_zones": schema.ListAttribute{
+			ElementType:         types.StringType,
+			Computed:            true,
+			Description:         "Availability zones available in the region",
+			MarkdownDescription: "Availability zones available in the region",
+		},
+		"services": schema.ListAttribute{
+			ElementType:         types.StringType,
+			Computed:            true,
+			Description:         "Available OpenStack services in the region",
+			MarkdownDescription: "Available OpenStack services in the region",
+		},
+	}
+}
+
+// cloudRegionObjectAttrTypes returns the attribute types of a single region object, matching
+// the attributes declared in cloudRegionDetailAttributes plus "name".
+func cloudRegionObjectAttrTypes() map[string]attr.Type {
+	return map[string]attr.Type{
+		"name":               ovhtypes.TfStringType{},
+		"status":             ovhtypes.TfStringType{},
+		"continent":          ovhtypes.TfStringType{},
+		"country":            ovhtypes.TfStringType{},
+		"datacenter_name":    ovhtypes.TfStringType{},
+		"availability_zones": types.ListType{ElemType: types.StringType},
+		"services":           types.ListType{ElemType: types.StringType},
+	}
+}
+
+// stringSliceToTfList converts a Go string slice into a Terraform list of strings. A nil slice
+// becomes a null list, while an empty (but non-nil) slice becomes an empty list.
+func stringSliceToTfList(ctx context.Context, in []string) (types.List, diag.Diagnostics) {
+	if in == nil {
+		return types.ListNull(types.StringType), nil
+	}
+	return types.ListValueFrom(ctx, types.StringType, in)
+}
+
+// MergeWith populates the singular data source model from an API region.
+func (m *cloudRegionDataSourceModel) MergeWith(ctx context.Context, region *CloudRegion) diag.Diagnostics {
+	var diags diag.Diagnostics
+
+	m.Name = ovhtypes.TfStringValue{StringValue: types.StringValue(region.Name)}
+	m.Status = ovhtypes.TfStringValue{StringValue: types.StringValue(region.Status)}
+	m.Continent = ovhtypes.TfStringValue{StringValue: types.StringValue(region.Continent)}
+	m.Country = ovhtypes.TfStringValue{StringValue: types.StringValue(region.Country)}
+	m.DatacenterName = ovhtypes.TfStringValue{StringValue: types.StringValue(region.DatacenterName)}
+
+	availabilityZones, d := stringSliceToTfList(ctx, region.AvailabilityZones)
+	diags.Append(d...)
+	m.AvailabilityZones = availabilityZones
+
+	services, d := stringSliceToTfList(ctx, region.Services)
+	diags.Append(d...)
+	m.Services = services
+
+	return diags
+}
+
+// cloudRegionToObject converts an API region into a Terraform object value matching
+// cloudRegionObjectAttrTypes.
+func cloudRegionToObject(ctx context.Context, region CloudRegion) (types.Object, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	availabilityZones, d := stringSliceToTfList(ctx, region.AvailabilityZones)
+	diags.Append(d...)
+
+	services, d := stringSliceToTfList(ctx, region.Services)
+	diags.Append(d...)
+
+	obj, d := types.ObjectValue(cloudRegionObjectAttrTypes(), map[string]attr.Value{
+		"name":               ovhtypes.TfStringValue{StringValue: types.StringValue(region.Name)},
+		"status":             ovhtypes.TfStringValue{StringValue: types.StringValue(region.Status)},
+		"continent":          ovhtypes.TfStringValue{StringValue: types.StringValue(region.Continent)},
+		"country":            ovhtypes.TfStringValue{StringValue: types.StringValue(region.Country)},
+		"datacenter_name":    ovhtypes.TfStringValue{StringValue: types.StringValue(region.DatacenterName)},
+		"availability_zones": availabilityZones,
+		"services":           services,
+	})
+	diags.Append(d...)
+
+	return obj, diags
+}


### PR DESCRIPTION
# Description

Adds datasources:
- `ovh_cloud_region`
- `ovh_cloud_regions`

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

```
$ make testacc TESTARGS="-run 'TestAccCloudRegionsDataSource_basic|TestAccCloudRegionDataSource_basic'"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -run 'TestAccCloudRegionsDataSource_basic|TestAccCloudRegionDataSource_basic' -timeout 600m -p 10
?   	github.com/ovh/terraform-provider-ovh/v2	[no test files]
=== RUN   TestAccCloudRegionDataSource_basic
--- PASS: TestAccCloudRegionDataSource_basic (1.89s)
=== RUN   TestAccCloudRegionsDataSource_basic
--- PASS: TestAccCloudRegionsDataSource_basic (1.66s)
PASS
ok  	github.com/ovh/terraform-provider-ovh/v2/ovh	3.611s
```

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or issues
- [x] I have added acceptance tests that prove my fix is effective or that my feature works
- [x] New and existing acceptance tests pass locally with my changes
- [x] I ran successfully `go mod vendor` if I added or modify `go.mod` file
