### PR TITLE
feat(dbaas/logs): add encryption_keys_ids to graylog stream

### DIFF
--- a/docs/data-sources/dbaas_logs_output_graylog_stream.md
+++ b/docs/data-sources/dbaas_logs_output_graylog_stream.md
@@ -30,8 +30,10 @@ data "ovh_dbaas_logs_output_graylog_stream" "stream" {
 * `cold_storage_notify_enabled` - Notify on new Cold storage archive
 * `cold_storage_retention` - Cold storage retention in year
 * `cold_storage_target` - ColdStorage destination
+* `can_alert` - Indicates if the current user can create alert on the stream
 * `created_at` - Stream creation
 * `description` - Stream description
+* `encryption_keys_ids` - Set of encryption key IDs used to encrypt stream archives
 * `indexing_enabled` - Enable ES indexing
 * `indexing_max_size` - Maximum indexing size (in GB)
 * `indexing_notify_enabled` - If set, notify when size is near 80, 90 or 100 % of the maximum configured setting
@@ -40,7 +42,7 @@ data "ovh_dbaas_logs_output_graylog_stream" "stream" {
 * `nb_alert_condition` - Number of alert condition
 * `nb_archive` - Number of coldstored archives
 * `parent_stream_id` - Parent stream ID
-* `pause_indexing_on_max_size` - If set, pause indexing when maximum size is reach
+* `pause_indexing_on_max_size` - If set, pause indexing when maximum size is reached
 * `retention_id` - Retention ID
 * `stream_id` - Stream ID
 * `updated_at` - Stream last update

--- a/docs/resources/dbaas_logs_output_graylog_stream.md
+++ b/docs/resources/dbaas_logs_output_graylog_stream.md
@@ -8,6 +8,8 @@ Creates a DBaaS Logs Graylog output stream.
 
 ## Example Usage
 
+### Example 1 - Basic stream
+
 ```terraform
 resource "ovh_dbaas_logs_output_graylog_stream" "stream" {
   service_name = "...."
@@ -16,7 +18,7 @@ resource "ovh_dbaas_logs_output_graylog_stream" "stream" {
 }
 ```
 
-To define the retention of the stream, you can use the following configuration:
+### Example 2 - Stream retention
 
 ```terraform
 data "ovh_dbaas_logs_cluster_retention" "retention" {
@@ -33,6 +35,27 @@ resource "ovh_dbaas_logs_output_graylog_stream" "stream" {
 }
 ```
 
+### Example 3 - Cold Storage encryption using a PGP public key
+
+```terraform
+resource "ovh_dbaas_logs_encryption_key" "key" {
+  service_name = "ldp-xx-xxxxx"
+  title        = "my PGP key"
+  content      = file("my-pgp-public-key.asc")
+  fingerprint  = "ABCDEF1234567890ABCDEF1234567890ABCDEF12"
+}
+
+resource "ovh_dbaas_logs_output_graylog_stream" "stream" {
+  service_name            = "ldp-xx-xxxxx"
+  title                   = "my stream"
+  description             = "my encrypted graylog stream"
+  cold_storage_enabled    = true
+  cold_storage_target     = "PCA"
+  cold_storage_retention  = 1
+  encryption_keys_ids     = [ovh_dbaas_logs_encryption_key.key.id]
+}
+```
+
 ## Argument Reference
 
 The following arguments are supported:
@@ -42,11 +65,12 @@ The following arguments are supported:
 * `parent_stream_id` - Parent stream ID
 * `retention_id` - Retention ID
 * `cold_storage_compression` - Cold storage compression method. One of "LZMA", "GZIP", "DEFLATED", "ZSTD"
-* `cold_storage_content` - ColdStorage content. One of "ALL", "GLEF", "PLAIN"
+* `cold_storage_content` - ColdStorage content. One of "ALL", "GELF", "PLAIN"
 * `cold_storage_enabled` - Is Cold storage enabled?
 * `cold_storage_notify_enabled` - Notify on new Cold storage archive
 * `cold_storage_retention` - Cold storage retention in year
 * `cold_storage_target` - ColdStorage destination. One of "PCA", "PCS"
+* `encryption_keys_ids` - Set of encryption key IDs used to encrypt stream archives
 * `indexing_enabled` - Enable ES indexing
 * `indexing_max_size` - Maximum indexing size (in GB)
 * `indexing_notify_enabled` - If set, notify when size is near 80, 90 or 100 % of the maximum configured setting
@@ -62,9 +86,9 @@ Id is set to the output stream Id. In addition, the following attributes are exp
 * `is_editable` - Indicates if you are allowed to edit entry
 * `is_shareable` - Indicates if you are allowed to share entry
 * `nb_alert_condition` - Number of alert condition
-* `nb_archive` - Number of coldstored archivesr
+* `nb_archive` - Number of coldstored archives
 * `stream_id` - Stream ID
-* `updated_at` - Stream last updater
+* `updated_at` - Stream last update
 * `write_token` - Write token of the stream (empty if the caller is not the owner of the stream)
 
 ## Import

--- a/examples/resources/dbaas_logs_output_graylog_stream/example_3.tf
+++ b/examples/resources/dbaas_logs_output_graylog_stream/example_3.tf
@@ -1,0 +1,16 @@
+resource "ovh_dbaas_logs_encryption_key" "key" {
+  service_name = "ldp-xx-xxxxx"
+  title        = "my PGP key"
+  content      = file("my-pgp-public-key.asc")
+  fingerprint  = "ABCDEF1234567890ABCDEF1234567890ABCDEF12"
+}
+
+resource "ovh_dbaas_logs_output_graylog_stream" "stream" {
+  service_name            = "ldp-xx-xxxxx"
+  title                   = "my stream"
+  description             = "my encrypted graylog stream"
+  cold_storage_enabled    = true
+  cold_storage_target     = "PCA"
+  cold_storage_retention  = 1
+  encryption_keys_ids     = [ovh_dbaas_logs_encryption_key.key.id]
+}

--- a/ovh/data_dbaas_logs_output_graylog_stream.go
+++ b/ovh/data_dbaas_logs_output_graylog_stream.go
@@ -72,6 +72,12 @@ func dataSourceDbaasLogsOutputGraylogStream() *schema.Resource {
 				Description: "Stream description",
 				Computed:    true,
 			},
+			"encryption_keys_ids": {
+				Type:        schema.TypeSet,
+				Description: "Set of encryption key IDs used to encrypt stream archives",
+				Computed:    true,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+			},
 			"indexing_enabled": {
 				Type:        schema.TypeBool,
 				Description: "Enable ES indexing",

--- a/ovh/data_dbaas_logs_output_graylog_stream_test.go
+++ b/ovh/data_dbaas_logs_output_graylog_stream_test.go
@@ -122,3 +122,64 @@ func TestAccDataSourceDbaasLogsOutputGraylogStream_with_retention(t *testing.T) 
 		},
 	})
 }
+
+func TestAccDataSourceDbaasLogsOutputGraylogStream_with_encryption_keys(t *testing.T) {
+	serviceName := os.Getenv("OVH_DBAAS_LOGS_SERVICE_TEST")
+	pgpContent := os.Getenv("OVH_DBAAS_LOGS_ENCRYPTION_KEY_CONTENT_TEST")
+	pgpFingerprint := os.Getenv("OVH_DBAAS_LOGS_ENCRYPTION_KEY_FINGERPRINT_TEST")
+	title := acctest.RandomWithPrefix(test_prefix)
+	desc := acctest.RandomWithPrefix(test_prefix)
+
+	config := fmt.Sprintf(`
+		resource "ovh_dbaas_logs_encryption_key" "key" {
+			service_name = "%s"
+			title        = "%s"
+			content      = trimspace(<<-EOT
+%s
+EOT
+			)
+			fingerprint  = "%s"
+		}
+
+		resource "ovh_dbaas_logs_output_graylog_stream" "stream" {
+			service_name        = "%s"
+			title               = "%s"
+			description         = "%s"
+			encryption_keys_ids = [ovh_dbaas_logs_encryption_key.key.id]
+		}
+
+		data "ovh_dbaas_logs_output_graylog_stream" "stream" {
+			service_name = ovh_dbaas_logs_output_graylog_stream.stream.service_name
+			title        = ovh_dbaas_logs_output_graylog_stream.stream.title
+		}`,
+		serviceName,
+		title,
+		pgpContent,
+		pgpFingerprint,
+		serviceName,
+		title,
+		desc,
+	)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() { testAccPreCheckDbaasLogsEncryptionKey(t) },
+
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(
+						"data.ovh_dbaas_logs_output_graylog_stream.stream",
+						"encryption_keys_ids.#",
+						"1",
+					),
+					resource.TestCheckTypeSetElemAttrPair(
+						"data.ovh_dbaas_logs_output_graylog_stream.stream", "encryption_keys_ids.*",
+						"ovh_dbaas_logs_encryption_key.key", "id",
+					),
+				),
+			},
+		},
+	})
+}

--- a/ovh/resource_dbaas_logs_output_graylog_stream.go
+++ b/ovh/resource_dbaas_logs_output_graylog_stream.go
@@ -128,6 +128,12 @@ func resourceDbaasLogsOutputGraylogStream() *schema.Resource {
 					return
 				},
 			},
+			"encryption_keys_ids": {
+				Type:        schema.TypeSet,
+				Description: "Set of encryption key IDs used to encrypt stream archives",
+				Optional:    true,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+			},
 			"indexing_enabled": {
 				Type:        schema.TypeBool,
 				Description: "Enable ES indexing",

--- a/ovh/resource_dbaas_logs_output_graylog_stream_test.go
+++ b/ovh/resource_dbaas_logs_output_graylog_stream_test.go
@@ -194,3 +194,60 @@ func TestAccResourceDbaasLogsOutputGraylogStream_with_retention(t *testing.T) {
 		},
 	})
 }
+
+func TestAccResourceDbaasLogsOutputGraylogStream_with_encryption_keys(t *testing.T) {
+	serviceName := os.Getenv("OVH_DBAAS_LOGS_SERVICE_TEST")
+	pgpContent := os.Getenv("OVH_DBAAS_LOGS_ENCRYPTION_KEY_CONTENT_TEST")
+	pgpFingerprint := os.Getenv("OVH_DBAAS_LOGS_ENCRYPTION_KEY_FINGERPRINT_TEST")
+	title := acctest.RandomWithPrefix(test_prefix)
+	desc := acctest.RandomWithPrefix(test_prefix)
+
+	config := fmt.Sprintf(`
+		resource "ovh_dbaas_logs_encryption_key" "key" {
+			service_name = "%s"
+			title        = "%s"
+			content      = trimspace(<<-EOT
+%s
+EOT
+			)
+			fingerprint  = "%s"
+		}
+
+		resource "ovh_dbaas_logs_output_graylog_stream" "stream" {
+			service_name        = "%s"
+			title               = "%s"
+			description         = "%s"
+			encryption_keys_ids = [ovh_dbaas_logs_encryption_key.key.id]
+		}
+		`,
+		serviceName,
+		title,
+		pgpContent,
+		pgpFingerprint,
+		serviceName,
+		title,
+		desc,
+	)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() { testAccPreCheckDbaasLogsEncryptionKey(t) },
+
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(
+						"ovh_dbaas_logs_output_graylog_stream.stream",
+						"encryption_keys_ids.#",
+						"1",
+					),
+					resource.TestCheckTypeSetElemAttrPair(
+						"ovh_dbaas_logs_output_graylog_stream.stream", "encryption_keys_ids.*",
+						"ovh_dbaas_logs_encryption_key.key", "id",
+					),
+				),
+			},
+		},
+	})
+}

--- a/ovh/types_dbaas_logs_output_graylog_stream.go
+++ b/ovh/types_dbaas_logs_output_graylog_stream.go
@@ -6,29 +6,30 @@ import (
 )
 
 type DbaasLogsOutputGraylogStream struct {
-	CanAlert                 bool    `json:"canAlert"`
-	ColdStorageCompression   *string `json:"coldStorageCompression"`
-	ColdStorageContent       *string `json:"coldStorageContent"`
-	ColdStorageEnabled       *bool   `json:"coldStorageEnabled"`
-	ColdStorageNotifyEnabled *bool   `json:"coldStorageNotifyEnabled"`
-	ColdStorageRetention     *int64  `json:"coldStorageRetention"`
-	ColdStorageTarget        *string `json:"coldStorageTarget"`
-	CreatedAt                string  `json:"createdAt"`
-	Description              string  `json:"description"`
-	IndexingEnabled          *bool   `json:"indexingEnabled"`
-	IndexingMaxSize          *int64  `json:"indexingMaxSize"`
-	IndexingNotifyEnabled    *bool   `json:"indexingNotifyEnabled"`
-	IsEditable               bool    `json:"isEditable"`
-	IsShareable              bool    `json:"isShareable"`
-	NbAlertCondition         int64   `json:"nbAlertCondition"`
-	NbArchive                int64   `json:"nbArchive"`
-	ParentStreamId           *string `json:"parentStreamId"`
-	PauseIndexingOnMaxSize   *bool   `json:"pauseIndexingOnMaxSize"`
-	RetentionId              string  `json:"retentionId"`
-	StreamId                 string  `json:"streamId"`
-	Title                    string  `json:"title"`
-	UpdatedAt                string  `json:"updatedAt"`
-	WebSocketEnabled         *bool   `json:"webSocketEnabled"`
+	CanAlert                 bool     `json:"canAlert"`
+	ColdStorageCompression   *string  `json:"coldStorageCompression"`
+	ColdStorageContent       *string  `json:"coldStorageContent"`
+	ColdStorageEnabled       *bool    `json:"coldStorageEnabled"`
+	ColdStorageNotifyEnabled *bool    `json:"coldStorageNotifyEnabled"`
+	ColdStorageRetention     *int64   `json:"coldStorageRetention"`
+	ColdStorageTarget        *string  `json:"coldStorageTarget"`
+	CreatedAt                string   `json:"createdAt"`
+	Description              string   `json:"description"`
+	EncryptionKeysIds        []string `json:"encryptionKeysIds"`
+	IndexingEnabled          *bool    `json:"indexingEnabled"`
+	IndexingMaxSize          *int64   `json:"indexingMaxSize"`
+	IndexingNotifyEnabled    *bool    `json:"indexingNotifyEnabled"`
+	IsEditable               bool     `json:"isEditable"`
+	IsShareable              bool     `json:"isShareable"`
+	NbAlertCondition         int64    `json:"nbAlertCondition"`
+	NbArchive                int64    `json:"nbArchive"`
+	ParentStreamId           *string  `json:"parentStreamId"`
+	PauseIndexingOnMaxSize   *bool    `json:"pauseIndexingOnMaxSize"`
+	RetentionId              string   `json:"retentionId"`
+	StreamId                 string   `json:"streamId"`
+	Title                    string   `json:"title"`
+	UpdatedAt                string   `json:"updatedAt"`
+	WebSocketEnabled         *bool    `json:"webSocketEnabled"`
 }
 
 func (v DbaasLogsOutputGraylogStream) ToMap() map[string]interface{} {
@@ -63,6 +64,9 @@ func (v DbaasLogsOutputGraylogStream) ToMap() map[string]interface{} {
 	if v.ColdStorageTarget != nil {
 		obj["cold_storage_target"] = *v.ColdStorageTarget
 	}
+	if v.EncryptionKeysIds != nil {
+		obj["encryption_keys_ids"] = v.EncryptionKeysIds
+	}
 	if v.IndexingEnabled != nil {
 		obj["indexing_enabled"] = *v.IndexingEnabled
 	}
@@ -83,21 +87,22 @@ func (v DbaasLogsOutputGraylogStream) ToMap() map[string]interface{} {
 }
 
 type DbaasLogsOutputGraylogStreamCreateOpts struct {
-	ColdStorageCompression   *string `json:"coldStorageCompression,omitempty"`
-	ColdStorageContent       *string `json:"coldStorageContent,omitempty"`
-	ColdStorageEnabled       *bool   `json:"coldStorageEnabled,omitempty"`
-	ColdStorageNotifyEnabled *bool   `json:"coldStorageNotifyEnabled,omitempty"`
-	ColdStorageRetention     *int64  `json:"coldStorageRetention,omitempty"`
-	ColdStorageTarget        *string `json:"coldStorageTarget,omitempty"`
-	Description              string  `json:"description"`
-	IndexingEnabled          *bool   `json:"indexingEnabled,omitempty"`
-	IndexingMaxSize          *int64  `json:"indexingMaxSize,omitempty"`
-	IndexingNotifyEnabled    *bool   `json:"indexingNotifyEnabled,omitempty"`
-	ParentStreamId           *string `json:"parentStreamId,omitempty"`
-	PauseIndexingOnMaxSize   *bool   `json:"pauseIndexingOnMaxSize,omitempty"`
-	RetentionId              *string `json:"retentionId,omitempty"`
-	Title                    string  `json:"title"`
-	WebSocketEnabled         *bool   `json:"webSocketEnabled,omitempty"`
+	ColdStorageCompression   *string  `json:"coldStorageCompression,omitempty"`
+	ColdStorageContent       *string  `json:"coldStorageContent,omitempty"`
+	ColdStorageEnabled       *bool    `json:"coldStorageEnabled,omitempty"`
+	ColdStorageNotifyEnabled *bool    `json:"coldStorageNotifyEnabled,omitempty"`
+	ColdStorageRetention     *int64   `json:"coldStorageRetention,omitempty"`
+	ColdStorageTarget        *string  `json:"coldStorageTarget,omitempty"`
+	Description              string   `json:"description"`
+	EncryptionKeysIds        []string `json:"encryptionKeysIds,omitempty"`
+	IndexingEnabled          *bool    `json:"indexingEnabled,omitempty"`
+	IndexingMaxSize          *int64   `json:"indexingMaxSize,omitempty"`
+	IndexingNotifyEnabled    *bool    `json:"indexingNotifyEnabled,omitempty"`
+	ParentStreamId           *string  `json:"parentStreamId,omitempty"`
+	PauseIndexingOnMaxSize   *bool    `json:"pauseIndexingOnMaxSize,omitempty"`
+	RetentionId              *string  `json:"retentionId,omitempty"`
+	Title                    string   `json:"title"`
+	WebSocketEnabled         *bool    `json:"webSocketEnabled,omitempty"`
 }
 
 func (opts *DbaasLogsOutputGraylogStreamCreateOpts) FromResource(d *schema.ResourceData) *DbaasLogsOutputGraylogStreamCreateOpts {
@@ -108,6 +113,7 @@ func (opts *DbaasLogsOutputGraylogStreamCreateOpts) FromResource(d *schema.Resou
 	opts.ColdStorageRetention = helpers.GetNilInt64PointerFromData(d, "cold_storage_retention")
 	opts.ColdStorageTarget = helpers.GetNilStringPointerFromData(d, "cold_storage_target")
 	opts.Description = d.Get("description").(string)
+	opts.EncryptionKeysIds, _ = helpers.StringsFromSchema(d, "encryption_keys_ids")
 	opts.IndexingEnabled = helpers.GetNilBoolPointerFromData(d, "indexing_enabled")
 	opts.IndexingMaxSize = helpers.GetNilInt64PointerFromData(d, "indexing_max_size")
 	opts.IndexingNotifyEnabled = helpers.GetNilBoolPointerFromData(d, "indexing_notify_enabled")
@@ -121,21 +127,22 @@ func (opts *DbaasLogsOutputGraylogStreamCreateOpts) FromResource(d *schema.Resou
 }
 
 type DbaasLogsOutputGraylogStreamUpdateOpts struct {
-	ColdStorageCompression   *string `json:"coldStorageCompression,omitempty"`
-	ColdStorageContent       *string `json:"coldStorageContent,omitempty"`
-	ColdStorageEnabled       *bool   `json:"coldStorageEnabled,omitempty"`
-	ColdStorageNotifyEnabled *bool   `json:"coldStorageNotifyEnabled,omitempty"`
-	ColdStorageRetention     *int64  `json:"coldStorageRetention,omitempty"`
-	ColdStorageTarget        *string `json:"coldStorageTarget,omitempty"`
-	Description              string  `json:"description"`
-	IndexingEnabled          *bool   `json:"indexingEnabled,omitempty"`
-	IndexingMaxSize          *int64  `json:"indexingMaxSize,omitempty"`
-	IndexingNotifyEnabled    *bool   `json:"indexingNotifyEnabled,omitempty"`
-	ParentStreamId           *string `json:"parentStreamId,omitempty"`
-	PauseIndexingOnMaxSize   *bool   `json:"pauseIndexingOnMaxSize,omitempty"`
-	RetentionId              *string `json:"retentionId"`
-	Title                    string  `json:"title"`
-	WebSocketEnabled         *bool   `json:"webSocketEnabled,omitempty"`
+	ColdStorageCompression   *string  `json:"coldStorageCompression,omitempty"`
+	ColdStorageContent       *string  `json:"coldStorageContent,omitempty"`
+	ColdStorageEnabled       *bool    `json:"coldStorageEnabled,omitempty"`
+	ColdStorageNotifyEnabled *bool    `json:"coldStorageNotifyEnabled,omitempty"`
+	ColdStorageRetention     *int64   `json:"coldStorageRetention,omitempty"`
+	ColdStorageTarget        *string  `json:"coldStorageTarget,omitempty"`
+	Description              string   `json:"description"`
+	EncryptionKeysIds        []string `json:"encryptionKeysIds,omitempty"`
+	IndexingEnabled          *bool    `json:"indexingEnabled,omitempty"`
+	IndexingMaxSize          *int64   `json:"indexingMaxSize,omitempty"`
+	IndexingNotifyEnabled    *bool    `json:"indexingNotifyEnabled,omitempty"`
+	ParentStreamId           *string  `json:"parentStreamId,omitempty"`
+	PauseIndexingOnMaxSize   *bool    `json:"pauseIndexingOnMaxSize,omitempty"`
+	RetentionId              *string  `json:"retentionId"`
+	Title                    string   `json:"title"`
+	WebSocketEnabled         *bool    `json:"webSocketEnabled,omitempty"`
 }
 
 func (opts *DbaasLogsOutputGraylogStreamUpdateOpts) FromResource(d *schema.ResourceData) *DbaasLogsOutputGraylogStreamUpdateOpts {
@@ -146,6 +153,7 @@ func (opts *DbaasLogsOutputGraylogStreamUpdateOpts) FromResource(d *schema.Resou
 	opts.ColdStorageRetention = helpers.GetNilInt64PointerFromData(d, "cold_storage_retention")
 	opts.ColdStorageTarget = helpers.GetNilStringPointerFromData(d, "cold_storage_target")
 	opts.Description = d.Get("description").(string)
+	opts.EncryptionKeysIds, _ = helpers.StringsFromSchema(d, "encryption_keys_ids")
 	opts.IndexingEnabled = helpers.GetNilBoolPointerFromData(d, "indexing_enabled")
 	opts.IndexingMaxSize = helpers.GetNilInt64PointerFromData(d, "indexing_max_size")
 	opts.IndexingNotifyEnabled = helpers.GetNilBoolPointerFromData(d, "indexing_notify_enabled")

--- a/templates/data-sources/dbaas_logs_output_graylog_stream.md.tmpl
+++ b/templates/data-sources/dbaas_logs_output_graylog_stream.md.tmpl
@@ -29,8 +29,10 @@ Use this data source to retrieve information about a DBaas logs output graylog s
 * `cold_storage_notify_enabled` - Notify on new Cold storage archive
 * `cold_storage_retention` - Cold storage retention in year
 * `cold_storage_target` - ColdStorage destination
+* `can_alert` - Indicates if the current user can create alert on the stream
 * `created_at` - Stream creation
 * `description` - Stream description
+* `encryption_keys_ids` - Set of encryption key IDs used to encrypt stream archives
 * `indexing_enabled` - Enable ES indexing
 * `indexing_max_size` - Maximum indexing size (in GB)
 * `indexing_notify_enabled` - If set, notify when size is near 80, 90 or 100 % of the maximum configured setting
@@ -39,7 +41,7 @@ Use this data source to retrieve information about a DBaas logs output graylog s
 * `nb_alert_condition` - Number of alert condition
 * `nb_archive` - Number of coldstored archives
 * `parent_stream_id` - Parent stream ID
-* `pause_indexing_on_max_size` - If set, pause indexing when maximum size is reach
+* `pause_indexing_on_max_size` - If set, pause indexing when maximum size is reached
 * `retention_id` - Retention ID
 * `stream_id` - Stream ID
 * `updated_at` - Stream last update

--- a/templates/resources/dbaas_logs_output_graylog_stream.md.tmpl
+++ b/templates/resources/dbaas_logs_output_graylog_stream.md.tmpl
@@ -12,11 +12,17 @@ Creates a DBaaS Logs Graylog output stream.
 
 ## Example Usage
 
+### Example 1 - Basic stream
+
 {{tffile "examples/resources/dbaas_logs_output_graylog_stream/example_1.tf"}}
 
-To define the retention of the stream, you can use the following configuration:
+### Example 2 - Stream retention
 
 {{tffile "examples/resources/dbaas_logs_output_graylog_stream/example_2.tf"}}
+
+### Example 3 - Cold Storage encryption using a PGP public key
+
+{{tffile "examples/resources/dbaas_logs_output_graylog_stream/example_3.tf"}}
 
 ## Argument Reference
 
@@ -27,11 +33,12 @@ The following arguments are supported:
 * `parent_stream_id` - Parent stream ID
 * `retention_id` - Retention ID
 * `cold_storage_compression` - Cold storage compression method. One of "LZMA", "GZIP", "DEFLATED", "ZSTD"
-* `cold_storage_content` - ColdStorage content. One of "ALL", "GLEF", "PLAIN"
+* `cold_storage_content` - ColdStorage content. One of "ALL", "GELF", "PLAIN"
 * `cold_storage_enabled` - Is Cold storage enabled?
 * `cold_storage_notify_enabled` - Notify on new Cold storage archive
 * `cold_storage_retention` - Cold storage retention in year
 * `cold_storage_target` - ColdStorage destination. One of "PCA", "PCS"
+* `encryption_keys_ids` - Set of encryption key IDs used to encrypt stream archives
 * `indexing_enabled` - Enable ES indexing
 * `indexing_max_size` - Maximum indexing size (in GB)
 * `indexing_notify_enabled` - If set, notify when size is near 80, 90 or 100 % of the maximum configured setting
@@ -47,9 +54,9 @@ Id is set to the output stream Id. In addition, the following attributes are exp
 * `is_editable` - Indicates if you are allowed to edit entry
 * `is_shareable` - Indicates if you are allowed to share entry
 * `nb_alert_condition` - Number of alert condition
-* `nb_archive` - Number of coldstored archivesr
+* `nb_archive` - Number of coldstored archives
 * `stream_id` - Stream ID
-* `updated_at` - Stream last updater
+* `updated_at` - Stream last update
 * `write_token` - Write token of the stream (empty if the caller is not the owner of the stream)
 
 ## Import


### PR DESCRIPTION
# Description

Adds support for the `encryption_keys_ids` attribute on the `ovh_dbaas_logs_output_graylog_stream` resource and data source. This attribute maps to the `encryptionKeysIds` field of the OVH API and allows users to associate PGP public keys (managed by `ovh_dbaas_logs_encryption_key`) with a Graylog stream to enable cold storage archive encryption at rest.

Fixes #1275 (issue)

## Type of change

- [x] Improvement (improve existing resource(s) or datasource(s))

# How Has This Been Tested?

Two acceptance tests were added and run against a live OVH LDP service:

- [x] Test A: `make testacc TESTARGS="-run TestAccResourceDbaasLogsOutputGraylogStream_with_encryption_keys"`
- [x] Test B: `make testacc TESTARGS="-run TestAccDataSourceDbaasLogsOutputGraylogStream_with_encryption_keys"`

**Test Configuration**:
* Terraform version: `tofu version`: OpenTofu v1.12.1
* Existing HCL configuration you used: 
```hcl
data "ovh_dbaas_logs_cluster" "logstash" {
  service_name = "ldp-xx-xxxxx"
  cluster_id   = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
}

resource "gpg_key_pair" "key1" {
  identities = [{
    name  = "Test 1"
    email = "test1@example.com"
  }]
  passphrase = "topsecret1"
}

resource "ovh_dbaas_logs_encryption_key" "key1" {
  service_name = "ldp-xx-xxxxx"
  title        = gpg_key_pair.key1.identities[0].email
  content      = gpg_key_pair.key1.public_key
  fingerprint  = upper(gpg_key_pair.key1.fingerprint)
}

resource "gpg_key_pair" "key2" {
  identities = [{
    name  = "Test 2"
    email = "test2@example.com"
  }]
  passphrase = "topsecret2"
}

resource "ovh_dbaas_logs_encryption_key" "key2" {
  service_name = "ldp-xx-xxxxx"
  title        = gpg_key_pair.key2.identities[0].email
  content      = gpg_key_pair.key2.public_key
  fingerprint  = upper(gpg_key_pair.key2.fingerprint)
}

resource "ovh_dbaas_logs_output_graylog_stream" "stream" {
  service_name        = "ldp-xx-xxxxx"
  title               = "my stream"
  description         = "my graylog stream"
  encryption_keys_ids = [
    ovh_dbaas_logs_encryption_key.key1.id,
    ovh_dbaas_logs_encryption_key.key2.id,
  ]
}
```

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or issues
- [x] I have added acceptance tests that prove my fix is effective or that my feature works
- [x] New and existing acceptance tests pass locally with my changes
- [x] I ran successfully `go mod vendor` if I added or modify `go.mod` file
