### PR TITLE
fix(docs): correct URN resource type in iam_resource_tags examples

### DIFF
--- a/docs/resources/iam_resource_tags.md
+++ b/docs/resources/iam_resource_tags.md
@@ -14,7 +14,7 @@ This resource allows you to apply and manage tags on OVHcloud resources identifi
 
 ```terraform
 resource "ovh_iam_resource_tags" "project_tags" {
-  urn = "urn:v1:eu:resource:cloudProject:1234567890abcdef"
+  urn = "urn:v1:eu:resource:publicCloudProject:1234567890abcdef"
   
   tags = {
     environment    = "staging"
@@ -64,7 +64,7 @@ In addition to all arguments above, the following attributes are exported:
 IAM resource tags can be imported using the resource URN:
 
 ```bash
-terraform import ovh_iam_resource_tags.my_tags "urn:v1:eu:resource:cloudProject:1234567890abcdef"
+terraform import ovh_iam_resource_tags.my_tags "urn:v1:eu:resource:publicCloudProject:1234567890abcdef"
 ```
 
 After importing, you should update your Terraform configuration to match the imported state. The import will bring in all tags currently applied to the resource, but only tags defined in your configuration will be managed by Terraform.

--- a/examples/resources/iam_resource_tags/example_2.tf
+++ b/examples/resources/iam_resource_tags/example_2.tf
@@ -1,5 +1,5 @@
 resource "ovh_iam_resource_tags" "project_tags" {
-  urn = "urn:v1:eu:resource:cloudProject:1234567890abcdef"
+  urn = "urn:v1:eu:resource:publicCloudProject:1234567890abcdef"
   
   tags = {
     environment    = "staging"

--- a/templates/resources/iam_resource_tags.md.tmpl
+++ b/templates/resources/iam_resource_tags.md.tmpl
@@ -37,7 +37,7 @@ In addition to all arguments above, the following attributes are exported:
 IAM resource tags can be imported using the resource URN:
 
 ```bash
-terraform import ovh_iam_resource_tags.my_tags "urn:v1:eu:resource:cloudProject:1234567890abcdef"
+terraform import ovh_iam_resource_tags.my_tags "urn:v1:eu:resource:publicCloudProject:1234567890abcdef"
 ```
 
 After importing, you should update your Terraform configuration to match the imported state. The import will bring in all tags currently applied to the resource, but only tags defined in your configuration will be managed by Terraform.


### PR DESCRIPTION
## Summary

- Fixes the URN format in the `ovh_iam_resource_tags` resource documentation
- Replaces `cloudProject` with `publicCloudProject` as the resource type in example URNs
- Affected files: example TF file, template, and generated docs

## Test plan

- [x] Verify the [registry docs page](https://registry.terraform.io/providers/ovh/ovh/latest/docs/resources/iam_resource_tags) shows the correct URN format after release