### PR TITLE
Dev/aamstutz/apiv2 networking datasources

### DIFF
--- a/docs/data-sources/cloud_gateway.md
+++ b/docs/data-sources/cloud_gateway.md
@@ -1,0 +1,56 @@
+---
+subcategory : "Gateway"
+---
+
+# ovh_cloud_gateway (Data Source)
+
+Use this data source to retrieve information about a gateway in a public cloud project.
+
+## Example Usage
+
+```terraform
+data "ovh_cloud_gateway" "gateway" {
+  service_name = "<public cloud project ID>"
+  id           = "<gateway ID>"
+}
+
+output "gateway_name" {
+  value = data.ovh_cloud_gateway.gateway.name
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `service_name` - (Required) Service name of the resource representing the id of the cloud project.
+* `id` - (Required) Gateway ID.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `region` - Region of the gateway.
+* `availability_zone` - Availability zone of the gateway.
+* `name` - Gateway name.
+* `description` - Gateway description.
+* `external_gateway` - External gateway configuration:
+  * `enabled` - Whether the external gateway is enabled.
+  * `model` - External gateway sizing model.
+* `subnet_ids` - List of subnet IDs attached as router interfaces.
+* `checksum` - Computed hash representing the current target specification value.
+* `created_at` - Creation date of the gateway.
+* `updated_at` - Last update date of the gateway.
+* `resource_status` - Gateway readiness in the system (`CREATING`, `DELETING`, `ERROR`, `OUT_OF_SYNC`, `READY`, `UPDATING`).
+* `current_state` - Current state of the gateway:
+  * `name` - Gateway name.
+  * `description` - Gateway description.
+  * `status` - OpenStack router status (`ACTIVE`, `BUILD`, `DOWN`, `ERROR`).
+  * `external_gateway` - External gateway configuration:
+    * `enabled` - Whether the external gateway is enabled.
+    * `model` - External gateway sizing model.
+  * `external_ip` - External IP address assigned to the gateway.
+  * `subnets` - Currently attached subnets:
+    * `id` - Subnet ID.
+  * `region` - Region.
+  * `availability_zone` - Availability zone.

--- a/docs/data-sources/cloud_gateways.md
+++ b/docs/data-sources/cloud_gateways.md
@@ -1,0 +1,54 @@
+---
+subcategory : "Gateway"
+---
+
+# ovh_cloud_gateways (Data Source)
+
+Use this data source to list the gateways of a public cloud project.
+
+## Example Usage
+
+```terraform
+data "ovh_cloud_gateways" "gateways" {
+  service_name = "<public cloud project ID>"
+}
+
+output "gateway_names" {
+  value = [for g in data.ovh_cloud_gateways.gateways.gateways : g.name]
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `service_name` - (Required) Service name of the resource representing the id of the cloud project.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `gateways` - List of gateways. Each element exports:
+  * `id` - Gateway ID.
+  * `name` - Gateway name.
+  * `description` - Gateway description.
+  * `region` - Region of the gateway.
+  * `external_gateway` - External gateway configuration:
+    * `enabled` - Whether the external gateway is enabled.
+    * `model` - External gateway sizing model.
+  * `checksum` - Computed hash representing the current target specification value.
+  * `created_at` - Creation date of the gateway.
+  * `updated_at` - Last update date of the gateway.
+  * `resource_status` - Gateway readiness in the system (`CREATING`, `DELETING`, `ERROR`, `OUT_OF_SYNC`, `READY`, `UPDATING`).
+  * `current_state` - Current state of the gateway:
+    * `name` - Gateway name.
+    * `description` - Gateway description.
+    * `status` - OpenStack router status (`ACTIVE`, `BUILD`, `DOWN`, `ERROR`).
+    * `external_gateway` - External gateway configuration:
+      * `enabled` - Whether the external gateway is enabled.
+      * `model` - External gateway sizing model.
+    * `external_ip` - External IP address assigned to the gateway.
+    * `subnets` - Currently attached subnets:
+      * `id` - Subnet ID.
+    * `region` - Region.
+    * `availability_zone` - Availability zone.

--- a/docs/data-sources/cloud_network_private_vrack.md
+++ b/docs/data-sources/cloud_network_private_vrack.md
@@ -31,7 +31,8 @@ The following arguments are supported:
 The following attributes are exported:
 
 * `name` - Network name.
-* `region` - Region of the network.
+* `location` - Location of the network:
+  * `region` - Region of the network.
 * `description` - Network description.
 * `checksum` - Computed hash representing the current target specification value.
 * `created_at` - Creation date of the network.

--- a/docs/data-sources/cloud_network_private_vrack.md
+++ b/docs/data-sources/cloud_network_private_vrack.md
@@ -1,0 +1,44 @@
+---
+subcategory : "Private Network"
+---
+
+# ovh_cloud_network_private_vrack (Data Source)
+
+Use this data source to retrieve information about a private network (vRack) in a public cloud project.
+
+## Example Usage
+
+```terraform
+data "ovh_cloud_network_private_vrack" "network" {
+  service_name = "<public cloud project ID>"
+  id           = "<network ID>"
+}
+
+output "network_name" {
+  value = data.ovh_cloud_network_private_vrack.network.name
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `service_name` - (Required) Service name of the resource representing the id of the cloud project.
+* `id` - (Required) Network ID.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `name` - Network name.
+* `region` - Region of the network.
+* `description` - Network description.
+* `checksum` - Computed hash representing the current target specification value.
+* `created_at` - Creation date of the network.
+* `updated_at` - Last update date of the network.
+* `resource_status` - Network readiness in the system (`CREATING`, `DELETING`, `ERROR`, `OUT_OF_SYNC`, `READY`, `UPDATING`).
+* `current_state` - Current state of the network:
+  * `name` - Network name.
+  * `description` - Network description.
+  * `location` - Location details:
+    * `region` - Region code.

--- a/docs/data-sources/cloud_network_private_vrack.md
+++ b/docs/data-sources/cloud_network_private_vrack.md
@@ -34,6 +34,7 @@ The following attributes are exported:
 * `location` - Location of the network:
   * `region` - Region of the network.
 * `description` - Network description.
+* `vlan_id` - VLAN ID of the network.
 * `checksum` - Computed hash representing the current target specification value.
 * `created_at` - Creation date of the network.
 * `updated_at` - Last update date of the network.
@@ -41,5 +42,6 @@ The following attributes are exported:
 * `current_state` - Current state of the network:
   * `name` - Network name.
   * `description` - Network description.
+  * `vlan_id` - VLAN ID of the network.
   * `location` - Location details:
     * `region` - Region code.

--- a/docs/data-sources/cloud_network_private_vrack_subnet.md
+++ b/docs/data-sources/cloud_network_private_vrack_subnet.md
@@ -34,7 +34,8 @@ The following attributes are exported:
 
 * `name` - Subnet name.
 * `cidr` - CIDR address range for the subnet.
-* `region` - Region of the subnet.
+* `location` - Location details:
+  * `region` - Region code.
 * `description` - Subnet description.
 * `dhcp_enabled` - Whether DHCP is enabled on the subnet.
 * `dns_nameservers` - DNS nameservers for the subnet.

--- a/docs/data-sources/cloud_network_private_vrack_subnet.md
+++ b/docs/data-sources/cloud_network_private_vrack_subnet.md
@@ -1,0 +1,60 @@
+---
+subcategory : "Private Network"
+---
+
+# ovh_cloud_network_private_vrack_subnet (Data Source)
+
+Use this data source to retrieve information about a subnet in a private network (vRack) of a public cloud project.
+
+## Example Usage
+
+```terraform
+data "ovh_cloud_network_private_vrack_subnet" "subnet" {
+  service_name = "<public cloud project ID>"
+  network_id   = "<network ID>"
+  id           = "<subnet ID>"
+}
+
+output "subnet_cidr" {
+  value = data.ovh_cloud_network_private_vrack_subnet.subnet.cidr
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `service_name` - (Required) Service name of the resource representing the id of the cloud project.
+* `network_id` - (Required) Network ID of the parent private network.
+* `id` - (Required) Subnet ID.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `name` - Subnet name.
+* `cidr` - CIDR address range for the subnet.
+* `region` - Region of the subnet.
+* `description` - Subnet description.
+* `dhcp_enabled` - Whether DHCP is enabled on the subnet.
+* `dns_nameservers` - DNS nameservers for the subnet.
+* `gateway_ip` - Default gateway IP address.
+* `allocation_pools` - IP address allocation pools:
+  * `start` - Start IP address of the pool.
+  * `end` - End IP address of the pool.
+* `checksum` - Computed hash representing the current target specification value.
+* `created_at` - Creation date of the subnet.
+* `updated_at` - Last update date of the subnet.
+* `resource_status` - Subnet readiness in the system (`CREATING`, `DELETING`, `ERROR`, `OUT_OF_SYNC`, `READY`, `UPDATING`).
+* `current_state` - Current state of the subnet:
+  * `name` - Subnet name.
+  * `cidr` - CIDR address range.
+  * `description` - Subnet description.
+  * `dhcp_enabled` - Whether DHCP is enabled.
+  * `dns_nameservers` - Configured DNS nameservers.
+  * `gateway_ip` - Default gateway IP address.
+  * `host_routes` - Static host routes:
+    * `destination` - Destination CIDR.
+    * `next_hop` - Next hop IP address.
+  * `location` - Location details:
+    * `region` - Region code.

--- a/docs/data-sources/cloud_network_private_vrack_subnets.md
+++ b/docs/data-sources/cloud_network_private_vrack_subnets.md
@@ -34,7 +34,8 @@ The following attributes are exported:
   * `id` - Subnet ID.
   * `name` - Subnet name.
   * `cidr` - CIDR address range for the subnet.
-  * `region` - Region of the subnet.
+  * `location` - Location details:
+    * `region` - Region code.
   * `description` - Subnet description.
   * `dhcp_enabled` - Whether DHCP is enabled on the subnet.
   * `dns_nameservers` - DNS nameservers for the subnet.

--- a/docs/data-sources/cloud_network_private_vrack_subnets.md
+++ b/docs/data-sources/cloud_network_private_vrack_subnets.md
@@ -1,0 +1,60 @@
+---
+subcategory : "Private Network"
+---
+
+# ovh_cloud_network_private_vrack_subnets (Data Source)
+
+Use this data source to list the subnets of a private network (vRack) in a public cloud project.
+
+## Example Usage
+
+```terraform
+data "ovh_cloud_network_private_vrack_subnets" "subnets" {
+  service_name = "<public cloud project ID>"
+  network_id   = "<network ID>"
+}
+
+output "subnet_cidrs" {
+  value = [for s in data.ovh_cloud_network_private_vrack_subnets.subnets.subnets : s.cidr]
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `service_name` - (Required) Service name of the resource representing the id of the cloud project.
+* `network_id` - (Required) Network ID of the parent private network.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `subnets` - List of subnets. Each element exports:
+  * `id` - Subnet ID.
+  * `name` - Subnet name.
+  * `cidr` - CIDR address range for the subnet.
+  * `region` - Region of the subnet.
+  * `description` - Subnet description.
+  * `dhcp_enabled` - Whether DHCP is enabled on the subnet.
+  * `dns_nameservers` - DNS nameservers for the subnet.
+  * `gateway_ip` - Default gateway IP address.
+  * `allocation_pools` - IP address allocation pools:
+    * `start` - Start IP address of the pool.
+    * `end` - End IP address of the pool.
+  * `checksum` - Computed hash representing the current target specification value.
+  * `created_at` - Creation date of the subnet.
+  * `updated_at` - Last update date of the subnet.
+  * `resource_status` - Subnet readiness in the system (`CREATING`, `DELETING`, `ERROR`, `OUT_OF_SYNC`, `READY`, `UPDATING`).
+  * `current_state` - Current state of the subnet:
+    * `name` - Subnet name.
+    * `cidr` - CIDR address range.
+    * `description` - Subnet description.
+    * `dhcp_enabled` - Whether DHCP is enabled.
+    * `dns_nameservers` - Configured DNS nameservers.
+    * `gateway_ip` - Default gateway IP address.
+    * `host_routes` - Static host routes:
+      * `destination` - Destination CIDR.
+      * `next_hop` - Next hop IP address.
+    * `location` - Location details:
+      * `region` - Region code.

--- a/docs/data-sources/cloud_network_private_vracks.md
+++ b/docs/data-sources/cloud_network_private_vracks.md
@@ -32,7 +32,8 @@ The following attributes are exported:
   * `id` - Network ID.
   * `name` - Network name.
   * `description` - Network description.
-  * `region` - Region of the network.
+  * `location` - Location of the network:
+    * `region` - Region of the network.
   * `checksum` - Computed hash representing the current target specification value.
   * `created_at` - Creation date of the network.
   * `updated_at` - Last update date of the network.

--- a/docs/data-sources/cloud_network_private_vracks.md
+++ b/docs/data-sources/cloud_network_private_vracks.md
@@ -32,6 +32,7 @@ The following attributes are exported:
   * `id` - Network ID.
   * `name` - Network name.
   * `description` - Network description.
+  * `vlan_id` - VLAN ID of the network.
   * `location` - Location of the network:
     * `region` - Region of the network.
   * `checksum` - Computed hash representing the current target specification value.
@@ -41,5 +42,6 @@ The following attributes are exported:
   * `current_state` - Current state of the network:
     * `name` - Network name.
     * `description` - Network description.
+    * `vlan_id` - VLAN ID of the network.
     * `location` - Location details:
       * `region` - Region code.

--- a/docs/data-sources/cloud_network_private_vracks.md
+++ b/docs/data-sources/cloud_network_private_vracks.md
@@ -1,0 +1,44 @@
+---
+subcategory : "Private Network"
+---
+
+# ovh_cloud_network_private_vracks (Data Source)
+
+Use this data source to list the private networks (vRack) of a public cloud project.
+
+## Example Usage
+
+```terraform
+data "ovh_cloud_network_private_vracks" "networks" {
+  service_name = "<public cloud project ID>"
+}
+
+output "network_names" {
+  value = [for n in data.ovh_cloud_network_private_vracks.networks.networks : n.name]
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `service_name` - (Required) Service name of the resource representing the id of the cloud project.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `networks` - List of private networks. Each element exports:
+  * `id` - Network ID.
+  * `name` - Network name.
+  * `description` - Network description.
+  * `region` - Region of the network.
+  * `checksum` - Computed hash representing the current target specification value.
+  * `created_at` - Creation date of the network.
+  * `updated_at` - Last update date of the network.
+  * `resource_status` - Network readiness in the system (`CREATING`, `DELETING`, `ERROR`, `OUT_OF_SYNC`, `READY`, `UPDATING`).
+  * `current_state` - Current state of the network:
+    * `name` - Network name.
+    * `description` - Network description.
+    * `location` - Location details:
+      * `region` - Region code.

--- a/docs/resources/cloud_gateway.md
+++ b/docs/resources/cloud_gateway.md
@@ -10,7 +10,7 @@ Creates a gateway in a public cloud project.
 
 ```terraform
 resource "ovh_cloud_network_private_vrack" "network" {
-  service_name = "xxxxxxxxxx"
+  service_name = "<public cloud project ID>"
   name         = "my-private-network"
   region       = "GRA1"
 }

--- a/docs/resources/cloud_gateway.md
+++ b/docs/resources/cloud_gateway.md
@@ -1,0 +1,89 @@
+---
+subcategory : "Gateway"
+---
+
+# ovh_cloud_gateway
+
+Creates a gateway in a public cloud project.
+
+## Example Usage
+
+```terraform
+resource "ovh_cloud_network_private_vrack" "network" {
+  service_name = "xxxxxxxxxx"
+  name         = "my-private-network"
+  region       = "GRA1"
+}
+
+resource "ovh_cloud_network_private_vrack_subnet" "subnet" {
+  service_name = ovh_cloud_network_private_vrack.network.service_name
+  network_id   = ovh_cloud_network_private_vrack.network.id
+  name         = "my-subnet"
+  cidr         = "10.0.0.0/24"
+  region       = "GRA1"
+}
+
+resource "ovh_cloud_gateway" "gateway" {
+  service_name = ovh_cloud_network_private_vrack.network.service_name
+  region       = "GRA1"
+  name         = "my-gateway"
+
+  external_gateway = {
+    enabled = true
+    model   = "S"
+  }
+
+  subnet_ids = [ovh_cloud_network_private_vrack_subnet.subnet.id]
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `service_name` - (Required) Service name of the resource representing the id of the cloud project. **Changing this value recreates the resource.**
+* `region` - (Required) Region where the gateway will be created. **Changing this value recreates the resource.**
+* `name` - (Required) Gateway name.
+* `availability_zone` - (Optional) Availability zone for the gateway. **Changing this value recreates the resource.**
+* `description` - (Optional) Gateway description.
+* `external_gateway` - (Optional) External gateway configuration:
+  * `enabled` - (Required) Whether the external gateway is enabled.
+  * `model` - (Optional) External gateway sizing model (`S`, `M`, `L`, `XL`, `2XL`, `3XL`). Required when `enabled` is true.
+* `subnet_ids` - (Optional) List of subnet IDs to attach as router interfaces.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `id` - Gateway ID.
+* `checksum` - Computed hash representing the current target specification value.
+* `created_at` - Creation date of the gateway.
+* `updated_at` - Last update date of the gateway.
+* `resource_status` - Gateway readiness in the system (`CREATING`, `DELETING`, `ERROR`, `OUT_OF_SYNC`, `READY`, `UPDATING`).
+* `current_state` - Current state of the gateway:
+  * `name` - Gateway name.
+  * `description` - Gateway description.
+  * `status` - OpenStack router status (`ACTIVE`, `BUILD`, `DOWN`, `ERROR`).
+  * `external_gateway` - External gateway configuration:
+    * `enabled` - Whether the external gateway is enabled.
+    * `model` - External gateway sizing model.
+  * `external_ip` - External IP address assigned to the gateway.
+  * `subnets` - Currently attached subnets:
+    * `id` - Subnet ID.
+  * `region` - Region.
+  * `availability_zone` - Availability zone.
+
+## Import
+
+A cloud gateway can be imported using the `service_name` and `gateway_id`, separated by `/`:
+
+```terraform
+import {
+  to = ovh_cloud_gateway.gateway
+  id = "<service_name>/<gateway_id>"
+}
+```
+
+```bash
+$ terraform import ovh_cloud_gateway.gateway service_name/gateway_id
+```

--- a/docs/resources/cloud_network_private_vrack.md
+++ b/docs/resources/cloud_network_private_vrack.md
@@ -1,0 +1,57 @@
+---
+subcategory : "Private Network"
+---
+
+# ovh_cloud_network_private_vrack
+
+Creates a private network (vRack) in a public cloud project.
+
+## Example Usage
+
+```terraform
+resource "ovh_cloud_network_private_vrack" "network" {
+  service_name = "xxxxxxxxxx"
+  name         = "my-private-network"
+  region       = "GRA1"
+  description  = "My private network"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `service_name` - (Required) Service name of the resource representing the id of the cloud project. **Changing this value recreates the resource.**
+* `name` - (Required) Network name.
+* `region` - (Required) Region where the network will be created. **Changing this value recreates the resource.**
+* `description` - (Optional) Network description. **Changing this value recreates the resource.**
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `id` - Network ID.
+* `checksum` - Computed hash representing the current target specification value.
+* `created_at` - Creation date of the network.
+* `updated_at` - Last update date of the network.
+* `resource_status` - Network readiness in the system (`CREATING`, `DELETING`, `ERROR`, `OUT_OF_SYNC`, `READY`, `UPDATING`).
+* `current_state` - Current state of the network:
+  * `name` - Network name.
+  * `description` - Network description.
+  * `location` - Location details:
+    * `region` - Region code.
+
+## Import
+
+A cloud private network can be imported using the `service_name` and `network_id`, separated by `/`:
+
+```terraform
+import {
+  to = ovh_cloud_network_private_vrack.network
+  id = "<service_name>/<network_id>"
+}
+```
+
+```bash
+$ terraform import ovh_cloud_network_private_vrack.network service_name/network_id
+```

--- a/docs/resources/cloud_network_private_vrack.md
+++ b/docs/resources/cloud_network_private_vrack.md
@@ -16,6 +16,7 @@ resource "ovh_cloud_network_private_vrack" "network" {
     region = "GRA1"
   }
   description = "My private network"
+  vlan_id     = 100
 }
 ```
 
@@ -28,6 +29,7 @@ The following arguments are supported:
 * `location` - (Required) Location of the network:
   * `region` - (Required) Region where the network will be created. **Changing this value recreates the resource.**
 * `description` - (Optional) Network description. **Changing this value recreates the resource.**
+* `vlan_id` - (Optional) VLAN ID of the network (0-4096). Assigned by the API if not set. **Changing this value recreates the resource.** Not supported in localzone regions.
 
 ## Attributes Reference
 
@@ -41,6 +43,7 @@ The following attributes are exported:
 * `current_state` - Current state of the network:
   * `name` - Network name.
   * `description` - Network description.
+  * `vlan_id` - VLAN ID.
   * `location` - Location details:
     * `region` - Region code.
 

--- a/docs/resources/cloud_network_private_vrack.md
+++ b/docs/resources/cloud_network_private_vrack.md
@@ -12,8 +12,10 @@ Creates a private network (vRack) in a public cloud project.
 resource "ovh_cloud_network_private_vrack" "network" {
   service_name = "xxxxxxxxxx"
   name         = "my-private-network"
-  region       = "GRA1"
-  description  = "My private network"
+  location = {
+    region = "GRA1"
+  }
+  description = "My private network"
 }
 ```
 
@@ -23,7 +25,8 @@ The following arguments are supported:
 
 * `service_name` - (Required) Service name of the resource representing the id of the cloud project. **Changing this value recreates the resource.**
 * `name` - (Required) Network name.
-* `region` - (Required) Region where the network will be created. **Changing this value recreates the resource.**
+* `location` - (Required) Location of the network:
+  * `region` - (Required) Region where the network will be created. **Changing this value recreates the resource.**
 * `description` - (Optional) Network description. **Changing this value recreates the resource.**
 
 ## Attributes Reference

--- a/docs/resources/cloud_network_private_vrack.md
+++ b/docs/resources/cloud_network_private_vrack.md
@@ -10,7 +10,7 @@ Creates a private network (vRack) in a public cloud project.
 
 ```terraform
 resource "ovh_cloud_network_private_vrack" "network" {
-  service_name = "xxxxxxxxxx"
+  service_name = "<public cloud project ID>"
   name         = "my-private-network"
   location = {
     region = "GRA1"

--- a/docs/resources/cloud_network_private_vrack_subnet.md
+++ b/docs/resources/cloud_network_private_vrack_subnet.md
@@ -1,0 +1,90 @@
+---
+subcategory : "Private Network"
+---
+
+# ovh_cloud_network_private_vrack_subnet
+
+Creates a subnet in a private network (vRack) in a public cloud project.
+
+## Example Usage
+
+```terraform
+resource "ovh_cloud_network_private_vrack" "network" {
+  service_name = "xxxxxxxxxx"
+  name         = "my-private-network"
+  region       = "GRA1"
+}
+
+resource "ovh_cloud_network_private_vrack_subnet" "subnet" {
+  service_name = ovh_cloud_network_private_vrack.network.service_name
+  network_id   = ovh_cloud_network_private_vrack.network.id
+  name         = "my-subnet"
+  cidr         = "10.0.0.0/24"
+  region       = "GRA1"
+  dhcp_enabled = true
+  gateway_ip   = "10.0.0.1"
+
+  dns_nameservers = [
+    "213.186.33.99",
+  ]
+
+  allocation_pools {
+    start = "10.0.0.2"
+    end   = "10.0.0.254"
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `service_name` - (Required) Service name of the resource representing the id of the cloud project. **Changing this value recreates the resource.**
+* `network_id` - (Required) Network ID of the parent private network. **Changing this value recreates the resource.**
+* `name` - (Required) Subnet name.
+* `cidr` - (Required) CIDR address range for the subnet (e.g. `10.0.0.0/24`). **Changing this value recreates the resource.**
+* `region` - (Required) Region where the subnet will be created. **Changing this value recreates the resource.**
+* `description` - (Optional) Subnet description.
+* `dhcp_enabled` - (Optional) Whether DHCP is enabled on the subnet.
+* `dns_nameservers` - (Optional) List of DNS nameserver addresses.
+* `gateway_ip` - (Optional) Default gateway IP address.
+* `allocation_pools` - (Optional) IP address allocation pools:
+  * `start` - (Required) Start IP address of the pool.
+  * `end` - (Required) End IP address of the pool.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `id` - Subnet ID.
+* `checksum` - Computed hash representing the current target specification value.
+* `created_at` - Creation date of the subnet.
+* `updated_at` - Last update date of the subnet.
+* `resource_status` - Subnet readiness in the system (`CREATING`, `DELETING`, `ERROR`, `OUT_OF_SYNC`, `READY`, `UPDATING`).
+* `current_state` - Current state of the subnet:
+  * `name` - Subnet name.
+  * `cidr` - CIDR address range.
+  * `description` - Subnet description.
+  * `dhcp_enabled` - Whether DHCP is enabled.
+  * `dns_nameservers` - Configured DNS nameservers.
+  * `gateway_ip` - Default gateway IP address.
+  * `host_routes` - Static host routes:
+    * `destination` - Destination CIDR.
+    * `next_hop` - Next hop IP address.
+  * `location` - Location details:
+    * `region` - Region code.
+
+## Import
+
+A cloud private network subnet can be imported using the `service_name`, `network_id` and `subnet_id`, separated by `/`:
+
+```terraform
+import {
+  to = ovh_cloud_network_private_vrack_subnet.subnet
+  id = "<service_name>/<network_id>/<subnet_id>"
+}
+```
+
+```bash
+$ terraform import ovh_cloud_network_private_vrack_subnet.subnet service_name/network_id/subnet_id
+```

--- a/docs/resources/cloud_network_private_vrack_subnet.md
+++ b/docs/resources/cloud_network_private_vrack_subnet.md
@@ -10,13 +10,13 @@ Creates a subnet in a private network (vRack) in a public cloud project.
 
 ```terraform
 resource "ovh_cloud_network_private_vrack" "network" {
-  service_name = "xxxxxxxxxx"
+  service_name = "<public cloud project ID>"
   name         = "my-private-network"
   region       = "GRA1"
 }
 
 resource "ovh_cloud_network_private_vrack_subnet" "subnet" {
-  project_id   = ovh_cloud_network_private_vrack.network.service_name
+  service_name = ovh_cloud_network_private_vrack.network.service_name
   network_id   = ovh_cloud_network_private_vrack.network.id
   name         = "my-subnet"
   cidr         = "10.0.0.0/24"
@@ -44,7 +44,7 @@ resource "ovh_cloud_network_private_vrack_subnet" "subnet" {
 
 The following arguments are supported:
 
-* `project_id` - (Required) Project ID (service name of the cloud project). **Changing this value recreates the resource.**
+* `service_name` - (Required) Service name (ID of the cloud project). **Changing this value recreates the resource.**
 * `network_id` - (Required) Network ID of the parent private network. **Changing this value recreates the resource.**
 * `name` - (Required) Subnet name.
 * `cidr` - (Required) CIDR address range for the subnet (e.g. `10.0.0.0/24`). **Changing this value recreates the resource.**
@@ -83,15 +83,15 @@ The following attributes are exported:
 
 ## Import
 
-A cloud private network subnet can be imported using the `project_id`, `network_id` and `id`, separated by `/`:
+A cloud private network subnet can be imported using the `service_name`, `network_id` and `id`, separated by `/`:
 
 ```terraform
 import {
   to = ovh_cloud_network_private_vrack_subnet.subnet
-  id = "<project_id>/<network_id>/<id>"
+  id = "<service_name>/<network_id>/<id>"
 }
 ```
 
 ```bash
-$ terraform import ovh_cloud_network_private_vrack_subnet.subnet project_id/network_id/id
+$ terraform import ovh_cloud_network_private_vrack_subnet.subnet service_name/network_id/id
 ```

--- a/docs/resources/cloud_network_private_vrack_subnet.md
+++ b/docs/resources/cloud_network_private_vrack_subnet.md
@@ -16,22 +16,27 @@ resource "ovh_cloud_network_private_vrack" "network" {
 }
 
 resource "ovh_cloud_network_private_vrack_subnet" "subnet" {
-  service_name = ovh_cloud_network_private_vrack.network.service_name
+  project_id   = ovh_cloud_network_private_vrack.network.service_name
   network_id   = ovh_cloud_network_private_vrack.network.id
   name         = "my-subnet"
   cidr         = "10.0.0.0/24"
-  region       = "GRA1"
   dhcp_enabled = true
   gateway_ip   = "10.0.0.1"
+
+  location = {
+    region = "GRA1"
+  }
 
   dns_nameservers = [
     "213.186.33.99",
   ]
 
-  allocation_pools {
-    start = "10.0.0.2"
-    end   = "10.0.0.254"
-  }
+  allocation_pools = [
+    {
+      start = "10.0.0.2"
+      end   = "10.0.0.254"
+    },
+  ]
 }
 ```
 
@@ -39,11 +44,13 @@ resource "ovh_cloud_network_private_vrack_subnet" "subnet" {
 
 The following arguments are supported:
 
-* `service_name` - (Required) Service name of the resource representing the id of the cloud project. **Changing this value recreates the resource.**
+* `project_id` - (Required) Project ID (service name of the cloud project). **Changing this value recreates the resource.**
 * `network_id` - (Required) Network ID of the parent private network. **Changing this value recreates the resource.**
 * `name` - (Required) Subnet name.
 * `cidr` - (Required) CIDR address range for the subnet (e.g. `10.0.0.0/24`). **Changing this value recreates the resource.**
-* `region` - (Required) Region where the subnet will be created. **Changing this value recreates the resource.**
+* `location` - (Required) Target location of the subnet:
+  * `region` - (Required) Region where the subnet will be created. **Changing this value recreates the resource.**
+  * `availability_zone` - (Optional) Availability zone within the region.
 * `description` - (Optional) Subnet description.
 * `dhcp_enabled` - (Optional) Whether DHCP is enabled on the subnet.
 * `dns_nameservers` - (Optional) List of DNS nameserver addresses.
@@ -76,15 +83,15 @@ The following attributes are exported:
 
 ## Import
 
-A cloud private network subnet can be imported using the `service_name`, `network_id` and `subnet_id`, separated by `/`:
+A cloud private network subnet can be imported using the `project_id`, `network_id` and `id`, separated by `/`:
 
 ```terraform
 import {
   to = ovh_cloud_network_private_vrack_subnet.subnet
-  id = "<service_name>/<network_id>/<subnet_id>"
+  id = "<project_id>/<network_id>/<id>"
 }
 ```
 
 ```bash
-$ terraform import ovh_cloud_network_private_vrack_subnet.subnet service_name/network_id/subnet_id
+$ terraform import ovh_cloud_network_private_vrack_subnet.subnet project_id/network_id/id
 ```

--- a/ovh/data_cloud_gateway.go
+++ b/ovh/data_cloud_gateway.go
@@ -1,0 +1,208 @@
+package ovh
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	ovhtypes "github.com/ovh/terraform-provider-ovh/v2/ovh/types"
+)
+
+var _ datasource.DataSourceWithConfigure = (*cloudGatewayDataSource)(nil)
+
+func NewCloudGatewayDataSource() datasource.DataSource {
+	return &cloudGatewayDataSource{}
+}
+
+type cloudGatewayDataSource struct {
+	config *Config
+}
+
+func (d *cloudGatewayDataSource) Metadata(ctx context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_cloud_gateway"
+}
+
+func (d *cloudGatewayDataSource) Configure(_ context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+
+	config, ok := req.ProviderData.(*Config)
+	if !ok {
+		resp.Diagnostics.AddError(
+			"Unexpected Data Source Configure Type",
+			fmt.Sprintf("Expected *Config, got: %T. Please report this issue to the provider developers.", req.ProviderData),
+		)
+		return
+	}
+
+	d.config = config
+}
+
+func (d *cloudGatewayDataSource) Schema(ctx context.Context, req datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Description: "Use this data source to retrieve information about a gateway in a public cloud project.",
+		Attributes: map[string]schema.Attribute{
+			"service_name": schema.StringAttribute{
+				CustomType:  ovhtypes.TfStringType{},
+				Required:    true,
+				Description: "Service name of the resource representing the id of the cloud project",
+			},
+			"id": schema.StringAttribute{
+				CustomType:  ovhtypes.TfStringType{},
+				Required:    true,
+				Description: "Gateway ID",
+			},
+			"region": schema.StringAttribute{
+				CustomType:  ovhtypes.TfStringType{},
+				Computed:    true,
+				Description: "Region of the gateway",
+			},
+			"availability_zone": schema.StringAttribute{
+				CustomType:  ovhtypes.TfStringType{},
+				Computed:    true,
+				Description: "Availability zone of the gateway",
+			},
+			"name": schema.StringAttribute{
+				CustomType:  ovhtypes.TfStringType{},
+				Computed:    true,
+				Description: "Gateway name",
+			},
+			"description": schema.StringAttribute{
+				CustomType:  ovhtypes.TfStringType{},
+				Computed:    true,
+				Description: "Gateway description",
+			},
+			"external_gateway": schema.SingleNestedAttribute{
+				Computed:    true,
+				Description: "External gateway configuration",
+				Attributes: map[string]schema.Attribute{
+					"enabled": schema.BoolAttribute{
+						Computed:    true,
+						Description: "Whether the external gateway is enabled",
+					},
+					"model": schema.StringAttribute{
+						CustomType:  ovhtypes.TfStringType{},
+						Computed:    true,
+						Description: "External gateway sizing model",
+					},
+				},
+			},
+			"subnet_ids": schema.ListAttribute{
+				CustomType:  ovhtypes.NewTfListNestedType[ovhtypes.TfStringValue](ctx),
+				Computed:    true,
+				Description: "List of subnet IDs attached as router interfaces",
+			},
+			"checksum": schema.StringAttribute{
+				CustomType:  ovhtypes.TfStringType{},
+				Computed:    true,
+				Description: "Computed hash representing the current target specification value",
+			},
+			"created_at": schema.StringAttribute{
+				CustomType:  ovhtypes.TfStringType{},
+				Computed:    true,
+				Description: "Creation date of the gateway",
+			},
+			"updated_at": schema.StringAttribute{
+				CustomType:  ovhtypes.TfStringType{},
+				Computed:    true,
+				Description: "Last update date of the gateway",
+			},
+			"resource_status": schema.StringAttribute{
+				CustomType:  ovhtypes.TfStringType{},
+				Computed:    true,
+				Description: "Gateway readiness in the system (CREATING, DELETING, ERROR, OUT_OF_SYNC, READY, UPDATING)",
+			},
+			"current_state": schema.SingleNestedAttribute{
+				Computed:    true,
+				Description: "Current state of the gateway",
+				Attributes: map[string]schema.Attribute{
+					"name": schema.StringAttribute{
+						CustomType:  ovhtypes.TfStringType{},
+						Computed:    true,
+						Description: "Gateway name",
+					},
+					"description": schema.StringAttribute{
+						CustomType:  ovhtypes.TfStringType{},
+						Computed:    true,
+						Description: "Gateway description",
+					},
+					"status": schema.StringAttribute{
+						CustomType:  ovhtypes.TfStringType{},
+						Computed:    true,
+						Description: "OpenStack router status (ACTIVE, BUILD, DOWN, ERROR)",
+					},
+					"external_gateway": schema.SingleNestedAttribute{
+						Computed:    true,
+						Description: "External gateway configuration",
+						Attributes: map[string]schema.Attribute{
+							"enabled": schema.BoolAttribute{
+								Computed:    true,
+								Description: "Whether the external gateway is enabled",
+							},
+							"model": schema.StringAttribute{
+								CustomType:  ovhtypes.TfStringType{},
+								Computed:    true,
+								Description: "External gateway sizing model",
+							},
+						},
+					},
+					"external_ip": schema.StringAttribute{
+						CustomType:  ovhtypes.TfStringType{},
+						Computed:    true,
+						Description: "External IP address assigned to the gateway",
+					},
+					"subnets": schema.ListNestedAttribute{
+						Computed:    true,
+						Description: "Currently attached subnets",
+						NestedObject: schema.NestedAttributeObject{
+							Attributes: map[string]schema.Attribute{
+								"id": schema.StringAttribute{
+									CustomType:  ovhtypes.TfStringType{},
+									Computed:    true,
+									Description: "Subnet ID",
+								},
+							},
+						},
+					},
+					"region": schema.StringAttribute{
+						CustomType:  ovhtypes.TfStringType{},
+						Computed:    true,
+						Description: "Region",
+					},
+					"availability_zone": schema.StringAttribute{
+						CustomType:  ovhtypes.TfStringType{},
+						Computed:    true,
+						Description: "Availability zone",
+					},
+				},
+			},
+		},
+	}
+}
+
+func (d *cloudGatewayDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+	var data CloudGatewayModel
+
+	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	endpoint := "/v2/publicCloud/project/" + url.PathEscape(data.ServiceName.ValueString()) + "/gateway/" + url.PathEscape(data.Id.ValueString())
+
+	var responseData CloudGatewayAPIResponse
+	if err := d.config.OVHClient.Get(endpoint, &responseData); err != nil {
+		resp.Diagnostics.AddError(
+			fmt.Sprintf("Error calling Get %s", endpoint),
+			err.Error(),
+		)
+		return
+	}
+
+	data.MergeWith(ctx, &responseData)
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}

--- a/ovh/data_cloud_gateway_test.go
+++ b/ovh/data_cloud_gateway_test.go
@@ -1,0 +1,64 @@
+package ovh
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+func TestAccDataSourceCloudGateway_basic(t *testing.T) {
+	serviceName := os.Getenv("OVH_CLOUD_PROJECT_SERVICE_TEST")
+	region := os.Getenv("OVH_CLOUD_PROJECT_REGION_TEST")
+	gatewayModel := os.Getenv("OVH_CLOUD_GATEWAY_MODEL_TEST")
+	if gatewayModel == "" {
+		gatewayModel = "S"
+	}
+
+	gatewayName := acctest.RandomWithPrefix(testAccResourceCloudGatewayNamePrefix)
+
+	config := fmt.Sprintf(`
+resource "ovh_cloud_gateway" "test" {
+  service_name = "%s"
+  name         = "%s"
+  region       = "%s"
+
+  external_gateway = {
+    enabled = true
+    model   = "%s"
+  }
+}
+
+data "ovh_cloud_gateway" "test" {
+  service_name = ovh_cloud_gateway.test.service_name
+  id           = ovh_cloud_gateway.test.id
+}
+`, serviceName, gatewayName, region, gatewayModel)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheckCloudGateway(t)
+		},
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("data.ovh_cloud_gateway.test", "service_name", serviceName),
+					resource.TestCheckResourceAttr("data.ovh_cloud_gateway.test", "name", gatewayName),
+					resource.TestCheckResourceAttr("data.ovh_cloud_gateway.test", "region", region),
+					resource.TestCheckResourceAttr("data.ovh_cloud_gateway.test", "external_gateway.enabled", "true"),
+					resource.TestCheckResourceAttr("data.ovh_cloud_gateway.test", "external_gateway.model", gatewayModel),
+					resource.TestCheckResourceAttrSet("data.ovh_cloud_gateway.test", "id"),
+					resource.TestCheckResourceAttrSet("data.ovh_cloud_gateway.test", "checksum"),
+					resource.TestCheckResourceAttrSet("data.ovh_cloud_gateway.test", "created_at"),
+					resource.TestCheckResourceAttr("data.ovh_cloud_gateway.test", "resource_status", "READY"),
+					resource.TestCheckResourceAttrSet("data.ovh_cloud_gateway.test", "current_state.name"),
+					resource.TestCheckResourceAttrSet("data.ovh_cloud_gateway.test", "current_state.status"),
+				),
+			},
+		},
+	})
+}

--- a/ovh/data_cloud_gateways.go
+++ b/ovh/data_cloud_gateways.go
@@ -1,0 +1,299 @@
+package ovh
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
+	ovhtypes "github.com/ovh/terraform-provider-ovh/v2/ovh/types"
+)
+
+var _ datasource.DataSourceWithConfigure = (*cloudGatewaysDataSource)(nil)
+
+func NewCloudGatewaysDataSource() datasource.DataSource {
+	return &cloudGatewaysDataSource{}
+}
+
+type cloudGatewaysDataSource struct {
+	config *Config
+}
+
+// CloudGatewaysModel is the model for the plural gateways data source.
+type CloudGatewaysModel struct {
+	ServiceName ovhtypes.TfStringValue `tfsdk:"service_name"`
+	Gateways    types.List             `tfsdk:"gateways"`
+}
+
+func (d *cloudGatewaysDataSource) Metadata(ctx context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_cloud_gateways"
+}
+
+func (d *cloudGatewaysDataSource) Configure(_ context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+
+	config, ok := req.ProviderData.(*Config)
+	if !ok {
+		resp.Diagnostics.AddError(
+			"Unexpected Data Source Configure Type",
+			fmt.Sprintf("Expected *Config, got: %T. Please report this issue to the provider developers.", req.ProviderData),
+		)
+		return
+	}
+
+	d.config = config
+}
+
+// GatewayListItemAttrTypes returns the attribute types for a single gateway
+// element of the plural data source list.
+func GatewayListItemAttrTypes() map[string]attr.Type {
+	return map[string]attr.Type{
+		"id":          ovhtypes.TfStringType{},
+		"name":        ovhtypes.TfStringType{},
+		"description": ovhtypes.TfStringType{},
+		"region":      ovhtypes.TfStringType{},
+		"external_gateway": types.ObjectType{
+			AttrTypes: ExternalGatewayAttrTypes(),
+		},
+		"checksum":        ovhtypes.TfStringType{},
+		"created_at":      ovhtypes.TfStringType{},
+		"updated_at":      ovhtypes.TfStringType{},
+		"resource_status": ovhtypes.TfStringType{},
+		"current_state": types.ObjectType{
+			AttrTypes: GatewayCurrentStateAttrTypes(),
+		},
+	}
+}
+
+func (d *cloudGatewaysDataSource) Schema(ctx context.Context, req datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Description: "Use this data source to list the gateways of a public cloud project.",
+		Attributes: map[string]schema.Attribute{
+			"service_name": schema.StringAttribute{
+				CustomType:  ovhtypes.TfStringType{},
+				Required:    true,
+				Description: "Service name of the resource representing the id of the cloud project",
+			},
+			"gateways": schema.ListNestedAttribute{
+				Computed:    true,
+				Description: "List of gateways",
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]schema.Attribute{
+						"id": schema.StringAttribute{
+							CustomType:  ovhtypes.TfStringType{},
+							Computed:    true,
+							Description: "Gateway ID",
+						},
+						"name": schema.StringAttribute{
+							CustomType:  ovhtypes.TfStringType{},
+							Computed:    true,
+							Description: "Gateway name",
+						},
+						"description": schema.StringAttribute{
+							CustomType:  ovhtypes.TfStringType{},
+							Computed:    true,
+							Description: "Gateway description",
+						},
+						"region": schema.StringAttribute{
+							CustomType:  ovhtypes.TfStringType{},
+							Computed:    true,
+							Description: "Region of the gateway",
+						},
+						"external_gateway": schema.SingleNestedAttribute{
+							Computed:    true,
+							Description: "External gateway configuration",
+							Attributes: map[string]schema.Attribute{
+								"enabled": schema.BoolAttribute{
+									Computed:    true,
+									Description: "Whether the external gateway is enabled",
+								},
+								"model": schema.StringAttribute{
+									CustomType:  ovhtypes.TfStringType{},
+									Computed:    true,
+									Description: "External gateway sizing model",
+								},
+							},
+						},
+						"checksum": schema.StringAttribute{
+							CustomType:  ovhtypes.TfStringType{},
+							Computed:    true,
+							Description: "Computed hash representing the current target specification value",
+						},
+						"created_at": schema.StringAttribute{
+							CustomType:  ovhtypes.TfStringType{},
+							Computed:    true,
+							Description: "Creation date of the gateway",
+						},
+						"updated_at": schema.StringAttribute{
+							CustomType:  ovhtypes.TfStringType{},
+							Computed:    true,
+							Description: "Last update date of the gateway",
+						},
+						"resource_status": schema.StringAttribute{
+							CustomType:  ovhtypes.TfStringType{},
+							Computed:    true,
+							Description: "Gateway readiness in the system (CREATING, DELETING, ERROR, OUT_OF_SYNC, READY, UPDATING)",
+						},
+						"current_state": schema.SingleNestedAttribute{
+							Computed:    true,
+							Description: "Current state of the gateway",
+							Attributes: map[string]schema.Attribute{
+								"name": schema.StringAttribute{
+									CustomType:  ovhtypes.TfStringType{},
+									Computed:    true,
+									Description: "Gateway name",
+								},
+								"description": schema.StringAttribute{
+									CustomType:  ovhtypes.TfStringType{},
+									Computed:    true,
+									Description: "Gateway description",
+								},
+								"status": schema.StringAttribute{
+									CustomType:  ovhtypes.TfStringType{},
+									Computed:    true,
+									Description: "OpenStack router status (ACTIVE, BUILD, DOWN, ERROR)",
+								},
+								"external_gateway": schema.SingleNestedAttribute{
+									Computed:    true,
+									Description: "External gateway configuration",
+									Attributes: map[string]schema.Attribute{
+										"enabled": schema.BoolAttribute{
+											Computed:    true,
+											Description: "Whether the external gateway is enabled",
+										},
+										"model": schema.StringAttribute{
+											CustomType:  ovhtypes.TfStringType{},
+											Computed:    true,
+											Description: "External gateway sizing model",
+										},
+									},
+								},
+								"external_ip": schema.StringAttribute{
+									CustomType:  ovhtypes.TfStringType{},
+									Computed:    true,
+									Description: "External IP address assigned to the gateway",
+								},
+								"subnets": schema.ListNestedAttribute{
+									Computed:    true,
+									Description: "Currently attached subnets",
+									NestedObject: schema.NestedAttributeObject{
+										Attributes: map[string]schema.Attribute{
+											"id": schema.StringAttribute{
+												CustomType:  ovhtypes.TfStringType{},
+												Computed:    true,
+												Description: "Subnet ID",
+											},
+										},
+									},
+								},
+								"region": schema.StringAttribute{
+									CustomType:  ovhtypes.TfStringType{},
+									Computed:    true,
+									Description: "Region",
+								},
+								"availability_zone": schema.StringAttribute{
+									CustomType:  ovhtypes.TfStringType{},
+									Computed:    true,
+									Description: "Availability zone",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func (d *cloudGatewaysDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+	var data CloudGatewaysModel
+
+	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	endpoint := "/v2/publicCloud/project/" + url.PathEscape(data.ServiceName.ValueString()) + "/gateway"
+
+	var responseData []CloudGatewayAPIResponse
+	if err := d.config.OVHClient.Get(endpoint, &responseData); err != nil {
+		resp.Diagnostics.AddError(
+			fmt.Sprintf("Error calling Get %s", endpoint),
+			err.Error(),
+		)
+		return
+	}
+
+	itemObjType := types.ObjectType{AttrTypes: GatewayListItemAttrTypes()}
+	items := make([]attr.Value, 0, len(responseData))
+	for i := range responseData {
+		items = append(items, buildGatewayListItemObject(ctx, &responseData[i]))
+	}
+
+	data.Gateways = types.ListValueMust(itemObjType, items)
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+// buildGatewayListItemObject builds a single gateway list element from an API
+// response, reusing the resource helpers for nested objects.
+func buildGatewayListItemObject(ctx context.Context, response *CloudGatewayAPIResponse) basetypes.ObjectValue {
+	nameVal := ovhtypes.TfStringValue{StringValue: types.StringNull()}
+	descVal := ovhtypes.TfStringValue{StringValue: types.StringNull()}
+	regionVal := ovhtypes.TfStringValue{StringValue: types.StringNull()}
+	externalGatewayVal := types.ObjectNull(ExternalGatewayAttrTypes())
+
+	if response.TargetSpec != nil {
+		nameVal = ovhtypes.TfStringValue{StringValue: types.StringValue(response.TargetSpec.Name)}
+		descVal = ovhtypes.TfStringValue{StringValue: types.StringValue(response.TargetSpec.Description)}
+
+		if response.TargetSpec.Location != nil {
+			regionVal = ovhtypes.TfStringValue{StringValue: types.StringValue(response.TargetSpec.Location.Region)}
+		}
+
+		if response.TargetSpec.ExternalGateway != nil {
+			modelVal := ovhtypes.TfStringValue{StringValue: types.StringNull()}
+			if response.TargetSpec.ExternalGateway.Model != "" {
+				modelVal = ovhtypes.TfStringValue{StringValue: types.StringValue(response.TargetSpec.ExternalGateway.Model)}
+			}
+			externalGatewayVal, _ = types.ObjectValue(
+				ExternalGatewayAttrTypes(),
+				map[string]attr.Value{
+					"enabled": types.BoolValue(response.TargetSpec.ExternalGateway.Enabled),
+					"model":   modelVal,
+				},
+			)
+		}
+	}
+
+	var currentStateVal attr.Value
+	if response.CurrentState != nil {
+		currentStateVal = buildGatewayCurrentStateObject(ctx, response.CurrentState)
+	} else {
+		currentStateVal = types.ObjectNull(GatewayCurrentStateAttrTypes())
+	}
+
+	obj, _ := types.ObjectValue(
+		GatewayListItemAttrTypes(),
+		map[string]attr.Value{
+			"id":               ovhtypes.TfStringValue{StringValue: types.StringValue(response.Id)},
+			"name":             nameVal,
+			"description":      descVal,
+			"region":           regionVal,
+			"external_gateway": externalGatewayVal,
+			"checksum":         ovhtypes.TfStringValue{StringValue: types.StringValue(response.Checksum)},
+			"created_at":       ovhtypes.TfStringValue{StringValue: types.StringValue(response.CreatedAt)},
+			"updated_at":       ovhtypes.TfStringValue{StringValue: types.StringValue(response.UpdatedAt)},
+			"resource_status":  ovhtypes.TfStringValue{StringValue: types.StringValue(response.ResourceStatus)},
+			"current_state":    currentStateVal,
+		},
+	)
+
+	return obj
+}

--- a/ovh/data_cloud_gateways_test.go
+++ b/ovh/data_cloud_gateways_test.go
@@ -1,0 +1,54 @@
+package ovh
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+func TestAccDataSourceCloudGateways_basic(t *testing.T) {
+	serviceName := os.Getenv("OVH_CLOUD_PROJECT_SERVICE_TEST")
+	region := os.Getenv("OVH_CLOUD_PROJECT_REGION_TEST")
+	gatewayModel := os.Getenv("OVH_CLOUD_GATEWAY_MODEL_TEST")
+	if gatewayModel == "" {
+		gatewayModel = "S"
+	}
+
+	gatewayName := acctest.RandomWithPrefix(testAccResourceCloudGatewayNamePrefix)
+
+	config := fmt.Sprintf(`
+resource "ovh_cloud_gateway" "test" {
+  service_name = "%s"
+  name         = "%s"
+  region       = "%s"
+
+  external_gateway = {
+    enabled = true
+    model   = "%s"
+  }
+}
+
+data "ovh_cloud_gateways" "test" {
+  service_name = ovh_cloud_gateway.test.service_name
+}
+`, serviceName, gatewayName, region, gatewayModel)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheckCloudGateway(t)
+		},
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("data.ovh_cloud_gateways.test", "service_name", serviceName),
+					resource.TestCheckResourceAttrSet("data.ovh_cloud_gateways.test", "gateways.#"),
+				),
+			},
+		},
+	})
+}

--- a/ovh/data_cloud_network_private_vrack.go
+++ b/ovh/data_cloud_network_private_vrack.go
@@ -60,10 +60,16 @@ func (d *cloudNetworkPrivateVrackDataSource) Schema(ctx context.Context, req dat
 				Computed:    true,
 				Description: "Network name",
 			},
-			"region": schema.StringAttribute{
-				CustomType:  ovhtypes.TfStringType{},
+			"location": schema.SingleNestedAttribute{
 				Computed:    true,
-				Description: "Region of the network",
+				Description: "Location of the network",
+				Attributes: map[string]schema.Attribute{
+					"region": schema.StringAttribute{
+						CustomType:  ovhtypes.TfStringType{},
+						Computed:    true,
+						Description: "Region of the network",
+					},
+				},
 			},
 			"description": schema.StringAttribute{
 				CustomType:  ovhtypes.TfStringType{},

--- a/ovh/data_cloud_network_private_vrack.go
+++ b/ovh/data_cloud_network_private_vrack.go
@@ -1,0 +1,146 @@
+package ovh
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	ovhtypes "github.com/ovh/terraform-provider-ovh/v2/ovh/types"
+)
+
+var _ datasource.DataSourceWithConfigure = (*cloudNetworkPrivateVrackDataSource)(nil)
+
+func NewCloudNetworkPrivateVrackDataSource() datasource.DataSource {
+	return &cloudNetworkPrivateVrackDataSource{}
+}
+
+type cloudNetworkPrivateVrackDataSource struct {
+	config *Config
+}
+
+func (d *cloudNetworkPrivateVrackDataSource) Metadata(ctx context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_cloud_network_private_vrack"
+}
+
+func (d *cloudNetworkPrivateVrackDataSource) Configure(_ context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+
+	config, ok := req.ProviderData.(*Config)
+	if !ok {
+		resp.Diagnostics.AddError(
+			"Unexpected Data Source Configure Type",
+			fmt.Sprintf("Expected *Config, got: %T. Please report this issue to the provider developers.", req.ProviderData),
+		)
+		return
+	}
+
+	d.config = config
+}
+
+func (d *cloudNetworkPrivateVrackDataSource) Schema(ctx context.Context, req datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Description: "Use this data source to retrieve information about a private network (vRack) in a public cloud project.",
+		Attributes: map[string]schema.Attribute{
+			"service_name": schema.StringAttribute{
+				CustomType:  ovhtypes.TfStringType{},
+				Required:    true,
+				Description: "Service name of the resource representing the id of the cloud project",
+			},
+			"id": schema.StringAttribute{
+				CustomType:  ovhtypes.TfStringType{},
+				Required:    true,
+				Description: "Network ID",
+			},
+			"name": schema.StringAttribute{
+				CustomType:  ovhtypes.TfStringType{},
+				Computed:    true,
+				Description: "Network name",
+			},
+			"region": schema.StringAttribute{
+				CustomType:  ovhtypes.TfStringType{},
+				Computed:    true,
+				Description: "Region of the network",
+			},
+			"description": schema.StringAttribute{
+				CustomType:  ovhtypes.TfStringType{},
+				Computed:    true,
+				Description: "Network description",
+			},
+			"checksum": schema.StringAttribute{
+				CustomType:  ovhtypes.TfStringType{},
+				Computed:    true,
+				Description: "Computed hash representing the current target specification value",
+			},
+			"created_at": schema.StringAttribute{
+				CustomType:  ovhtypes.TfStringType{},
+				Computed:    true,
+				Description: "Creation date of the network",
+			},
+			"updated_at": schema.StringAttribute{
+				CustomType:  ovhtypes.TfStringType{},
+				Computed:    true,
+				Description: "Last update date of the network",
+			},
+			"resource_status": schema.StringAttribute{
+				CustomType:  ovhtypes.TfStringType{},
+				Computed:    true,
+				Description: "Network readiness in the system (CREATING, DELETING, ERROR, OUT_OF_SYNC, READY, UPDATING)",
+			},
+			"current_state": schema.SingleNestedAttribute{
+				Computed:    true,
+				Description: "Current state of the network",
+				Attributes: map[string]schema.Attribute{
+					"name": schema.StringAttribute{
+						CustomType:  ovhtypes.TfStringType{},
+						Computed:    true,
+						Description: "Network name",
+					},
+					"description": schema.StringAttribute{
+						CustomType:  ovhtypes.TfStringType{},
+						Computed:    true,
+						Description: "Network description",
+					},
+					"location": schema.SingleNestedAttribute{
+						Computed:    true,
+						Description: "Location details",
+						Attributes: map[string]schema.Attribute{
+							"region": schema.StringAttribute{
+								CustomType:  ovhtypes.TfStringType{},
+								Computed:    true,
+								Description: "Region code",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func (d *cloudNetworkPrivateVrackDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+	var data CloudNetworkPrivateVrackModel
+
+	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	endpoint := "/v2/publicCloud/project/" + url.PathEscape(data.ServiceName.ValueString()) + "/network/" + url.PathEscape(data.Id.ValueString())
+
+	var responseData CloudNetworkAPIResponse
+	if err := d.config.OVHClient.Get(endpoint, &responseData); err != nil {
+		resp.Diagnostics.AddError(
+			fmt.Sprintf("Error calling Get %s", endpoint),
+			err.Error(),
+		)
+		return
+	}
+
+	data.MergeWith(ctx, &responseData)
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}

--- a/ovh/data_cloud_network_private_vrack.go
+++ b/ovh/data_cloud_network_private_vrack.go
@@ -76,6 +76,11 @@ func (d *cloudNetworkPrivateVrackDataSource) Schema(ctx context.Context, req dat
 				Computed:    true,
 				Description: "Network description",
 			},
+			"vlan_id": schema.Int64Attribute{
+				CustomType:  ovhtypes.TfInt64Type{},
+				Computed:    true,
+				Description: "VLAN ID of the network",
+			},
 			"checksum": schema.StringAttribute{
 				CustomType:  ovhtypes.TfStringType{},
 				Computed:    true,
@@ -109,6 +114,11 @@ func (d *cloudNetworkPrivateVrackDataSource) Schema(ctx context.Context, req dat
 						CustomType:  ovhtypes.TfStringType{},
 						Computed:    true,
 						Description: "Network description",
+					},
+					"vlan_id": schema.Int64Attribute{
+						CustomType:  ovhtypes.TfInt64Type{},
+						Computed:    true,
+						Description: "VLAN ID of the network",
 					},
 					"location": schema.SingleNestedAttribute{
 						Computed:    true,

--- a/ovh/data_cloud_network_private_vrack_subnet.go
+++ b/ovh/data_cloud_network_private_vrack_subnet.go
@@ -71,10 +71,16 @@ func (d *cloudNetworkPrivateVrackSubnetDataSource) Schema(ctx context.Context, r
 				Computed:    true,
 				Description: "CIDR address range for the subnet",
 			},
-			"region": schema.StringAttribute{
-				CustomType:  ovhtypes.TfStringType{},
+			"location": schema.SingleNestedAttribute{
 				Computed:    true,
-				Description: "Region of the subnet",
+				Description: "Location details",
+				Attributes: map[string]schema.Attribute{
+					"region": schema.StringAttribute{
+						CustomType:  ovhtypes.TfStringType{},
+						Computed:    true,
+						Description: "Region code",
+					},
+				},
 			},
 			"description": schema.StringAttribute{
 				CustomType:  ovhtypes.TfStringType{},
@@ -165,6 +171,24 @@ func (d *cloudNetworkPrivateVrackSubnetDataSource) Schema(ctx context.Context, r
 						CustomType:  ovhtypes.TfStringType{},
 						Computed:    true,
 						Description: "Default gateway IP address",
+					},
+					"allocation_pools": schema.ListNestedAttribute{
+						Computed:    true,
+						Description: "IP address allocation pools",
+						NestedObject: schema.NestedAttributeObject{
+							Attributes: map[string]schema.Attribute{
+								"start": schema.StringAttribute{
+									CustomType:  ovhtypes.TfStringType{},
+									Computed:    true,
+									Description: "Start IP address of the pool",
+								},
+								"end": schema.StringAttribute{
+									CustomType:  ovhtypes.TfStringType{},
+									Computed:    true,
+									Description: "End IP address of the pool",
+								},
+							},
+						},
 					},
 					"host_routes": schema.ListNestedAttribute{
 						Computed:    true,

--- a/ovh/data_cloud_network_private_vrack_subnet.go
+++ b/ovh/data_cloud_network_private_vrack_subnet.go
@@ -1,0 +1,226 @@
+package ovh
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	ovhtypes "github.com/ovh/terraform-provider-ovh/v2/ovh/types"
+)
+
+var _ datasource.DataSourceWithConfigure = (*cloudNetworkPrivateVrackSubnetDataSource)(nil)
+
+func NewCloudNetworkPrivateVrackSubnetDataSource() datasource.DataSource {
+	return &cloudNetworkPrivateVrackSubnetDataSource{}
+}
+
+type cloudNetworkPrivateVrackSubnetDataSource struct {
+	config *Config
+}
+
+func (d *cloudNetworkPrivateVrackSubnetDataSource) Metadata(ctx context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_cloud_network_private_vrack_subnet"
+}
+
+func (d *cloudNetworkPrivateVrackSubnetDataSource) Configure(_ context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+
+	config, ok := req.ProviderData.(*Config)
+	if !ok {
+		resp.Diagnostics.AddError(
+			"Unexpected Data Source Configure Type",
+			fmt.Sprintf("Expected *Config, got: %T. Please report this issue to the provider developers.", req.ProviderData),
+		)
+		return
+	}
+
+	d.config = config
+}
+
+func (d *cloudNetworkPrivateVrackSubnetDataSource) Schema(ctx context.Context, req datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Description: "Use this data source to retrieve information about a subnet in a private network (vRack) of a public cloud project.",
+		Attributes: map[string]schema.Attribute{
+			"service_name": schema.StringAttribute{
+				CustomType:  ovhtypes.TfStringType{},
+				Required:    true,
+				Description: "Service name of the resource representing the id of the cloud project",
+			},
+			"network_id": schema.StringAttribute{
+				CustomType:  ovhtypes.TfStringType{},
+				Required:    true,
+				Description: "Network ID of the parent private network",
+			},
+			"id": schema.StringAttribute{
+				CustomType:  ovhtypes.TfStringType{},
+				Required:    true,
+				Description: "Subnet ID",
+			},
+			"name": schema.StringAttribute{
+				CustomType:  ovhtypes.TfStringType{},
+				Computed:    true,
+				Description: "Subnet name",
+			},
+			"cidr": schema.StringAttribute{
+				CustomType:  ovhtypes.TfStringType{},
+				Computed:    true,
+				Description: "CIDR address range for the subnet",
+			},
+			"region": schema.StringAttribute{
+				CustomType:  ovhtypes.TfStringType{},
+				Computed:    true,
+				Description: "Region of the subnet",
+			},
+			"description": schema.StringAttribute{
+				CustomType:  ovhtypes.TfStringType{},
+				Computed:    true,
+				Description: "Subnet description",
+			},
+			"dhcp_enabled": schema.BoolAttribute{
+				Computed:    true,
+				Description: "Whether DHCP is enabled on the subnet",
+			},
+			"dns_nameservers": schema.ListAttribute{
+				ElementType: types.StringType,
+				Computed:    true,
+				Description: "DNS nameservers for the subnet",
+			},
+			"gateway_ip": schema.StringAttribute{
+				CustomType:  ovhtypes.TfStringType{},
+				Computed:    true,
+				Description: "Default gateway IP address",
+			},
+			"allocation_pools": schema.ListNestedAttribute{
+				Computed:    true,
+				Description: "IP address allocation pools",
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]schema.Attribute{
+						"start": schema.StringAttribute{
+							CustomType:  ovhtypes.TfStringType{},
+							Computed:    true,
+							Description: "Start IP address of the pool",
+						},
+						"end": schema.StringAttribute{
+							CustomType:  ovhtypes.TfStringType{},
+							Computed:    true,
+							Description: "End IP address of the pool",
+						},
+					},
+				},
+			},
+			"checksum": schema.StringAttribute{
+				CustomType:  ovhtypes.TfStringType{},
+				Computed:    true,
+				Description: "Computed hash representing the current target specification value",
+			},
+			"created_at": schema.StringAttribute{
+				CustomType:  ovhtypes.TfStringType{},
+				Computed:    true,
+				Description: "Creation date of the subnet",
+			},
+			"updated_at": schema.StringAttribute{
+				CustomType:  ovhtypes.TfStringType{},
+				Computed:    true,
+				Description: "Last update date of the subnet",
+			},
+			"resource_status": schema.StringAttribute{
+				CustomType:  ovhtypes.TfStringType{},
+				Computed:    true,
+				Description: "Subnet readiness in the system (CREATING, DELETING, ERROR, OUT_OF_SYNC, READY, UPDATING)",
+			},
+			"current_state": schema.SingleNestedAttribute{
+				Computed:    true,
+				Description: "Current state of the subnet",
+				Attributes: map[string]schema.Attribute{
+					"name": schema.StringAttribute{
+						CustomType:  ovhtypes.TfStringType{},
+						Computed:    true,
+						Description: "Subnet name",
+					},
+					"cidr": schema.StringAttribute{
+						CustomType:  ovhtypes.TfStringType{},
+						Computed:    true,
+						Description: "CIDR address range",
+					},
+					"description": schema.StringAttribute{
+						CustomType:  ovhtypes.TfStringType{},
+						Computed:    true,
+						Description: "Subnet description",
+					},
+					"dhcp_enabled": schema.BoolAttribute{
+						Computed:    true,
+						Description: "Whether DHCP is enabled",
+					},
+					"dns_nameservers": schema.ListAttribute{
+						ElementType: types.StringType,
+						Computed:    true,
+						Description: "DNS nameservers",
+					},
+					"gateway_ip": schema.StringAttribute{
+						CustomType:  ovhtypes.TfStringType{},
+						Computed:    true,
+						Description: "Default gateway IP address",
+					},
+					"host_routes": schema.ListNestedAttribute{
+						Computed:    true,
+						Description: "Static host routes",
+						NestedObject: schema.NestedAttributeObject{
+							Attributes: map[string]schema.Attribute{
+								"destination": schema.StringAttribute{
+									CustomType:  ovhtypes.TfStringType{},
+									Computed:    true,
+									Description: "Destination CIDR",
+								},
+								"next_hop": schema.StringAttribute{
+									CustomType:  ovhtypes.TfStringType{},
+									Computed:    true,
+									Description: "Next hop IP address",
+								},
+							},
+						},
+					},
+					"location": schema.SingleNestedAttribute{
+						Computed:    true,
+						Description: "Location details",
+						Attributes: map[string]schema.Attribute{
+							"region": schema.StringAttribute{
+								CustomType:  ovhtypes.TfStringType{},
+								Computed:    true,
+								Description: "Region code",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func (d *cloudNetworkPrivateVrackSubnetDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+	var data CloudSubnetModel
+
+	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	endpoint := "/v2/publicCloud/project/" + url.PathEscape(data.ServiceName.ValueString()) + "/network/" + url.PathEscape(data.NetworkId.ValueString()) + "/subnet/" + url.PathEscape(data.Id.ValueString())
+
+	var responseData CloudSubnetAPIResponse
+	if err := d.config.OVHClient.Get(endpoint, &responseData); err != nil {
+		resp.Diagnostics.AddError(
+			fmt.Sprintf("Error calling Get %s", endpoint),
+			err.Error(),
+		)
+		return
+	}
+
+	data.MergeWith(ctx, &responseData)
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}

--- a/ovh/data_cloud_network_private_vrack_subnet_test.go
+++ b/ovh/data_cloud_network_private_vrack_subnet_test.go
@@ -26,7 +26,7 @@ resource "ovh_cloud_network_private_vrack" "network" {
 }
 
 resource "ovh_cloud_network_private_vrack_subnet" "test" {
-  project_id   = ovh_cloud_network_private_vrack.network.service_name
+  service_name = ovh_cloud_network_private_vrack.network.service_name
   network_id   = ovh_cloud_network_private_vrack.network.id
   name         = "%s"
   cidr         = "10.0.0.0/24"
@@ -37,7 +37,7 @@ resource "ovh_cloud_network_private_vrack_subnet" "test" {
 }
 
 data "ovh_cloud_network_private_vrack_subnet" "test" {
-  service_name = ovh_cloud_network_private_vrack_subnet.test.project_id
+  service_name = ovh_cloud_network_private_vrack_subnet.test.service_name
   network_id   = ovh_cloud_network_private_vrack_subnet.test.network_id
   id           = ovh_cloud_network_private_vrack_subnet.test.id
 }

--- a/ovh/data_cloud_network_private_vrack_subnet_test.go
+++ b/ovh/data_cloud_network_private_vrack_subnet_test.go
@@ -1,0 +1,68 @@
+package ovh
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+func TestAccDataSourceCloudNetworkPrivateVrackSubnet_basic(t *testing.T) {
+	serviceName := os.Getenv("OVH_CLOUD_PROJECT_SERVICE_TEST")
+	region := os.Getenv("OVH_CLOUD_PROJECT_REGION_TEST")
+
+	networkName := acctest.RandomWithPrefix(testAccResourceCloudNetworkPrivateVrackNamePrefix)
+	subnetName := acctest.RandomWithPrefix(testAccResourceCloudNetworkPrivateVrackSubnetNamePrefix)
+
+	config := fmt.Sprintf(`
+resource "ovh_cloud_network_private_vrack" "network" {
+  service_name = "%s"
+  name         = "%s"
+  region       = "%s"
+}
+
+resource "ovh_cloud_network_private_vrack_subnet" "test" {
+  service_name = ovh_cloud_network_private_vrack.network.service_name
+  network_id   = ovh_cloud_network_private_vrack.network.id
+  name         = "%s"
+  cidr         = "10.0.0.0/24"
+  region       = "%s"
+  dhcp_enabled = true
+}
+
+data "ovh_cloud_network_private_vrack_subnet" "test" {
+  service_name = ovh_cloud_network_private_vrack_subnet.test.service_name
+  network_id   = ovh_cloud_network_private_vrack_subnet.test.network_id
+  id           = ovh_cloud_network_private_vrack_subnet.test.id
+}
+`, serviceName, networkName, region, subnetName, region)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheckCloudNetworkPrivateVrackSubnet(t)
+		},
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("data.ovh_cloud_network_private_vrack_subnet.test", "service_name", serviceName),
+					resource.TestCheckResourceAttr("data.ovh_cloud_network_private_vrack_subnet.test", "name", subnetName),
+					resource.TestCheckResourceAttr("data.ovh_cloud_network_private_vrack_subnet.test", "cidr", "10.0.0.0/24"),
+					resource.TestCheckResourceAttr("data.ovh_cloud_network_private_vrack_subnet.test", "region", region),
+					resource.TestCheckResourceAttr("data.ovh_cloud_network_private_vrack_subnet.test", "dhcp_enabled", "true"),
+					resource.TestCheckResourceAttrSet("data.ovh_cloud_network_private_vrack_subnet.test", "id"),
+					resource.TestCheckResourceAttrSet("data.ovh_cloud_network_private_vrack_subnet.test", "network_id"),
+					resource.TestCheckResourceAttrSet("data.ovh_cloud_network_private_vrack_subnet.test", "checksum"),
+					resource.TestCheckResourceAttrSet("data.ovh_cloud_network_private_vrack_subnet.test", "created_at"),
+					resource.TestCheckResourceAttr("data.ovh_cloud_network_private_vrack_subnet.test", "resource_status", "READY"),
+					resource.TestCheckResourceAttrSet("data.ovh_cloud_network_private_vrack_subnet.test", "current_state.name"),
+					resource.TestCheckResourceAttrSet("data.ovh_cloud_network_private_vrack_subnet.test", "current_state.cidr"),
+					resource.TestCheckResourceAttrSet("data.ovh_cloud_network_private_vrack_subnet.test", "current_state.location.region"),
+				),
+			},
+		},
+	})
+}

--- a/ovh/data_cloud_network_private_vrack_subnet_test.go
+++ b/ovh/data_cloud_network_private_vrack_subnet_test.go
@@ -14,26 +14,30 @@ func TestAccDataSourceCloudNetworkPrivateVrackSubnet_basic(t *testing.T) {
 	region := os.Getenv("OVH_CLOUD_PROJECT_REGION_TEST")
 
 	networkName := acctest.RandomWithPrefix(testAccResourceCloudNetworkPrivateVrackNamePrefix)
-	subnetName := acctest.RandomWithPrefix(testAccResourceCloudNetworkPrivateVrackSubnetNamePrefix)
+	subnetName := acctest.RandomWithPrefix(testAccResourceCloudNetworkPrivateSubnetNamePrefix)
 
 	config := fmt.Sprintf(`
 resource "ovh_cloud_network_private_vrack" "network" {
   service_name = "%s"
   name         = "%s"
-  region       = "%s"
+  location = {
+	region = "%s"
+  }
 }
 
 resource "ovh_cloud_network_private_vrack_subnet" "test" {
-  service_name = ovh_cloud_network_private_vrack.network.service_name
+  project_id   = ovh_cloud_network_private_vrack.network.service_name
   network_id   = ovh_cloud_network_private_vrack.network.id
   name         = "%s"
   cidr         = "10.0.0.0/24"
-  region       = "%s"
   dhcp_enabled = true
+  location = {
+    region = "%s"
+  }
 }
 
 data "ovh_cloud_network_private_vrack_subnet" "test" {
-  service_name = ovh_cloud_network_private_vrack_subnet.test.service_name
+  service_name = ovh_cloud_network_private_vrack_subnet.test.project_id
   network_id   = ovh_cloud_network_private_vrack_subnet.test.network_id
   id           = ovh_cloud_network_private_vrack_subnet.test.id
 }
@@ -41,7 +45,7 @@ data "ovh_cloud_network_private_vrack_subnet" "test" {
 
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
-			testAccPreCheckCloudNetworkPrivateVrackSubnet(t)
+			testAccPreCheckCloudNetworkPrivateSubnet(t)
 		},
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
@@ -51,7 +55,7 @@ data "ovh_cloud_network_private_vrack_subnet" "test" {
 					resource.TestCheckResourceAttr("data.ovh_cloud_network_private_vrack_subnet.test", "service_name", serviceName),
 					resource.TestCheckResourceAttr("data.ovh_cloud_network_private_vrack_subnet.test", "name", subnetName),
 					resource.TestCheckResourceAttr("data.ovh_cloud_network_private_vrack_subnet.test", "cidr", "10.0.0.0/24"),
-					resource.TestCheckResourceAttr("data.ovh_cloud_network_private_vrack_subnet.test", "region", region),
+					resource.TestCheckResourceAttr("data.ovh_cloud_network_private_vrack_subnet.test", "location.region", region),
 					resource.TestCheckResourceAttr("data.ovh_cloud_network_private_vrack_subnet.test", "dhcp_enabled", "true"),
 					resource.TestCheckResourceAttrSet("data.ovh_cloud_network_private_vrack_subnet.test", "id"),
 					resource.TestCheckResourceAttrSet("data.ovh_cloud_network_private_vrack_subnet.test", "network_id"),

--- a/ovh/data_cloud_network_private_vrack_subnets.go
+++ b/ovh/data_cloud_network_private_vrack_subnets.go
@@ -55,10 +55,12 @@ func (d *cloudNetworkPrivateVrackSubnetsDataSource) Configure(_ context.Context,
 // element of the plural data source list.
 func SubnetListItemAttrTypes() map[string]attr.Type {
 	return map[string]attr.Type{
-		"id":           ovhtypes.TfStringType{},
-		"name":         ovhtypes.TfStringType{},
-		"cidr":         ovhtypes.TfStringType{},
-		"region":       ovhtypes.TfStringType{},
+		"id":   ovhtypes.TfStringType{},
+		"name": ovhtypes.TfStringType{},
+		"cidr": ovhtypes.TfStringType{},
+		"location": types.ObjectType{
+			AttrTypes: subnetDataLocationAttrTypes(),
+		},
 		"description":  ovhtypes.TfStringType{},
 		"dhcp_enabled": types.BoolType,
 		"dns_nameservers": types.ListType{
@@ -114,10 +116,16 @@ func (d *cloudNetworkPrivateVrackSubnetsDataSource) Schema(ctx context.Context, 
 							Computed:    true,
 							Description: "CIDR address range for the subnet",
 						},
-						"region": schema.StringAttribute{
-							CustomType:  ovhtypes.TfStringType{},
+						"location": schema.SingleNestedAttribute{
 							Computed:    true,
-							Description: "Region of the subnet",
+							Description: "Location details",
+							Attributes: map[string]schema.Attribute{
+								"region": schema.StringAttribute{
+									CustomType:  ovhtypes.TfStringType{},
+									Computed:    true,
+									Description: "Region code",
+								},
+							},
 						},
 						"description": schema.StringAttribute{
 							CustomType:  ovhtypes.TfStringType{},
@@ -209,6 +217,24 @@ func (d *cloudNetworkPrivateVrackSubnetsDataSource) Schema(ctx context.Context, 
 									Computed:    true,
 									Description: "Default gateway IP address",
 								},
+								"allocation_pools": schema.ListNestedAttribute{
+									Computed:    true,
+									Description: "IP address allocation pools",
+									NestedObject: schema.NestedAttributeObject{
+										Attributes: map[string]schema.Attribute{
+											"start": schema.StringAttribute{
+												CustomType:  ovhtypes.TfStringType{},
+												Computed:    true,
+												Description: "Start IP address of the pool",
+											},
+											"end": schema.StringAttribute{
+												CustomType:  ovhtypes.TfStringType{},
+												Computed:    true,
+												Description: "End IP address of the pool",
+											},
+										},
+									},
+								},
 								"host_routes": schema.ListNestedAttribute{
 									Computed:    true,
 									Description: "Static host routes",
@@ -282,7 +308,7 @@ func (d *cloudNetworkPrivateVrackSubnetsDataSource) Read(ctx context.Context, re
 func buildSubnetListItemObject(response *CloudSubnetAPIResponse) basetypes.ObjectValue {
 	nameVal := ovhtypes.TfStringValue{StringValue: types.StringNull()}
 	cidrVal := ovhtypes.TfStringValue{StringValue: types.StringNull()}
-	regionVal := ovhtypes.TfStringValue{StringValue: types.StringNull()}
+	locationVal := types.ObjectNull(subnetDataLocationAttrTypes())
 	descVal := ovhtypes.TfStringValue{StringValue: types.StringNull()}
 	gatewayIPVal := ovhtypes.TfStringValue{StringValue: types.StringNull()}
 	dhcpVal := types.BoolNull()
@@ -298,7 +324,12 @@ func buildSubnetListItemObject(response *CloudSubnetAPIResponse) basetypes.Objec
 		gatewayIPVal = ovhtypes.TfStringValue{StringValue: types.StringValue(response.TargetSpec.GatewayIP)}
 
 		if response.TargetSpec.Location != nil {
-			regionVal = ovhtypes.TfStringValue{StringValue: types.StringValue(response.TargetSpec.Location.Region)}
+			locationVal, _ = types.ObjectValue(
+				subnetDataLocationAttrTypes(),
+				map[string]attr.Value{
+					"region": ovhtypes.TfStringValue{StringValue: types.StringValue(response.TargetSpec.Location.Region)},
+				},
+			)
 		}
 
 		if response.TargetSpec.DHCPEnabled != nil {
@@ -342,7 +373,7 @@ func buildSubnetListItemObject(response *CloudSubnetAPIResponse) basetypes.Objec
 			"id":               ovhtypes.TfStringValue{StringValue: types.StringValue(response.Id)},
 			"name":             nameVal,
 			"cidr":             cidrVal,
-			"region":           regionVal,
+			"location":         locationVal,
 			"description":      descVal,
 			"dhcp_enabled":     dhcpVal,
 			"dns_nameservers":  dnsVal,

--- a/ovh/data_cloud_network_private_vrack_subnets.go
+++ b/ovh/data_cloud_network_private_vrack_subnets.go
@@ -1,0 +1,360 @@
+package ovh
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
+	ovhtypes "github.com/ovh/terraform-provider-ovh/v2/ovh/types"
+)
+
+var _ datasource.DataSourceWithConfigure = (*cloudNetworkPrivateVrackSubnetsDataSource)(nil)
+
+func NewCloudNetworkPrivateVrackSubnetsDataSource() datasource.DataSource {
+	return &cloudNetworkPrivateVrackSubnetsDataSource{}
+}
+
+type cloudNetworkPrivateVrackSubnetsDataSource struct {
+	config *Config
+}
+
+// CloudNetworkPrivateVrackSubnetsModel is the model for the plural subnets data source.
+type CloudNetworkPrivateVrackSubnetsModel struct {
+	ServiceName ovhtypes.TfStringValue `tfsdk:"service_name"`
+	NetworkId   ovhtypes.TfStringValue `tfsdk:"network_id"`
+	Subnets     types.List             `tfsdk:"subnets"`
+}
+
+func (d *cloudNetworkPrivateVrackSubnetsDataSource) Metadata(ctx context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_cloud_network_private_vrack_subnets"
+}
+
+func (d *cloudNetworkPrivateVrackSubnetsDataSource) Configure(_ context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+
+	config, ok := req.ProviderData.(*Config)
+	if !ok {
+		resp.Diagnostics.AddError(
+			"Unexpected Data Source Configure Type",
+			fmt.Sprintf("Expected *Config, got: %T. Please report this issue to the provider developers.", req.ProviderData),
+		)
+		return
+	}
+
+	d.config = config
+}
+
+// SubnetListItemAttrTypes returns the attribute types for a single subnet
+// element of the plural data source list.
+func SubnetListItemAttrTypes() map[string]attr.Type {
+	return map[string]attr.Type{
+		"id":           ovhtypes.TfStringType{},
+		"name":         ovhtypes.TfStringType{},
+		"cidr":         ovhtypes.TfStringType{},
+		"region":       ovhtypes.TfStringType{},
+		"description":  ovhtypes.TfStringType{},
+		"dhcp_enabled": types.BoolType,
+		"dns_nameservers": types.ListType{
+			ElemType: types.StringType,
+		},
+		"gateway_ip": ovhtypes.TfStringType{},
+		"allocation_pools": types.ListType{
+			ElemType: types.ObjectType{
+				AttrTypes: subnetAllocationPoolAttrTypes(),
+			},
+		},
+		"checksum":        ovhtypes.TfStringType{},
+		"created_at":      ovhtypes.TfStringType{},
+		"updated_at":      ovhtypes.TfStringType{},
+		"resource_status": ovhtypes.TfStringType{},
+		"current_state": types.ObjectType{
+			AttrTypes: SubnetCurrentStateAttrTypes(),
+		},
+	}
+}
+
+func (d *cloudNetworkPrivateVrackSubnetsDataSource) Schema(ctx context.Context, req datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Description: "Use this data source to list the subnets of a private network (vRack) in a public cloud project.",
+		Attributes: map[string]schema.Attribute{
+			"service_name": schema.StringAttribute{
+				CustomType:  ovhtypes.TfStringType{},
+				Required:    true,
+				Description: "Service name of the resource representing the id of the cloud project",
+			},
+			"network_id": schema.StringAttribute{
+				CustomType:  ovhtypes.TfStringType{},
+				Required:    true,
+				Description: "Network ID of the parent private network",
+			},
+			"subnets": schema.ListNestedAttribute{
+				Computed:    true,
+				Description: "List of subnets",
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]schema.Attribute{
+						"id": schema.StringAttribute{
+							CustomType:  ovhtypes.TfStringType{},
+							Computed:    true,
+							Description: "Subnet ID",
+						},
+						"name": schema.StringAttribute{
+							CustomType:  ovhtypes.TfStringType{},
+							Computed:    true,
+							Description: "Subnet name",
+						},
+						"cidr": schema.StringAttribute{
+							CustomType:  ovhtypes.TfStringType{},
+							Computed:    true,
+							Description: "CIDR address range for the subnet",
+						},
+						"region": schema.StringAttribute{
+							CustomType:  ovhtypes.TfStringType{},
+							Computed:    true,
+							Description: "Region of the subnet",
+						},
+						"description": schema.StringAttribute{
+							CustomType:  ovhtypes.TfStringType{},
+							Computed:    true,
+							Description: "Subnet description",
+						},
+						"dhcp_enabled": schema.BoolAttribute{
+							Computed:    true,
+							Description: "Whether DHCP is enabled on the subnet",
+						},
+						"dns_nameservers": schema.ListAttribute{
+							ElementType: types.StringType,
+							Computed:    true,
+							Description: "DNS nameservers for the subnet",
+						},
+						"gateway_ip": schema.StringAttribute{
+							CustomType:  ovhtypes.TfStringType{},
+							Computed:    true,
+							Description: "Default gateway IP address",
+						},
+						"allocation_pools": schema.ListNestedAttribute{
+							Computed:    true,
+							Description: "IP address allocation pools",
+							NestedObject: schema.NestedAttributeObject{
+								Attributes: map[string]schema.Attribute{
+									"start": schema.StringAttribute{
+										CustomType:  ovhtypes.TfStringType{},
+										Computed:    true,
+										Description: "Start IP address of the pool",
+									},
+									"end": schema.StringAttribute{
+										CustomType:  ovhtypes.TfStringType{},
+										Computed:    true,
+										Description: "End IP address of the pool",
+									},
+								},
+							},
+						},
+						"checksum": schema.StringAttribute{
+							CustomType:  ovhtypes.TfStringType{},
+							Computed:    true,
+							Description: "Computed hash representing the current target specification value",
+						},
+						"created_at": schema.StringAttribute{
+							CustomType:  ovhtypes.TfStringType{},
+							Computed:    true,
+							Description: "Creation date of the subnet",
+						},
+						"updated_at": schema.StringAttribute{
+							CustomType:  ovhtypes.TfStringType{},
+							Computed:    true,
+							Description: "Last update date of the subnet",
+						},
+						"resource_status": schema.StringAttribute{
+							CustomType:  ovhtypes.TfStringType{},
+							Computed:    true,
+							Description: "Subnet readiness in the system (CREATING, DELETING, ERROR, OUT_OF_SYNC, READY, UPDATING)",
+						},
+						"current_state": schema.SingleNestedAttribute{
+							Computed:    true,
+							Description: "Current state of the subnet",
+							Attributes: map[string]schema.Attribute{
+								"name": schema.StringAttribute{
+									CustomType:  ovhtypes.TfStringType{},
+									Computed:    true,
+									Description: "Subnet name",
+								},
+								"cidr": schema.StringAttribute{
+									CustomType:  ovhtypes.TfStringType{},
+									Computed:    true,
+									Description: "CIDR address range",
+								},
+								"description": schema.StringAttribute{
+									CustomType:  ovhtypes.TfStringType{},
+									Computed:    true,
+									Description: "Subnet description",
+								},
+								"dhcp_enabled": schema.BoolAttribute{
+									Computed:    true,
+									Description: "Whether DHCP is enabled",
+								},
+								"dns_nameservers": schema.ListAttribute{
+									ElementType: types.StringType,
+									Computed:    true,
+									Description: "DNS nameservers",
+								},
+								"gateway_ip": schema.StringAttribute{
+									CustomType:  ovhtypes.TfStringType{},
+									Computed:    true,
+									Description: "Default gateway IP address",
+								},
+								"host_routes": schema.ListNestedAttribute{
+									Computed:    true,
+									Description: "Static host routes",
+									NestedObject: schema.NestedAttributeObject{
+										Attributes: map[string]schema.Attribute{
+											"destination": schema.StringAttribute{
+												CustomType:  ovhtypes.TfStringType{},
+												Computed:    true,
+												Description: "Destination CIDR",
+											},
+											"next_hop": schema.StringAttribute{
+												CustomType:  ovhtypes.TfStringType{},
+												Computed:    true,
+												Description: "Next hop IP address",
+											},
+										},
+									},
+								},
+								"location": schema.SingleNestedAttribute{
+									Computed:    true,
+									Description: "Location details",
+									Attributes: map[string]schema.Attribute{
+										"region": schema.StringAttribute{
+											CustomType:  ovhtypes.TfStringType{},
+											Computed:    true,
+											Description: "Region code",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func (d *cloudNetworkPrivateVrackSubnetsDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+	var data CloudNetworkPrivateVrackSubnetsModel
+
+	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	endpoint := "/v2/publicCloud/project/" + url.PathEscape(data.ServiceName.ValueString()) + "/network/" + url.PathEscape(data.NetworkId.ValueString()) + "/subnet"
+
+	var responseData []CloudSubnetAPIResponse
+	if err := d.config.OVHClient.Get(endpoint, &responseData); err != nil {
+		resp.Diagnostics.AddError(
+			fmt.Sprintf("Error calling Get %s", endpoint),
+			err.Error(),
+		)
+		return
+	}
+
+	itemObjType := types.ObjectType{AttrTypes: SubnetListItemAttrTypes()}
+	items := make([]attr.Value, 0, len(responseData))
+	for i := range responseData {
+		items = append(items, buildSubnetListItemObject(&responseData[i]))
+	}
+
+	data.Subnets = types.ListValueMust(itemObjType, items)
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+// buildSubnetListItemObject builds a single subnet list element from an API
+// response, reusing the resource helpers for nested objects.
+func buildSubnetListItemObject(response *CloudSubnetAPIResponse) basetypes.ObjectValue {
+	nameVal := ovhtypes.TfStringValue{StringValue: types.StringNull()}
+	cidrVal := ovhtypes.TfStringValue{StringValue: types.StringNull()}
+	regionVal := ovhtypes.TfStringValue{StringValue: types.StringNull()}
+	descVal := ovhtypes.TfStringValue{StringValue: types.StringNull()}
+	gatewayIPVal := ovhtypes.TfStringValue{StringValue: types.StringNull()}
+	dhcpVal := types.BoolNull()
+	dnsVal := types.ListNull(types.StringType)
+
+	allocationPoolObjType := types.ObjectType{AttrTypes: subnetAllocationPoolAttrTypes()}
+	allocationPoolsVal := types.ListNull(allocationPoolObjType)
+
+	if response.TargetSpec != nil {
+		nameVal = ovhtypes.TfStringValue{StringValue: types.StringValue(response.TargetSpec.Name)}
+		cidrVal = ovhtypes.TfStringValue{StringValue: types.StringValue(response.TargetSpec.CIDR)}
+		descVal = ovhtypes.TfStringValue{StringValue: types.StringValue(response.TargetSpec.Description)}
+		gatewayIPVal = ovhtypes.TfStringValue{StringValue: types.StringValue(response.TargetSpec.GatewayIP)}
+
+		if response.TargetSpec.Location != nil {
+			regionVal = ovhtypes.TfStringValue{StringValue: types.StringValue(response.TargetSpec.Location.Region)}
+		}
+
+		if response.TargetSpec.DHCPEnabled != nil {
+			dhcpVal = types.BoolValue(*response.TargetSpec.DHCPEnabled)
+		}
+
+		if response.TargetSpec.DNSNameservers != nil {
+			dnsVals := make([]attr.Value, len(response.TargetSpec.DNSNameservers))
+			for i, dns := range response.TargetSpec.DNSNameservers {
+				dnsVals[i] = types.StringValue(dns)
+			}
+			dnsVal = types.ListValueMust(types.StringType, dnsVals)
+		}
+
+		if response.TargetSpec.AllocationPools != nil {
+			poolObjs := make([]attr.Value, len(response.TargetSpec.AllocationPools))
+			for i, pool := range response.TargetSpec.AllocationPools {
+				poolObj, _ := types.ObjectValue(
+					subnetAllocationPoolAttrTypes(),
+					map[string]attr.Value{
+						"start": ovhtypes.TfStringValue{StringValue: types.StringValue(pool.Start)},
+						"end":   ovhtypes.TfStringValue{StringValue: types.StringValue(pool.End)},
+					},
+				)
+				poolObjs[i] = poolObj
+			}
+			allocationPoolsVal = types.ListValueMust(allocationPoolObjType, poolObjs)
+		}
+	}
+
+	var currentStateVal attr.Value
+	if response.CurrentState != nil {
+		currentStateVal = buildSubnetCurrentStateObject(response.CurrentState)
+	} else {
+		currentStateVal = types.ObjectNull(SubnetCurrentStateAttrTypes())
+	}
+
+	obj, _ := types.ObjectValue(
+		SubnetListItemAttrTypes(),
+		map[string]attr.Value{
+			"id":               ovhtypes.TfStringValue{StringValue: types.StringValue(response.Id)},
+			"name":             nameVal,
+			"cidr":             cidrVal,
+			"region":           regionVal,
+			"description":      descVal,
+			"dhcp_enabled":     dhcpVal,
+			"dns_nameservers":  dnsVal,
+			"gateway_ip":       gatewayIPVal,
+			"allocation_pools": allocationPoolsVal,
+			"checksum":         ovhtypes.TfStringValue{StringValue: types.StringValue(response.Checksum)},
+			"created_at":       ovhtypes.TfStringValue{StringValue: types.StringValue(response.CreatedAt)},
+			"updated_at":       ovhtypes.TfStringValue{StringValue: types.StringValue(response.UpdatedAt)},
+			"resource_status":  ovhtypes.TfStringValue{StringValue: types.StringValue(response.ResourceStatus)},
+			"current_state":    currentStateVal,
+		},
+	)
+
+	return obj
+}

--- a/ovh/data_cloud_network_private_vrack_subnets_test.go
+++ b/ovh/data_cloud_network_private_vrack_subnets_test.go
@@ -26,7 +26,7 @@ resource "ovh_cloud_network_private_vrack" "network" {
 }
 
 resource "ovh_cloud_network_private_vrack_subnet" "test" {
-  project_id   = ovh_cloud_network_private_vrack.network.service_name
+  service_name = ovh_cloud_network_private_vrack.network.service_name
   network_id   = ovh_cloud_network_private_vrack.network.id
   name         = "%s"
   cidr         = "10.0.0.0/24"
@@ -37,7 +37,7 @@ resource "ovh_cloud_network_private_vrack_subnet" "test" {
 }
 
 data "ovh_cloud_network_private_vrack_subnets" "test" {
-  service_name = ovh_cloud_network_private_vrack_subnet.test.project_id
+  service_name = ovh_cloud_network_private_vrack_subnet.test.service_name
   network_id   = ovh_cloud_network_private_vrack_subnet.test.network_id
 }
 `, serviceName, networkName, region, subnetName, region)

--- a/ovh/data_cloud_network_private_vrack_subnets_test.go
+++ b/ovh/data_cloud_network_private_vrack_subnets_test.go
@@ -1,0 +1,57 @@
+package ovh
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+func TestAccDataSourceCloudNetworkPrivateVrackSubnets_basic(t *testing.T) {
+	serviceName := os.Getenv("OVH_CLOUD_PROJECT_SERVICE_TEST")
+	region := os.Getenv("OVH_CLOUD_PROJECT_REGION_TEST")
+
+	networkName := acctest.RandomWithPrefix(testAccResourceCloudNetworkPrivateVrackNamePrefix)
+	subnetName := acctest.RandomWithPrefix(testAccResourceCloudNetworkPrivateVrackSubnetNamePrefix)
+
+	config := fmt.Sprintf(`
+resource "ovh_cloud_network_private_vrack" "network" {
+  service_name = "%s"
+  name         = "%s"
+  region       = "%s"
+}
+
+resource "ovh_cloud_network_private_vrack_subnet" "test" {
+  service_name = ovh_cloud_network_private_vrack.network.service_name
+  network_id   = ovh_cloud_network_private_vrack.network.id
+  name         = "%s"
+  cidr         = "10.0.0.0/24"
+  region       = "%s"
+  dhcp_enabled = true
+}
+
+data "ovh_cloud_network_private_vrack_subnets" "test" {
+  service_name = ovh_cloud_network_private_vrack_subnet.test.service_name
+  network_id   = ovh_cloud_network_private_vrack_subnet.test.network_id
+}
+`, serviceName, networkName, region, subnetName, region)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheckCloudNetworkPrivateVrackSubnet(t)
+		},
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("data.ovh_cloud_network_private_vrack_subnets.test", "service_name", serviceName),
+					resource.TestCheckResourceAttrSet("data.ovh_cloud_network_private_vrack_subnets.test", "network_id"),
+					resource.TestCheckResourceAttrSet("data.ovh_cloud_network_private_vrack_subnets.test", "subnets.#"),
+				),
+			},
+		},
+	})
+}

--- a/ovh/data_cloud_network_private_vrack_subnets_test.go
+++ b/ovh/data_cloud_network_private_vrack_subnets_test.go
@@ -14,33 +14,37 @@ func TestAccDataSourceCloudNetworkPrivateVrackSubnets_basic(t *testing.T) {
 	region := os.Getenv("OVH_CLOUD_PROJECT_REGION_TEST")
 
 	networkName := acctest.RandomWithPrefix(testAccResourceCloudNetworkPrivateVrackNamePrefix)
-	subnetName := acctest.RandomWithPrefix(testAccResourceCloudNetworkPrivateVrackSubnetNamePrefix)
+	subnetName := acctest.RandomWithPrefix(testAccResourceCloudNetworkPrivateSubnetNamePrefix)
 
 	config := fmt.Sprintf(`
 resource "ovh_cloud_network_private_vrack" "network" {
   service_name = "%s"
   name         = "%s"
-  region       = "%s"
+  location = {
+	region = "%s"
+  }
 }
 
 resource "ovh_cloud_network_private_vrack_subnet" "test" {
-  service_name = ovh_cloud_network_private_vrack.network.service_name
+  project_id   = ovh_cloud_network_private_vrack.network.service_name
   network_id   = ovh_cloud_network_private_vrack.network.id
   name         = "%s"
   cidr         = "10.0.0.0/24"
-  region       = "%s"
   dhcp_enabled = true
+  location = {
+    region = "%s"
+  }
 }
 
 data "ovh_cloud_network_private_vrack_subnets" "test" {
-  service_name = ovh_cloud_network_private_vrack_subnet.test.service_name
+  service_name = ovh_cloud_network_private_vrack_subnet.test.project_id
   network_id   = ovh_cloud_network_private_vrack_subnet.test.network_id
 }
 `, serviceName, networkName, region, subnetName, region)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
-			testAccPreCheckCloudNetworkPrivateVrackSubnet(t)
+			testAccPreCheckCloudNetworkPrivateSubnet(t)
 		},
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{

--- a/ovh/data_cloud_network_private_vrack_test.go
+++ b/ovh/data_cloud_network_private_vrack_test.go
@@ -19,7 +19,9 @@ func TestAccDataSourceCloudNetworkPrivateVrack_basic(t *testing.T) {
 resource "ovh_cloud_network_private_vrack" "test" {
   service_name = "%s"
   name         = "%s"
-  region       = "%s"
+  location = {
+    region = "%s"
+  }
 }
 
 data "ovh_cloud_network_private_vrack" "test" {
@@ -39,7 +41,7 @@ data "ovh_cloud_network_private_vrack" "test" {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("data.ovh_cloud_network_private_vrack.test", "service_name", serviceName),
 					resource.TestCheckResourceAttr("data.ovh_cloud_network_private_vrack.test", "name", networkName),
-					resource.TestCheckResourceAttr("data.ovh_cloud_network_private_vrack.test", "region", region),
+					resource.TestCheckResourceAttr("data.ovh_cloud_network_private_vrack.test", "location.region", region),
 					resource.TestCheckResourceAttrSet("data.ovh_cloud_network_private_vrack.test", "id"),
 					resource.TestCheckResourceAttrSet("data.ovh_cloud_network_private_vrack.test", "checksum"),
 					resource.TestCheckResourceAttrSet("data.ovh_cloud_network_private_vrack.test", "created_at"),

--- a/ovh/data_cloud_network_private_vrack_test.go
+++ b/ovh/data_cloud_network_private_vrack_test.go
@@ -1,0 +1,53 @@
+package ovh
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+func TestAccDataSourceCloudNetworkPrivateVrack_basic(t *testing.T) {
+	serviceName := os.Getenv("OVH_CLOUD_PROJECT_SERVICE_TEST")
+	region := os.Getenv("OVH_CLOUD_PROJECT_REGION_TEST")
+
+	networkName := acctest.RandomWithPrefix(testAccResourceCloudNetworkPrivateVrackNamePrefix)
+
+	config := fmt.Sprintf(`
+resource "ovh_cloud_network_private_vrack" "test" {
+  service_name = "%s"
+  name         = "%s"
+  region       = "%s"
+}
+
+data "ovh_cloud_network_private_vrack" "test" {
+  service_name = ovh_cloud_network_private_vrack.test.service_name
+  id           = ovh_cloud_network_private_vrack.test.id
+}
+`, serviceName, networkName, region)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheckCloudNetworkPrivateVrack(t)
+		},
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("data.ovh_cloud_network_private_vrack.test", "service_name", serviceName),
+					resource.TestCheckResourceAttr("data.ovh_cloud_network_private_vrack.test", "name", networkName),
+					resource.TestCheckResourceAttr("data.ovh_cloud_network_private_vrack.test", "region", region),
+					resource.TestCheckResourceAttrSet("data.ovh_cloud_network_private_vrack.test", "id"),
+					resource.TestCheckResourceAttrSet("data.ovh_cloud_network_private_vrack.test", "checksum"),
+					resource.TestCheckResourceAttrSet("data.ovh_cloud_network_private_vrack.test", "created_at"),
+					resource.TestCheckResourceAttr("data.ovh_cloud_network_private_vrack.test", "resource_status", "READY"),
+					resource.TestCheckResourceAttrSet("data.ovh_cloud_network_private_vrack.test", "current_state.name"),
+					resource.TestCheckResourceAttrSet("data.ovh_cloud_network_private_vrack.test", "current_state.location.region"),
+				),
+			},
+		},
+	})
+}

--- a/ovh/data_cloud_network_private_vracks.go
+++ b/ovh/data_cloud_network_private_vracks.go
@@ -1,0 +1,227 @@
+package ovh
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
+	ovhtypes "github.com/ovh/terraform-provider-ovh/v2/ovh/types"
+)
+
+var _ datasource.DataSourceWithConfigure = (*cloudNetworkPrivateVracksDataSource)(nil)
+
+func NewCloudNetworkPrivateVracksDataSource() datasource.DataSource {
+	return &cloudNetworkPrivateVracksDataSource{}
+}
+
+type cloudNetworkPrivateVracksDataSource struct {
+	config *Config
+}
+
+// CloudNetworkPrivateVracksModel is the model for the plural networks data source.
+type CloudNetworkPrivateVracksModel struct {
+	ServiceName ovhtypes.TfStringValue `tfsdk:"service_name"`
+	Networks    types.List             `tfsdk:"networks"`
+}
+
+func (d *cloudNetworkPrivateVracksDataSource) Metadata(ctx context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_cloud_network_private_vracks"
+}
+
+func (d *cloudNetworkPrivateVracksDataSource) Configure(_ context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+
+	config, ok := req.ProviderData.(*Config)
+	if !ok {
+		resp.Diagnostics.AddError(
+			"Unexpected Data Source Configure Type",
+			fmt.Sprintf("Expected *Config, got: %T. Please report this issue to the provider developers.", req.ProviderData),
+		)
+		return
+	}
+
+	d.config = config
+}
+
+// NetworkListItemAttrTypes returns the attribute types for a single network
+// element of the plural data source list.
+func NetworkListItemAttrTypes() map[string]attr.Type {
+	return map[string]attr.Type{
+		"id":              ovhtypes.TfStringType{},
+		"name":            ovhtypes.TfStringType{},
+		"description":     ovhtypes.TfStringType{},
+		"region":          ovhtypes.TfStringType{},
+		"checksum":        ovhtypes.TfStringType{},
+		"created_at":      ovhtypes.TfStringType{},
+		"updated_at":      ovhtypes.TfStringType{},
+		"resource_status": ovhtypes.TfStringType{},
+		"current_state": types.ObjectType{
+			AttrTypes: NetworkCurrentStateAttrTypes(),
+		},
+	}
+}
+
+func (d *cloudNetworkPrivateVracksDataSource) Schema(ctx context.Context, req datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Description: "Use this data source to list the private networks (vRack) of a public cloud project.",
+		Attributes: map[string]schema.Attribute{
+			"service_name": schema.StringAttribute{
+				CustomType:  ovhtypes.TfStringType{},
+				Required:    true,
+				Description: "Service name of the resource representing the id of the cloud project",
+			},
+			"networks": schema.ListNestedAttribute{
+				Computed:    true,
+				Description: "List of private networks",
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]schema.Attribute{
+						"id": schema.StringAttribute{
+							CustomType:  ovhtypes.TfStringType{},
+							Computed:    true,
+							Description: "Network ID",
+						},
+						"name": schema.StringAttribute{
+							CustomType:  ovhtypes.TfStringType{},
+							Computed:    true,
+							Description: "Network name",
+						},
+						"description": schema.StringAttribute{
+							CustomType:  ovhtypes.TfStringType{},
+							Computed:    true,
+							Description: "Network description",
+						},
+						"region": schema.StringAttribute{
+							CustomType:  ovhtypes.TfStringType{},
+							Computed:    true,
+							Description: "Region of the network",
+						},
+						"checksum": schema.StringAttribute{
+							CustomType:  ovhtypes.TfStringType{},
+							Computed:    true,
+							Description: "Computed hash representing the current target specification value",
+						},
+						"created_at": schema.StringAttribute{
+							CustomType:  ovhtypes.TfStringType{},
+							Computed:    true,
+							Description: "Creation date of the network",
+						},
+						"updated_at": schema.StringAttribute{
+							CustomType:  ovhtypes.TfStringType{},
+							Computed:    true,
+							Description: "Last update date of the network",
+						},
+						"resource_status": schema.StringAttribute{
+							CustomType:  ovhtypes.TfStringType{},
+							Computed:    true,
+							Description: "Network readiness in the system (CREATING, DELETING, ERROR, OUT_OF_SYNC, READY, UPDATING)",
+						},
+						"current_state": schema.SingleNestedAttribute{
+							Computed:    true,
+							Description: "Current state of the network",
+							Attributes: map[string]schema.Attribute{
+								"name": schema.StringAttribute{
+									CustomType:  ovhtypes.TfStringType{},
+									Computed:    true,
+									Description: "Network name",
+								},
+								"description": schema.StringAttribute{
+									CustomType:  ovhtypes.TfStringType{},
+									Computed:    true,
+									Description: "Network description",
+								},
+								"location": schema.SingleNestedAttribute{
+									Computed:    true,
+									Description: "Location details",
+									Attributes: map[string]schema.Attribute{
+										"region": schema.StringAttribute{
+											CustomType:  ovhtypes.TfStringType{},
+											Computed:    true,
+											Description: "Region code",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func (d *cloudNetworkPrivateVracksDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+	var data CloudNetworkPrivateVracksModel
+
+	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	endpoint := "/v2/publicCloud/project/" + url.PathEscape(data.ServiceName.ValueString()) + "/network"
+
+	var responseData []CloudNetworkAPIResponse
+	if err := d.config.OVHClient.Get(endpoint, &responseData); err != nil {
+		resp.Diagnostics.AddError(
+			fmt.Sprintf("Error calling Get %s", endpoint),
+			err.Error(),
+		)
+		return
+	}
+
+	itemObjType := types.ObjectType{AttrTypes: NetworkListItemAttrTypes()}
+	items := make([]attr.Value, 0, len(responseData))
+	for i := range responseData {
+		items = append(items, buildNetworkListItemObject(&responseData[i]))
+	}
+
+	data.Networks = types.ListValueMust(itemObjType, items)
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+// buildNetworkListItemObject builds a single network list element from an API
+// response, reusing the resource helpers for nested objects.
+func buildNetworkListItemObject(response *CloudNetworkAPIResponse) basetypes.ObjectValue {
+	nameVal := ovhtypes.TfStringValue{StringValue: types.StringNull()}
+	descVal := ovhtypes.TfStringValue{StringValue: types.StringNull()}
+	regionVal := ovhtypes.TfStringValue{StringValue: types.StringNull()}
+
+	if response.TargetSpec != nil {
+		nameVal = ovhtypes.TfStringValue{StringValue: types.StringValue(response.TargetSpec.Name)}
+		descVal = ovhtypes.TfStringValue{StringValue: types.StringValue(response.TargetSpec.Description)}
+		if response.TargetSpec.Location != nil {
+			regionVal = ovhtypes.TfStringValue{StringValue: types.StringValue(response.TargetSpec.Location.Region)}
+		}
+	}
+
+	var currentStateVal attr.Value
+	if response.CurrentState != nil {
+		currentStateVal = buildNetworkCurrentStateObject(response.CurrentState)
+	} else {
+		currentStateVal = types.ObjectNull(NetworkCurrentStateAttrTypes())
+	}
+
+	obj, _ := types.ObjectValue(
+		NetworkListItemAttrTypes(),
+		map[string]attr.Value{
+			"id":              ovhtypes.TfStringValue{StringValue: types.StringValue(response.Id)},
+			"name":            nameVal,
+			"description":     descVal,
+			"region":          regionVal,
+			"checksum":        ovhtypes.TfStringValue{StringValue: types.StringValue(response.Checksum)},
+			"created_at":      ovhtypes.TfStringValue{StringValue: types.StringValue(response.CreatedAt)},
+			"updated_at":      ovhtypes.TfStringValue{StringValue: types.StringValue(response.UpdatedAt)},
+			"resource_status": ovhtypes.TfStringValue{StringValue: types.StringValue(response.ResourceStatus)},
+			"current_state":   currentStateVal,
+		},
+	)
+
+	return obj
+}

--- a/ovh/data_cloud_network_private_vracks.go
+++ b/ovh/data_cloud_network_private_vracks.go
@@ -54,10 +54,12 @@ func (d *cloudNetworkPrivateVracksDataSource) Configure(_ context.Context, req d
 // element of the plural data source list.
 func NetworkListItemAttrTypes() map[string]attr.Type {
 	return map[string]attr.Type{
-		"id":              ovhtypes.TfStringType{},
-		"name":            ovhtypes.TfStringType{},
-		"description":     ovhtypes.TfStringType{},
-		"region":          ovhtypes.TfStringType{},
+		"id":          ovhtypes.TfStringType{},
+		"name":        ovhtypes.TfStringType{},
+		"description": ovhtypes.TfStringType{},
+		"location": types.ObjectType{
+			AttrTypes: vrackLocationAttrTypes(),
+		},
 		"checksum":        ovhtypes.TfStringType{},
 		"created_at":      ovhtypes.TfStringType{},
 		"updated_at":      ovhtypes.TfStringType{},
@@ -97,10 +99,16 @@ func (d *cloudNetworkPrivateVracksDataSource) Schema(ctx context.Context, req da
 							Computed:    true,
 							Description: "Network description",
 						},
-						"region": schema.StringAttribute{
-							CustomType:  ovhtypes.TfStringType{},
+						"location": schema.SingleNestedAttribute{
 							Computed:    true,
-							Description: "Region of the network",
+							Description: "Location of the network",
+							Attributes: map[string]schema.Attribute{
+								"region": schema.StringAttribute{
+									CustomType:  ovhtypes.TfStringType{},
+									Computed:    true,
+									Description: "Region of the network",
+								},
+							},
 						},
 						"checksum": schema.StringAttribute{
 							CustomType:  ovhtypes.TfStringType{},
@@ -191,13 +199,18 @@ func (d *cloudNetworkPrivateVracksDataSource) Read(ctx context.Context, req data
 func buildNetworkListItemObject(response *CloudNetworkAPIResponse) basetypes.ObjectValue {
 	nameVal := ovhtypes.TfStringValue{StringValue: types.StringNull()}
 	descVal := ovhtypes.TfStringValue{StringValue: types.StringNull()}
-	regionVal := ovhtypes.TfStringValue{StringValue: types.StringNull()}
+	locationVal := types.ObjectNull(vrackLocationAttrTypes())
 
 	if response.TargetSpec != nil {
 		nameVal = ovhtypes.TfStringValue{StringValue: types.StringValue(response.TargetSpec.Name)}
 		descVal = ovhtypes.TfStringValue{StringValue: types.StringValue(response.TargetSpec.Description)}
 		if response.TargetSpec.Location != nil {
-			regionVal = ovhtypes.TfStringValue{StringValue: types.StringValue(response.TargetSpec.Location.Region)}
+			locationVal, _ = types.ObjectValue(
+				vrackLocationAttrTypes(),
+				map[string]attr.Value{
+					"region": ovhtypes.TfStringValue{StringValue: types.StringValue(response.TargetSpec.Location.Region)},
+				},
+			)
 		}
 	}
 
@@ -214,7 +227,7 @@ func buildNetworkListItemObject(response *CloudNetworkAPIResponse) basetypes.Obj
 			"id":              ovhtypes.TfStringValue{StringValue: types.StringValue(response.Id)},
 			"name":            nameVal,
 			"description":     descVal,
-			"region":          regionVal,
+			"location":        locationVal,
 			"checksum":        ovhtypes.TfStringValue{StringValue: types.StringValue(response.Checksum)},
 			"created_at":      ovhtypes.TfStringValue{StringValue: types.StringValue(response.CreatedAt)},
 			"updated_at":      ovhtypes.TfStringValue{StringValue: types.StringValue(response.UpdatedAt)},

--- a/ovh/data_cloud_network_private_vracks.go
+++ b/ovh/data_cloud_network_private_vracks.go
@@ -57,6 +57,7 @@ func NetworkListItemAttrTypes() map[string]attr.Type {
 		"id":          ovhtypes.TfStringType{},
 		"name":        ovhtypes.TfStringType{},
 		"description": ovhtypes.TfStringType{},
+		"vlan_id":     ovhtypes.TfInt64Type{},
 		"location": types.ObjectType{
 			AttrTypes: vrackLocationAttrTypes(),
 		},
@@ -98,6 +99,11 @@ func (d *cloudNetworkPrivateVracksDataSource) Schema(ctx context.Context, req da
 							CustomType:  ovhtypes.TfStringType{},
 							Computed:    true,
 							Description: "Network description",
+						},
+						"vlan_id": schema.Int64Attribute{
+							CustomType:  ovhtypes.TfInt64Type{},
+							Computed:    true,
+							Description: "VLAN ID of the network",
 						},
 						"location": schema.SingleNestedAttribute{
 							Computed:    true,
@@ -143,6 +149,11 @@ func (d *cloudNetworkPrivateVracksDataSource) Schema(ctx context.Context, req da
 									CustomType:  ovhtypes.TfStringType{},
 									Computed:    true,
 									Description: "Network description",
+								},
+								"vlan_id": schema.Int64Attribute{
+									CustomType:  ovhtypes.TfInt64Type{},
+									Computed:    true,
+									Description: "VLAN ID of the network",
 								},
 								"location": schema.SingleNestedAttribute{
 									Computed:    true,
@@ -199,11 +210,15 @@ func (d *cloudNetworkPrivateVracksDataSource) Read(ctx context.Context, req data
 func buildNetworkListItemObject(response *CloudNetworkAPIResponse) basetypes.ObjectValue {
 	nameVal := ovhtypes.TfStringValue{StringValue: types.StringNull()}
 	descVal := ovhtypes.TfStringValue{StringValue: types.StringNull()}
+	vlanIdVal := ovhtypes.TfInt64Value{Int64Value: types.Int64Null()}
 	locationVal := types.ObjectNull(vrackLocationAttrTypes())
 
 	if response.TargetSpec != nil {
 		nameVal = ovhtypes.TfStringValue{StringValue: types.StringValue(response.TargetSpec.Name)}
 		descVal = ovhtypes.TfStringValue{StringValue: types.StringValue(response.TargetSpec.Description)}
+		if response.TargetSpec.VlanId != nil {
+			vlanIdVal = ovhtypes.TfInt64Value{Int64Value: types.Int64Value(*response.TargetSpec.VlanId)}
+		}
 		if response.TargetSpec.Location != nil {
 			locationVal, _ = types.ObjectValue(
 				vrackLocationAttrTypes(),
@@ -227,6 +242,7 @@ func buildNetworkListItemObject(response *CloudNetworkAPIResponse) basetypes.Obj
 			"id":              ovhtypes.TfStringValue{StringValue: types.StringValue(response.Id)},
 			"name":            nameVal,
 			"description":     descVal,
+			"vlan_id":         vlanIdVal,
 			"location":        locationVal,
 			"checksum":        ovhtypes.TfStringValue{StringValue: types.StringValue(response.Checksum)},
 			"created_at":      ovhtypes.TfStringValue{StringValue: types.StringValue(response.CreatedAt)},

--- a/ovh/data_cloud_network_private_vracks_test.go
+++ b/ovh/data_cloud_network_private_vracks_test.go
@@ -19,7 +19,9 @@ func TestAccDataSourceCloudNetworkPrivateVracks_basic(t *testing.T) {
 resource "ovh_cloud_network_private_vrack" "test" {
   service_name = "%s"
   name         = "%s"
-  region       = "%s"
+  location = {
+    region = "%s"
+  }
 }
 
 data "ovh_cloud_network_private_vracks" "test" {

--- a/ovh/data_cloud_network_private_vracks_test.go
+++ b/ovh/data_cloud_network_private_vracks_test.go
@@ -1,0 +1,45 @@
+package ovh
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+func TestAccDataSourceCloudNetworkPrivateVracks_basic(t *testing.T) {
+	serviceName := os.Getenv("OVH_CLOUD_PROJECT_SERVICE_TEST")
+	region := os.Getenv("OVH_CLOUD_PROJECT_REGION_TEST")
+
+	networkName := acctest.RandomWithPrefix(testAccResourceCloudNetworkPrivateVrackNamePrefix)
+
+	config := fmt.Sprintf(`
+resource "ovh_cloud_network_private_vrack" "test" {
+  service_name = "%s"
+  name         = "%s"
+  region       = "%s"
+}
+
+data "ovh_cloud_network_private_vracks" "test" {
+  service_name = ovh_cloud_network_private_vrack.test.service_name
+}
+`, serviceName, networkName, region)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheckCloudNetworkPrivateVrack(t)
+		},
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("data.ovh_cloud_network_private_vracks.test", "service_name", serviceName),
+					resource.TestCheckResourceAttrSet("data.ovh_cloud_network_private_vracks.test", "networks.#"),
+				),
+			},
+		},
+	})
+}

--- a/ovh/provider_new.go
+++ b/ovh/provider_new.go
@@ -227,6 +227,12 @@ func (p *OvhProvider) Configure(ctx context.Context, req provider.ConfigureReque
 // DataSources defines the data sources implemented in the provider.
 func (p *OvhProvider) DataSources(_ context.Context) []func() datasource.DataSource {
 	return []func() datasource.DataSource{
+		NewCloudGatewayDataSource,
+		NewCloudGatewaysDataSource,
+		NewCloudNetworkPrivateVrackDataSource,
+		NewCloudNetworkPrivateVracksDataSource,
+		NewCloudNetworkPrivateVrackSubnetDataSource,
+		NewCloudNetworkPrivateVrackSubnetsDataSource,
 		NewCloudSecurityGroupDataSource,
 		NewCloudSecurityGroupsDataSource,
 		NewCloudProjectDatabaseIPRestrictionsDataSource,
@@ -311,6 +317,9 @@ func (p *OvhProvider) DataSources(_ context.Context) []func() datasource.DataSou
 // Resources defines the resources implemented in the provider.
 func (p *OvhProvider) Resources(_ context.Context) []func() resource.Resource {
 	return []func() resource.Resource{
+		NewCloudGatewayResource,
+		NewCloudNetworkPrivateVrackResource,
+		NewCloudNetworkPrivateVrackSubnetResource,
 		NewCloudSecurityGroupResource,
 		NewCloudProjectAlertingResource,
 		NewCloudProjectFileStorageShareResource,

--- a/ovh/resource_cloud_gateway.go
+++ b/ovh/resource_cloud_gateway.go
@@ -1,0 +1,442 @@
+package ovh
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
+	"github.com/ovh/go-ovh/ovh"
+	ovhtypes "github.com/ovh/terraform-provider-ovh/v2/ovh/types"
+)
+
+var (
+	_ resource.Resource                = (*cloudGatewayResource)(nil)
+	_ resource.ResourceWithConfigure   = (*cloudGatewayResource)(nil)
+	_ resource.ResourceWithImportState = (*cloudGatewayResource)(nil)
+)
+
+func NewCloudGatewayResource() resource.Resource {
+	return &cloudGatewayResource{}
+}
+
+type cloudGatewayResource struct {
+	config *Config
+}
+
+func (r *cloudGatewayResource) Metadata(ctx context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_cloud_gateway"
+}
+
+func (r *cloudGatewayResource) Configure(ctx context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+
+	config, ok := req.ProviderData.(*Config)
+	if !ok {
+		resp.Diagnostics.AddError(
+			"Unexpected Resource Configure Type",
+			fmt.Sprintf("Expected *Config, got: %T. Please report this issue to the provider developers.", req.ProviderData),
+		)
+		return
+	}
+
+	r.config = config
+}
+
+var gatewayMutableAttrs = MutableAttrs{
+	Strings:           []string{"name", "description"},
+	Objects:           []string{"external_gateway"},
+	CustomStringLists: []string{"subnet_ids"},
+}
+
+func (r *cloudGatewayResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Description: "Creates a gateway in a public cloud project.",
+		Attributes: map[string]schema.Attribute{
+			"service_name": schema.StringAttribute{
+				CustomType:          ovhtypes.TfStringType{},
+				Required:            true,
+				Description:         "Service name of the resource representing the id of the cloud project",
+				MarkdownDescription: "Service name of the resource representing the id of the cloud project",
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+			},
+			"region": schema.StringAttribute{
+				CustomType:          ovhtypes.TfStringType{},
+				Required:            true,
+				Description:         "Region where the gateway will be created",
+				MarkdownDescription: "Region where the gateway will be created",
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+			},
+			"availability_zone": schema.StringAttribute{
+				CustomType:          ovhtypes.TfStringType{},
+				Optional:            true,
+				Description:         "Availability zone for the gateway",
+				MarkdownDescription: "Availability zone for the gateway",
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+			},
+			"name": schema.StringAttribute{
+				CustomType:          ovhtypes.TfStringType{},
+				Required:            true,
+				Description:         "Gateway name",
+				MarkdownDescription: "Gateway name",
+			},
+			"description": schema.StringAttribute{
+				CustomType:          ovhtypes.TfStringType{},
+				Optional:            true,
+				Description:         "Gateway description",
+				MarkdownDescription: "Gateway description",
+			},
+			"external_gateway": schema.SingleNestedAttribute{
+				Optional:            true,
+				Description:         "External gateway configuration",
+				MarkdownDescription: "External gateway configuration",
+				Attributes: map[string]schema.Attribute{
+					"enabled": schema.BoolAttribute{
+						Required:            true,
+						Description:         "Whether the external gateway is enabled",
+						MarkdownDescription: "Whether the external gateway is enabled",
+					},
+					"model": schema.StringAttribute{
+						CustomType:          ovhtypes.TfStringType{},
+						Optional:            true,
+						Description:         "External gateway sizing model (S, M, L, XL, 2XL, 3XL). Required when enabled is true.",
+						MarkdownDescription: "External gateway sizing model (`S`, `M`, `L`, `XL`, `2XL`, `3XL`). Required when enabled is true.",
+					},
+				},
+			},
+			"subnet_ids": schema.ListAttribute{
+				CustomType:          ovhtypes.NewTfListNestedType[ovhtypes.TfStringValue](ctx),
+				Optional:            true,
+				Description:         "List of subnet IDs to attach as router interfaces",
+				MarkdownDescription: "List of subnet IDs to attach as router interfaces",
+			},
+			"id": schema.StringAttribute{
+				CustomType:          ovhtypes.TfStringType{},
+				Computed:            true,
+				Description:         "Gateway ID",
+				MarkdownDescription: "Gateway ID",
+			},
+			"checksum": schema.StringAttribute{
+				CustomType:          ovhtypes.TfStringType{},
+				Computed:            true,
+				Description:         "Computed hash representing the current target specification value",
+				MarkdownDescription: "Computed hash representing the current target specification value",
+				PlanModifiers: []planmodifier.String{
+					UnknownDuringUpdateStringModifier(gatewayMutableAttrs),
+				},
+			},
+			"created_at": schema.StringAttribute{
+				CustomType:          ovhtypes.TfStringType{},
+				Computed:            true,
+				Description:         "Creation date of the gateway",
+				MarkdownDescription: "Creation date of the gateway",
+			},
+			"updated_at": schema.StringAttribute{
+				CustomType:          ovhtypes.TfStringType{},
+				Computed:            true,
+				Description:         "Last update date of the gateway",
+				MarkdownDescription: "Last update date of the gateway",
+				PlanModifiers: []planmodifier.String{
+					UnknownDuringUpdateStringModifier(gatewayMutableAttrs),
+				},
+			},
+			"resource_status": schema.StringAttribute{
+				CustomType:          ovhtypes.TfStringType{},
+				Computed:            true,
+				Description:         "Gateway readiness in the system (CREATING, DELETING, ERROR, OUT_OF_SYNC, READY, UPDATING)",
+				MarkdownDescription: "Gateway readiness in the system (`CREATING`, `DELETING`, `ERROR`, `OUT_OF_SYNC`, `READY`, `UPDATING`)",
+				PlanModifiers: []planmodifier.String{
+					OutOfSyncPlanModifier(),
+				},
+			},
+			"current_state": schema.SingleNestedAttribute{
+				Computed:    true,
+				Description: "Current state of the gateway",
+				PlanModifiers: []planmodifier.Object{
+					UnknownDuringUpdateObjectModifier(gatewayMutableAttrs),
+				},
+				Attributes: map[string]schema.Attribute{
+					"name": schema.StringAttribute{
+						CustomType:  ovhtypes.TfStringType{},
+						Computed:    true,
+						Description: "Gateway name",
+					},
+					"description": schema.StringAttribute{
+						CustomType:  ovhtypes.TfStringType{},
+						Computed:    true,
+						Description: "Gateway description",
+					},
+					"status": schema.StringAttribute{
+						CustomType:  ovhtypes.TfStringType{},
+						Computed:    true,
+						Description: "OpenStack router status (ACTIVE, BUILD, DOWN, ERROR)",
+					},
+					"external_gateway": schema.SingleNestedAttribute{
+						Computed:    true,
+						Description: "External gateway configuration",
+						Attributes: map[string]schema.Attribute{
+							"enabled": schema.BoolAttribute{
+								Computed:    true,
+								Description: "Whether the external gateway is enabled",
+							},
+							"model": schema.StringAttribute{
+								CustomType:  ovhtypes.TfStringType{},
+								Computed:    true,
+								Description: "External gateway sizing model",
+							},
+						},
+					},
+					"external_ip": schema.StringAttribute{
+						CustomType:  ovhtypes.TfStringType{},
+						Computed:    true,
+						Description: "External IP address assigned to the gateway",
+					},
+					"subnets": schema.ListNestedAttribute{
+						Computed:    true,
+						Description: "Currently attached subnets",
+						NestedObject: schema.NestedAttributeObject{
+							Attributes: map[string]schema.Attribute{
+								"id": schema.StringAttribute{
+									CustomType:  ovhtypes.TfStringType{},
+									Computed:    true,
+									Description: "Subnet ID",
+								},
+							},
+						},
+					},
+					"region": schema.StringAttribute{
+						CustomType:  ovhtypes.TfStringType{},
+						Computed:    true,
+						Description: "Region",
+					},
+					"availability_zone": schema.StringAttribute{
+						CustomType:  ovhtypes.TfStringType{},
+						Computed:    true,
+						Description: "Availability zone",
+					},
+				},
+			},
+		},
+	}
+}
+
+func (r *cloudGatewayResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	splits := strings.Split(req.ID, "/")
+	if len(splits) != 2 {
+		resp.Diagnostics.AddError("Given ID is malformed", "ID must be formatted like the following: <service_name>/<gateway_id>")
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("service_name"), splits[0])...)
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("id"), splits[1])...)
+}
+
+func (r *cloudGatewayResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	var data CloudGatewayModel
+
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	createPayload := data.ToCreate()
+
+	endpoint := "/v2/publicCloud/project/" + url.PathEscape(data.ServiceName.ValueString()) + "/gateway"
+
+	var responseData CloudGatewayAPIResponse
+	if err := r.config.OVHClient.Post(endpoint, createPayload, &responseData); err != nil {
+		resp.Diagnostics.AddError(
+			fmt.Sprintf("Error calling Post %s", endpoint),
+			err.Error(),
+		)
+		return
+	}
+
+	// Save state immediately so the resource ID is tracked even if the workflow fails
+	data.MergeWith(ctx, &responseData)
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+
+	// Wait for gateway to be READY
+	_, err := r.waitForGatewayReady(ctx, data.ServiceName.ValueString(), responseData.Id)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Error waiting for gateway to be ready",
+			err.Error(),
+		)
+		return
+	}
+
+	// Read final state
+	endpoint = "/v2/publicCloud/project/" + url.PathEscape(data.ServiceName.ValueString()) + "/gateway/" + url.PathEscape(responseData.Id)
+	if err := r.config.OVHClient.Get(endpoint, &responseData); err != nil {
+		resp.Diagnostics.AddError(
+			fmt.Sprintf("Error calling Get %s", endpoint),
+			err.Error(),
+		)
+		return
+	}
+
+	data.MergeWith(ctx, &responseData)
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+func (r *cloudGatewayResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	var data CloudGatewayModel
+
+	resp.Diagnostics.Append(req.State.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	endpoint := "/v2/publicCloud/project/" + url.PathEscape(data.ServiceName.ValueString()) + "/gateway/" + url.PathEscape(data.Id.ValueString())
+
+	var responseData CloudGatewayAPIResponse
+	if err := r.config.OVHClient.Get(endpoint, &responseData); err != nil {
+		resp.Diagnostics.AddError(
+			fmt.Sprintf("Error calling Get %s", endpoint),
+			err.Error(),
+		)
+		return
+	}
+
+	data.MergeWith(ctx, &responseData)
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+func (r *cloudGatewayResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	var data, planData CloudGatewayModel
+
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &planData)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	resp.Diagnostics.Append(req.State.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	updatePayload := planData.ToUpdate(data.Checksum.ValueString())
+
+	endpoint := "/v2/publicCloud/project/" + url.PathEscape(data.ServiceName.ValueString()) + "/gateway/" + url.PathEscape(data.Id.ValueString())
+
+	var responseData CloudGatewayAPIResponse
+	if err := r.config.OVHClient.Put(endpoint, updatePayload, &responseData); err != nil {
+		resp.Diagnostics.AddError(
+			fmt.Sprintf("Error calling Put %s", endpoint),
+			err.Error(),
+		)
+		return
+	}
+
+	// Wait for gateway to be READY
+	_, err := r.waitForGatewayReady(ctx, data.ServiceName.ValueString(), data.Id.ValueString())
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Error waiting for gateway to be ready after update",
+			err.Error(),
+		)
+		return
+	}
+
+	// Read final state
+	if err := r.config.OVHClient.Get(endpoint, &responseData); err != nil {
+		resp.Diagnostics.AddError(
+			fmt.Sprintf("Error calling Get %s", endpoint),
+			err.Error(),
+		)
+		return
+	}
+
+	planData.MergeWith(ctx, &responseData)
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &planData)...)
+}
+
+func (r *cloudGatewayResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	var data CloudGatewayModel
+
+	resp.Diagnostics.Append(req.State.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	endpoint := "/v2/publicCloud/project/" + url.PathEscape(data.ServiceName.ValueString()) + "/gateway/" + url.PathEscape(data.Id.ValueString())
+
+	if err := r.config.OVHClient.Delete(endpoint, nil); err != nil {
+		if errOvh, ok := err.(*ovh.APIError); ok && errOvh.Code == 404 {
+			return
+		}
+		resp.Diagnostics.AddError(
+			fmt.Sprintf("Error calling Delete %s", endpoint),
+			err.Error(),
+		)
+		return
+	}
+
+	// Wait for deletion to complete
+	stateConf := &retry.StateChangeConf{
+		Pending: []string{"DELETING"},
+		Target:  []string{"DELETED"},
+		Refresh: func() (interface{}, string, error) {
+			res := &CloudGatewayAPIResponse{}
+			endpoint := "/v2/publicCloud/project/" + url.PathEscape(data.ServiceName.ValueString()) + "/gateway/" + url.PathEscape(data.Id.ValueString())
+			err := r.config.OVHClient.GetWithContext(ctx, endpoint, res)
+			if err != nil {
+				if errOvh, ok := err.(*ovh.APIError); ok && errOvh.Code == 404 {
+					return res, "DELETED", nil
+				}
+				return res, "", err
+			}
+			return res, res.ResourceStatus, nil
+		},
+		Timeout:    20 * time.Minute,
+		Delay:      10 * time.Second,
+		MinTimeout: 5 * time.Second,
+	}
+
+	if _, err := stateConf.WaitForStateContext(ctx); err != nil {
+		resp.Diagnostics.AddError(
+			"Error waiting for gateway to be deleted",
+			err.Error(),
+		)
+	}
+}
+
+func (r *cloudGatewayResource) waitForGatewayReady(ctx context.Context, serviceName, gatewayId string) (interface{}, error) {
+	stateConf := &retry.StateChangeConf{
+		Pending: []string{"CREATING", "UPDATING", "PENDING", "OUT_OF_SYNC"},
+		Target:  []string{"READY"},
+		Refresh: func() (interface{}, string, error) {
+			res := &CloudGatewayAPIResponse{}
+			endpoint := "/v2/publicCloud/project/" + url.PathEscape(serviceName) + "/gateway/" + url.PathEscape(gatewayId)
+			err := r.config.OVHClient.GetWithContext(ctx, endpoint, res)
+			if err != nil {
+				return res, "", err
+			}
+			return res, res.ResourceStatus, nil
+		},
+		Timeout:    20 * time.Minute,
+		Delay:      10 * time.Second,
+		MinTimeout: 5 * time.Second,
+	}
+
+	return stateConf.WaitForStateContext(ctx)
+}

--- a/ovh/resource_cloud_gateway_test.go
+++ b/ovh/resource_cloud_gateway_test.go
@@ -26,6 +26,7 @@ func TestAccCloudGateway_basic(t *testing.T) {
 resource "ovh_cloud_gateway" "test" {
   service_name = "%s"
   name         = "%s"
+
   region       = "%s"
 
   external_gateway = {
@@ -131,6 +132,176 @@ resource "ovh_cloud_gateway" "test" {
 					resource.TestCheckResourceAttrSet("ovh_cloud_gateway.test", "id"),
 					resource.TestCheckResourceAttrSet("ovh_cloud_gateway.test", "checksum"),
 				),
+			},
+		},
+	})
+}
+
+func TestAccCloudGateway_disabledExternalGateway(t *testing.T) {
+	serviceName := os.Getenv("OVH_CLOUD_PROJECT_SERVICE_TEST")
+	region := os.Getenv("OVH_CLOUD_PROJECT_REGION_TEST")
+
+	gatewayName := acctest.RandomWithPrefix(testAccResourceCloudGatewayNamePrefix)
+
+	config := fmt.Sprintf(`
+resource "ovh_cloud_gateway" "test" {
+  service_name = "%s"
+  name         = "%s"
+  region       = "%s"
+
+  external_gateway = {
+    enabled = false
+  }
+}
+`, serviceName, gatewayName, region)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheckCloudGateway(t)
+		},
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("ovh_cloud_gateway.test", "name", gatewayName),
+					resource.TestCheckResourceAttr("ovh_cloud_gateway.test", "external_gateway.enabled", "false"),
+					resource.TestCheckResourceAttrSet("ovh_cloud_gateway.test", "id"),
+					resource.TestCheckResourceAttr("ovh_cloud_gateway.test", "resource_status", "READY"),
+					resource.TestCheckResourceAttr("ovh_cloud_gateway.test", "current_state.external_gateway.enabled", "false"),
+				),
+			},
+			// Test import
+			{
+				ResourceName:      "ovh_cloud_gateway.test",
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testAccCloudGatewayImportStateIdFunc("ovh_cloud_gateway.test"),
+			},
+		},
+	})
+}
+
+func TestAccCloudGateway_updateExternalGatewayModel(t *testing.T) {
+	serviceName := os.Getenv("OVH_CLOUD_PROJECT_SERVICE_TEST")
+	region := os.Getenv("OVH_CLOUD_PROJECT_REGION_TEST")
+
+	gatewayName := acctest.RandomWithPrefix(testAccResourceCloudGatewayNamePrefix)
+
+	configTemplate := `
+resource "ovh_cloud_gateway" "test" {
+  service_name = "%s"
+  name         = "%s"
+  region       = "%s"
+
+  external_gateway = {
+    enabled = true
+    model   = "%s"
+  }
+}
+`
+
+	config := fmt.Sprintf(configTemplate, serviceName, gatewayName, region, "S")
+	updatedConfig := fmt.Sprintf(configTemplate, serviceName, gatewayName, region, "M")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheckCloudGateway(t)
+		},
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("ovh_cloud_gateway.test", "external_gateway.model", "S"),
+					resource.TestCheckResourceAttr("ovh_cloud_gateway.test", "current_state.external_gateway.model", "S"),
+				),
+			},
+			{
+				Config: updatedConfig,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("ovh_cloud_gateway.test", "external_gateway.model", "M"),
+					resource.TestCheckResourceAttr("ovh_cloud_gateway.test", "current_state.external_gateway.model", "M"),
+					resource.TestCheckResourceAttr("ovh_cloud_gateway.test", "resource_status", "READY"),
+				),
+			},
+		},
+	})
+}
+
+// TestAccCloudGateway_withSubnets exercises the full networking feature end to end:
+// a private network, a subnet inside it, and a gateway attaching that subnet through
+// subnet_ids (router interface).
+func TestAccCloudGateway_withSubnets(t *testing.T) {
+	serviceName := os.Getenv("OVH_CLOUD_PROJECT_SERVICE_TEST")
+	region := os.Getenv("OVH_CLOUD_PROJECT_REGION_TEST")
+	gatewayModel := os.Getenv("OVH_CLOUD_GATEWAY_MODEL_TEST")
+	if gatewayModel == "" {
+		gatewayModel = "S"
+	}
+
+	networkName := acctest.RandomWithPrefix(testAccResourceCloudNetworkPrivateVrackNamePrefix)
+	subnetName := acctest.RandomWithPrefix(testAccResourceCloudNetworkPrivateVrackSubnetNamePrefix)
+	gatewayName := acctest.RandomWithPrefix(testAccResourceCloudGatewayNamePrefix)
+
+	config := fmt.Sprintf(`
+resource "ovh_cloud_network_private_vrack" "network" {
+  service_name = "%s"
+  name         = "%s"
+  region       = "%s"
+}
+
+resource "ovh_cloud_network_private_vrack_subnet" "subnet" {
+  service_name = ovh_cloud_network_private_vrack.network.service_name
+  network_id   = ovh_cloud_network_private_vrack.network.id
+  name         = "%s"
+  cidr         = "10.0.0.0/24"
+  region       = "%s"
+  dhcp_enabled = true
+}
+
+resource "ovh_cloud_gateway" "test" {
+  service_name = ovh_cloud_network_private_vrack.network.service_name
+  name         = "%s"
+  region       = "%s"
+  subnet_ids   = [ovh_cloud_network_private_vrack_subnet.subnet.id]
+
+  external_gateway = {
+    enabled = true
+    model   = "%s"
+  }
+}
+`, serviceName, networkName, region, subnetName, region, gatewayName, region, gatewayModel)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheckCloudGateway(t)
+		},
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("ovh_cloud_gateway.test", "name", gatewayName),
+					resource.TestCheckResourceAttr("ovh_cloud_gateway.test", "subnet_ids.#", "1"),
+					resource.TestCheckResourceAttrPair(
+						"ovh_cloud_gateway.test", "subnet_ids.0",
+						"ovh_cloud_network_private_vrack_subnet.subnet", "id",
+					),
+					resource.TestCheckResourceAttr("ovh_cloud_gateway.test", "resource_status", "READY"),
+					resource.TestCheckResourceAttr("ovh_cloud_gateway.test", "current_state.subnets.#", "1"),
+					resource.TestCheckResourceAttrSet("ovh_cloud_gateway.test", "current_state.external_ip"),
+				),
+			},
+			// Test import
+			{
+				ResourceName:      "ovh_cloud_gateway.test",
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"subnet_ids",
+				},
+				ImportStateIdFunc: testAccCloudGatewayImportStateIdFunc("ovh_cloud_gateway.test"),
 			},
 		},
 	})

--- a/ovh/resource_cloud_gateway_test.go
+++ b/ovh/resource_cloud_gateway_test.go
@@ -254,7 +254,7 @@ resource "ovh_cloud_network_private_vrack" "network" {
 }
 
 resource "ovh_cloud_network_private_vrack_subnet" "subnet" {
-  project_id   = ovh_cloud_network_private_vrack.network.service_name
+  service_name = ovh_cloud_network_private_vrack.network.service_name
   network_id   = ovh_cloud_network_private_vrack.network.id
   name         = "%s"
   cidr         = "10.0.0.0/24"

--- a/ovh/resource_cloud_gateway_test.go
+++ b/ovh/resource_cloud_gateway_test.go
@@ -241,23 +241,27 @@ func TestAccCloudGateway_withSubnets(t *testing.T) {
 	}
 
 	networkName := acctest.RandomWithPrefix(testAccResourceCloudNetworkPrivateVrackNamePrefix)
-	subnetName := acctest.RandomWithPrefix(testAccResourceCloudNetworkPrivateVrackSubnetNamePrefix)
+	subnetName := acctest.RandomWithPrefix(testAccResourceCloudNetworkPrivateSubnetNamePrefix)
 	gatewayName := acctest.RandomWithPrefix(testAccResourceCloudGatewayNamePrefix)
 
 	config := fmt.Sprintf(`
 resource "ovh_cloud_network_private_vrack" "network" {
   service_name = "%s"
   name         = "%s"
-  region       = "%s"
+  location = {
+    region = "%s"
+  }
 }
 
 resource "ovh_cloud_network_private_vrack_subnet" "subnet" {
-  service_name = ovh_cloud_network_private_vrack.network.service_name
+  project_id   = ovh_cloud_network_private_vrack.network.service_name
   network_id   = ovh_cloud_network_private_vrack.network.id
   name         = "%s"
   cidr         = "10.0.0.0/24"
-  region       = "%s"
   dhcp_enabled = true
+  location = {
+    region = "%s"
+  }
 }
 
 resource "ovh_cloud_gateway" "test" {

--- a/ovh/resource_cloud_gateway_test.go
+++ b/ovh/resource_cloud_gateway_test.go
@@ -1,0 +1,157 @@
+package ovh
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+)
+
+const testAccResourceCloudGatewayNamePrefix = "tf-test-gateway-v2-"
+
+func TestAccCloudGateway_basic(t *testing.T) {
+	serviceName := os.Getenv("OVH_CLOUD_PROJECT_SERVICE_TEST")
+	region := os.Getenv("OVH_CLOUD_PROJECT_REGION_TEST")
+	gatewayModel := os.Getenv("OVH_CLOUD_GATEWAY_MODEL_TEST")
+	if gatewayModel == "" {
+		gatewayModel = "S"
+	}
+
+	gatewayName := acctest.RandomWithPrefix(testAccResourceCloudGatewayNamePrefix)
+
+	config := fmt.Sprintf(`
+resource "ovh_cloud_gateway" "test" {
+  service_name = "%s"
+  name         = "%s"
+  region       = "%s"
+
+  external_gateway = {
+    enabled = true
+    model   = "%s"
+  }
+}
+`, serviceName, gatewayName, region, gatewayModel)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheckCloudGateway(t)
+		},
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("ovh_cloud_gateway.test", "service_name", serviceName),
+					resource.TestCheckResourceAttr("ovh_cloud_gateway.test", "name", gatewayName),
+					resource.TestCheckResourceAttr("ovh_cloud_gateway.test", "external_gateway.enabled", "true"),
+					resource.TestCheckResourceAttr("ovh_cloud_gateway.test", "external_gateway.model", gatewayModel),
+					resource.TestCheckResourceAttr("ovh_cloud_gateway.test", "region", region),
+					resource.TestCheckResourceAttrSet("ovh_cloud_gateway.test", "id"),
+					resource.TestCheckResourceAttrSet("ovh_cloud_gateway.test", "checksum"),
+					resource.TestCheckResourceAttrSet("ovh_cloud_gateway.test", "created_at"),
+					resource.TestCheckResourceAttr("ovh_cloud_gateway.test", "resource_status", "READY"),
+					resource.TestCheckResourceAttrSet("ovh_cloud_gateway.test", "current_state.name"),
+					resource.TestCheckResourceAttr("ovh_cloud_gateway.test", "current_state.external_gateway.enabled", "true"),
+					resource.TestCheckResourceAttrSet("ovh_cloud_gateway.test", "current_state.status"),
+				),
+			},
+			// Test import
+			{
+				ResourceName:      "ovh_cloud_gateway.test",
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testAccCloudGatewayImportStateIdFunc("ovh_cloud_gateway.test"),
+			},
+		},
+	})
+}
+
+func TestAccCloudGateway_update(t *testing.T) {
+	serviceName := os.Getenv("OVH_CLOUD_PROJECT_SERVICE_TEST")
+	region := os.Getenv("OVH_CLOUD_PROJECT_REGION_TEST")
+	gatewayModel := os.Getenv("OVH_CLOUD_GATEWAY_MODEL_TEST")
+	if gatewayModel == "" {
+		gatewayModel = "S"
+	}
+
+	gatewayName := acctest.RandomWithPrefix(testAccResourceCloudGatewayNamePrefix)
+	updatedName := acctest.RandomWithPrefix(testAccResourceCloudGatewayNamePrefix)
+
+	config := fmt.Sprintf(`
+resource "ovh_cloud_gateway" "test" {
+  service_name = "%s"
+  name         = "%s"
+  region       = "%s"
+  description  = "initial description"
+
+  external_gateway = {
+    enabled = true
+    model   = "%s"
+  }
+}
+`, serviceName, gatewayName, region, gatewayModel)
+
+	updatedConfig := fmt.Sprintf(`
+resource "ovh_cloud_gateway" "test" {
+  service_name = "%s"
+  name         = "%s"
+  region       = "%s"
+  description  = "updated description"
+
+  external_gateway = {
+    enabled = true
+    model   = "%s"
+  }
+}
+`, serviceName, updatedName, region, gatewayModel)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheckCloudGateway(t)
+		},
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("ovh_cloud_gateway.test", "name", gatewayName),
+					resource.TestCheckResourceAttr("ovh_cloud_gateway.test", "description", "initial description"),
+					resource.TestCheckResourceAttr("ovh_cloud_gateway.test", "external_gateway.enabled", "true"),
+					resource.TestCheckResourceAttr("ovh_cloud_gateway.test", "external_gateway.model", gatewayModel),
+				),
+			},
+			{
+				Config: updatedConfig,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("ovh_cloud_gateway.test", "name", updatedName),
+					resource.TestCheckResourceAttr("ovh_cloud_gateway.test", "description", "updated description"),
+					resource.TestCheckResourceAttrSet("ovh_cloud_gateway.test", "id"),
+					resource.TestCheckResourceAttrSet("ovh_cloud_gateway.test", "checksum"),
+				),
+			},
+		},
+	})
+}
+
+func testAccPreCheckCloudGateway(t *testing.T) {
+	testAccPreCheckCredentials(t)
+	if os.Getenv("OVH_CLOUD_PROJECT_SERVICE_TEST") == "" {
+		t.Skip("OVH_CLOUD_PROJECT_SERVICE_TEST not set")
+	}
+	if os.Getenv("OVH_CLOUD_PROJECT_REGION_TEST") == "" {
+		t.Skip("OVH_CLOUD_PROJECT_REGION_TEST not set")
+	}
+}
+
+func testAccCloudGatewayImportStateIdFunc(resourceName string) resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return "", fmt.Errorf("not found: %s", resourceName)
+		}
+		return fmt.Sprintf("%s/%s", rs.Primary.Attributes["service_name"], rs.Primary.Attributes["id"]), nil
+	}
+}

--- a/ovh/resource_cloud_network_private_vrack.go
+++ b/ovh/resource_cloud_network_private_vrack.go
@@ -7,11 +7,14 @@ import (
 	"strings"
 	"time"
 
+	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/ovh/go-ovh/ovh"
 	ovhtypes "github.com/ovh/terraform-provider-ovh/v2/ovh/types"
@@ -98,6 +101,16 @@ func (r *cloudNetworkPrivateVrackResource) Schema(ctx context.Context, req resou
 					stringplanmodifier.RequiresReplace(),
 				},
 			},
+			"vlan_id": schema.Int64Attribute{
+				CustomType:  ovhtypes.TfInt64Type{},
+				Optional:    true,
+				Computed:    true,
+				Description: "VLAN ID of the network (0-4096). Assigned by the API if not set. Changing this value recreates the resource. Not supported in localzone regions.",
+				Validators:  []validator.Int64{int64validator.Between(0, 4096)},
+				PlanModifiers: []planmodifier.Int64{
+					int64planmodifier.RequiresReplaceIfConfigured(),
+				},
+			},
 
 			// Computed attributes
 			"id": schema.StringAttribute{
@@ -152,6 +165,11 @@ func (r *cloudNetworkPrivateVrackResource) Schema(ctx context.Context, req resou
 						CustomType:  ovhtypes.TfStringType{},
 						Computed:    true,
 						Description: "Network description",
+					},
+					"vlan_id": schema.Int64Attribute{
+						CustomType:  ovhtypes.TfInt64Type{},
+						Computed:    true,
+						Description: "VLAN ID of the network",
 					},
 					"location": schema.SingleNestedAttribute{
 						Computed:    true,

--- a/ovh/resource_cloud_network_private_vrack.go
+++ b/ovh/resource_cloud_network_private_vrack.go
@@ -74,12 +74,18 @@ func (r *cloudNetworkPrivateVrackResource) Schema(ctx context.Context, req resou
 				Required:    true,
 				Description: "Network name",
 			},
-			"region": schema.StringAttribute{
-				CustomType:  ovhtypes.TfStringType{},
+			"location": schema.SingleNestedAttribute{
 				Required:    true,
-				Description: "Region where the network will be created",
-				PlanModifiers: []planmodifier.String{
-					stringplanmodifier.RequiresReplace(),
+				Description: "Location of the network",
+				Attributes: map[string]schema.Attribute{
+					"region": schema.StringAttribute{
+						CustomType:  ovhtypes.TfStringType{},
+						Required:    true,
+						Description: "Region where the network will be created. Changing this value recreates the resource.",
+						PlanModifiers: []planmodifier.String{
+							stringplanmodifier.RequiresReplace(),
+						},
+					},
 				},
 			},
 

--- a/ovh/resource_cloud_network_private_vrack.go
+++ b/ovh/resource_cloud_network_private_vrack.go
@@ -1,0 +1,371 @@
+package ovh
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
+	"github.com/ovh/go-ovh/ovh"
+	ovhtypes "github.com/ovh/terraform-provider-ovh/v2/ovh/types"
+)
+
+var (
+	_ resource.Resource                = (*cloudNetworkPrivateVrackResource)(nil)
+	_ resource.ResourceWithConfigure   = (*cloudNetworkPrivateVrackResource)(nil)
+	_ resource.ResourceWithImportState = (*cloudNetworkPrivateVrackResource)(nil)
+)
+
+func NewCloudNetworkPrivateVrackResource() resource.Resource {
+	return &cloudNetworkPrivateVrackResource{}
+}
+
+type cloudNetworkPrivateVrackResource struct {
+	config *Config
+}
+
+func (r *cloudNetworkPrivateVrackResource) Metadata(ctx context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_cloud_network_private_vrack"
+}
+
+func (r *cloudNetworkPrivateVrackResource) Configure(ctx context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+
+	config, ok := req.ProviderData.(*Config)
+	if !ok {
+		resp.Diagnostics.AddError(
+			"Unexpected Resource Configure Type",
+			fmt.Sprintf("Expected *Config, got: %T. Please report this issue to the provider developers.", req.ProviderData),
+		)
+		return
+	}
+
+	r.config = config
+}
+
+var networkPrivateVrackMutableAttrs = MutableAttrs{
+	Strings: []string{"name"},
+}
+
+func (r *cloudNetworkPrivateVrackResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Description: "Creates a private network (vRack) in a public cloud project using the v2 API.",
+		Attributes: map[string]schema.Attribute{
+			// Required attributes
+			"service_name": schema.StringAttribute{
+				CustomType:  ovhtypes.TfStringType{},
+				Required:    true,
+				Description: "Service name of the resource representing the id of the cloud project",
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+			},
+			"name": schema.StringAttribute{
+				CustomType:  ovhtypes.TfStringType{},
+				Required:    true,
+				Description: "Network name",
+			},
+			"region": schema.StringAttribute{
+				CustomType:  ovhtypes.TfStringType{},
+				Required:    true,
+				Description: "Region where the network will be created",
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+			},
+
+			// Optional attributes
+			"description": schema.StringAttribute{
+				CustomType:  ovhtypes.TfStringType{},
+				Optional:    true,
+				Description: "Network description",
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+			},
+
+			// Computed attributes
+			"id": schema.StringAttribute{
+				CustomType:  ovhtypes.TfStringType{},
+				Computed:    true,
+				Description: "Network ID",
+			},
+			"checksum": schema.StringAttribute{
+				CustomType:  ovhtypes.TfStringType{},
+				Computed:    true,
+				Description: "Computed hash representing the current target specification value",
+				PlanModifiers: []planmodifier.String{
+					UnknownDuringUpdateStringModifier(networkPrivateVrackMutableAttrs),
+				},
+			},
+			"created_at": schema.StringAttribute{
+				CustomType:  ovhtypes.TfStringType{},
+				Computed:    true,
+				Description: "Creation date of the network",
+			},
+			"updated_at": schema.StringAttribute{
+				CustomType:  ovhtypes.TfStringType{},
+				Computed:    true,
+				Description: "Last update date of the network",
+				PlanModifiers: []planmodifier.String{
+					UnknownDuringUpdateStringModifier(networkPrivateVrackMutableAttrs),
+				},
+			},
+			"resource_status": schema.StringAttribute{
+				CustomType:  ovhtypes.TfStringType{},
+				Computed:    true,
+				Description: "Network readiness in the system (CREATING, DELETING, ERROR, OUT_OF_SYNC, READY, UPDATING)",
+				PlanModifiers: []planmodifier.String{
+					OutOfSyncPlanModifier(),
+				},
+			},
+
+			// Current state (computed, read-only)
+			"current_state": schema.SingleNestedAttribute{
+				Computed:    true,
+				Description: "Current state of the network",
+				PlanModifiers: []planmodifier.Object{
+					UnknownDuringUpdateObjectModifier(networkPrivateVrackMutableAttrs),
+				},
+				Attributes: map[string]schema.Attribute{
+					"name": schema.StringAttribute{
+						CustomType:  ovhtypes.TfStringType{},
+						Computed:    true,
+						Description: "Network name",
+					},
+					"description": schema.StringAttribute{
+						CustomType:  ovhtypes.TfStringType{},
+						Computed:    true,
+						Description: "Network description",
+					},
+					"location": schema.SingleNestedAttribute{
+						Computed:    true,
+						Description: "Location details",
+						Attributes: map[string]schema.Attribute{
+							"region": schema.StringAttribute{
+								CustomType:  ovhtypes.TfStringType{},
+								Computed:    true,
+								Description: "Region code",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func (r *cloudNetworkPrivateVrackResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	splits := strings.Split(req.ID, "/")
+	if len(splits) != 2 {
+		resp.Diagnostics.AddError("Given ID is malformed", "ID must be formatted like the following: <service_name>/<network_id>")
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("service_name"), splits[0])...)
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("id"), splits[1])...)
+}
+
+func (r *cloudNetworkPrivateVrackResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	var data CloudNetworkPrivateVrackModel
+
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	createPayload := data.ToCreate()
+
+	endpoint := "/v2/publicCloud/project/" + url.PathEscape(data.ServiceName.ValueString()) + "/network"
+
+	var responseData CloudNetworkAPIResponse
+	if err := r.config.OVHClient.Post(endpoint, createPayload, &responseData); err != nil {
+		resp.Diagnostics.AddError(
+			fmt.Sprintf("Error calling Post %s", endpoint),
+			err.Error(),
+		)
+		return
+	}
+
+	// Save state immediately so the resource ID is tracked even if the workflow fails
+	data.MergeWith(ctx, &responseData)
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+
+	// Wait for network to be READY
+	_, err := r.waitForReady(ctx, data.ServiceName.ValueString(), responseData.Id)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Error waiting for network to be ready",
+			err.Error(),
+		)
+		return
+	}
+
+	// Read the final state
+	endpoint = "/v2/publicCloud/project/" + url.PathEscape(data.ServiceName.ValueString()) + "/network/" + url.PathEscape(responseData.Id)
+	if err := r.config.OVHClient.Get(endpoint, &responseData); err != nil {
+		resp.Diagnostics.AddError(
+			fmt.Sprintf("Error calling Get %s", endpoint),
+			err.Error(),
+		)
+		return
+	}
+
+	data.MergeWith(ctx, &responseData)
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+func (r *cloudNetworkPrivateVrackResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	var data CloudNetworkPrivateVrackModel
+
+	resp.Diagnostics.Append(req.State.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	endpoint := "/v2/publicCloud/project/" + url.PathEscape(data.ServiceName.ValueString()) + "/network/" + url.PathEscape(data.Id.ValueString())
+
+	var responseData CloudNetworkAPIResponse
+	if err := r.config.OVHClient.Get(endpoint, &responseData); err != nil {
+		resp.Diagnostics.AddError(
+			fmt.Sprintf("Error calling Get %s", endpoint),
+			err.Error(),
+		)
+		return
+	}
+
+	data.MergeWith(ctx, &responseData)
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+func (r *cloudNetworkPrivateVrackResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	var data, planData CloudNetworkPrivateVrackModel
+
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &planData)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	resp.Diagnostics.Append(req.State.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	updatePayload := planData.ToUpdate(data.Checksum.ValueString())
+
+	endpoint := "/v2/publicCloud/project/" + url.PathEscape(data.ServiceName.ValueString()) + "/network/" + url.PathEscape(data.Id.ValueString())
+
+	var responseData CloudNetworkAPIResponse
+	if err := r.config.OVHClient.Put(endpoint, updatePayload, &responseData); err != nil {
+		resp.Diagnostics.AddError(
+			fmt.Sprintf("Error calling Put %s", endpoint),
+			err.Error(),
+		)
+		return
+	}
+
+	// Wait for network to be READY
+	_, err := r.waitForReady(ctx, data.ServiceName.ValueString(), data.Id.ValueString())
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Error waiting for network to be ready after update",
+			err.Error(),
+		)
+		return
+	}
+
+	// Read the final state
+	if err := r.config.OVHClient.Get(endpoint, &responseData); err != nil {
+		resp.Diagnostics.AddError(
+			fmt.Sprintf("Error calling Get %s", endpoint),
+			err.Error(),
+		)
+		return
+	}
+
+	planData.MergeWith(ctx, &responseData)
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &planData)...)
+}
+
+func (r *cloudNetworkPrivateVrackResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	var data CloudNetworkPrivateVrackModel
+
+	resp.Diagnostics.Append(req.State.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	endpoint := "/v2/publicCloud/project/" + url.PathEscape(data.ServiceName.ValueString()) + "/network/" + url.PathEscape(data.Id.ValueString())
+
+	if err := r.config.OVHClient.Delete(endpoint, nil); err != nil {
+		if errOvh, ok := err.(*ovh.APIError); ok && errOvh.Code == 404 {
+			return
+		}
+		resp.Diagnostics.AddError(
+			fmt.Sprintf("Error calling Delete %s", endpoint),
+			err.Error(),
+		)
+		return
+	}
+
+	// Wait for deletion to complete
+	stateConf := &retry.StateChangeConf{
+		Pending: []string{"DELETING"},
+		Target:  []string{"DELETED"},
+		Refresh: func() (interface{}, string, error) {
+			res := &CloudNetworkAPIResponse{}
+			endpoint := "/v2/publicCloud/project/" + url.PathEscape(data.ServiceName.ValueString()) + "/network/" + url.PathEscape(data.Id.ValueString())
+			err := r.config.OVHClient.GetWithContext(ctx, endpoint, res)
+			if err != nil {
+				if errOvh, ok := err.(*ovh.APIError); ok && errOvh.Code == 404 {
+					return res, "DELETED", nil
+				}
+				return res, "", err
+			}
+			return res, res.ResourceStatus, nil
+		},
+		Timeout:    20 * time.Minute,
+		Delay:      10 * time.Second,
+		MinTimeout: 5 * time.Second,
+	}
+
+	if _, err := stateConf.WaitForStateContext(ctx); err != nil {
+		resp.Diagnostics.AddError(
+			"Error waiting for network to be deleted",
+			err.Error(),
+		)
+	}
+}
+
+func (r *cloudNetworkPrivateVrackResource) waitForReady(ctx context.Context, serviceName, networkId string) (interface{}, error) {
+	stateConf := &retry.StateChangeConf{
+		Pending: []string{"CREATING", "UPDATING", "PENDING", "OUT_OF_SYNC"},
+		Target:  []string{"READY"},
+		Refresh: func() (interface{}, string, error) {
+			res := &CloudNetworkAPIResponse{}
+			endpoint := "/v2/publicCloud/project/" + url.PathEscape(serviceName) + "/network/" + url.PathEscape(networkId)
+			err := r.config.OVHClient.GetWithContext(ctx, endpoint, res)
+			if err != nil {
+				return res, "", err
+			}
+			return res, res.ResourceStatus, nil
+		},
+		Timeout:    20 * time.Minute,
+		Delay:      10 * time.Second,
+		MinTimeout: 5 * time.Second,
+	}
+
+	return stateConf.WaitForStateContext(ctx)
+}

--- a/ovh/resource_cloud_network_private_vrack_subnet.go
+++ b/ovh/resource_cloud_network_private_vrack_subnet.go
@@ -2,41 +2,46 @@ package ovh
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"net/url"
 	"strings"
 	"time"
 
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/boolplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/listplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/ovh/go-ovh/ovh"
+	"github.com/ovh/terraform-provider-ovh/v2/ovh/helpers"
 	ovhtypes "github.com/ovh/terraform-provider-ovh/v2/ovh/types"
 )
 
 var (
-	_ resource.Resource                = (*cloudNetworkPrivateVrackSubnetResource)(nil)
-	_ resource.ResourceWithConfigure   = (*cloudNetworkPrivateVrackSubnetResource)(nil)
-	_ resource.ResourceWithImportState = (*cloudNetworkPrivateVrackSubnetResource)(nil)
+	_ resource.Resource                = (*cloudNetworkPrivateSubnetResource)(nil)
+	_ resource.ResourceWithConfigure   = (*cloudNetworkPrivateSubnetResource)(nil)
+	_ resource.ResourceWithImportState = (*cloudNetworkPrivateSubnetResource)(nil)
 )
 
 func NewCloudNetworkPrivateVrackSubnetResource() resource.Resource {
-	return &cloudNetworkPrivateVrackSubnetResource{}
+	return &cloudNetworkPrivateSubnetResource{}
 }
 
-type cloudNetworkPrivateVrackSubnetResource struct {
+type cloudNetworkPrivateSubnetResource struct {
 	config *Config
 }
 
-func (r *cloudNetworkPrivateVrackSubnetResource) Metadata(ctx context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+func (r *cloudNetworkPrivateSubnetResource) Metadata(ctx context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
 	resp.TypeName = req.ProviderTypeName + "_cloud_network_private_vrack_subnet"
 }
 
-func (r *cloudNetworkPrivateVrackSubnetResource) Configure(ctx context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
+func (r *cloudNetworkPrivateSubnetResource) Configure(_ context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
 	if req.ProviderData == nil {
 		return
 	}
@@ -53,276 +58,91 @@ func (r *cloudNetworkPrivateVrackSubnetResource) Configure(ctx context.Context, 
 	r.config = config
 }
 
-var subnetMutableAttrs = MutableAttrs{
-	Strings: []string{"name", "description", "gateway_ip"},
-	Bools:   []string{"dhcp_enabled"},
-	Lists:   []string{"dns_nameservers", "allocation_pools"},
+func (r *cloudNetworkPrivateSubnetResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = CloudNetworkPrivateSubnetResourceSchema(ctx)
 }
 
-func (r *cloudNetworkPrivateVrackSubnetResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
-	resp.Schema = schema.Schema{
-		Description: "Creates a subnet in a private network (vRack) in a public cloud project using the v2 API.",
-		Attributes: map[string]schema.Attribute{
-			// Required attributes
-			"service_name": schema.StringAttribute{
-				CustomType:  ovhtypes.TfStringType{},
-				Required:    true,
-				Description: "Service name of the resource representing the id of the cloud project",
-				PlanModifiers: []planmodifier.String{
-					stringplanmodifier.RequiresReplace(),
-				},
-			},
-			"network_id": schema.StringAttribute{
-				CustomType:  ovhtypes.TfStringType{},
-				Required:    true,
-				Description: "Network ID of the parent private network",
-				PlanModifiers: []planmodifier.String{
-					stringplanmodifier.RequiresReplace(),
-				},
-			},
-			"name": schema.StringAttribute{
-				CustomType:  ovhtypes.TfStringType{},
-				Required:    true,
-				Description: "Subnet name",
-			},
-			"cidr": schema.StringAttribute{
-				CustomType:  ovhtypes.TfStringType{},
-				Required:    true,
-				Description: "CIDR address range for the subnet",
-				PlanModifiers: []planmodifier.String{
-					stringplanmodifier.RequiresReplace(),
-				},
-			},
-			"region": schema.StringAttribute{
-				CustomType:  ovhtypes.TfStringType{},
-				Required:    true,
-				Description: "Region where the subnet will be created",
-				PlanModifiers: []planmodifier.String{
-					stringplanmodifier.RequiresReplace(),
-				},
-			},
-
-			// Optional attributes
-			"description": schema.StringAttribute{
-				CustomType:  ovhtypes.TfStringType{},
-				Optional:    true,
-				Description: "Subnet description",
-			},
-			"dhcp_enabled": schema.BoolAttribute{
-				Optional:    true,
-				Description: "Whether DHCP is enabled on the subnet",
-			},
-			"dns_nameservers": schema.ListAttribute{
-				ElementType: types.StringType,
-				Optional:    true,
-				Description: "DNS nameservers for the subnet",
-			},
-			"gateway_ip": schema.StringAttribute{
-				CustomType:  ovhtypes.TfStringType{},
-				Optional:    true,
-				Description: "Default gateway IP address",
-			},
-			"allocation_pools": schema.ListNestedAttribute{
-				Optional:    true,
-				Description: "IP address allocation pools",
-				NestedObject: schema.NestedAttributeObject{
-					Attributes: map[string]schema.Attribute{
-						"start": schema.StringAttribute{
-							CustomType:  ovhtypes.TfStringType{},
-							Required:    true,
-							Description: "Start IP address of the pool",
-						},
-						"end": schema.StringAttribute{
-							CustomType:  ovhtypes.TfStringType{},
-							Required:    true,
-							Description: "End IP address of the pool",
-						},
-					},
-				},
-			},
-
-			// Computed attributes
-			"id": schema.StringAttribute{
-				CustomType:  ovhtypes.TfStringType{},
-				Computed:    true,
-				Description: "Subnet ID",
-			},
-			"checksum": schema.StringAttribute{
-				CustomType:  ovhtypes.TfStringType{},
-				Computed:    true,
-				Description: "Computed hash representing the current target specification value",
-				PlanModifiers: []planmodifier.String{
-					UnknownDuringUpdateStringModifier(subnetMutableAttrs),
-				},
-			},
-			"created_at": schema.StringAttribute{
-				CustomType:  ovhtypes.TfStringType{},
-				Computed:    true,
-				Description: "Creation date of the subnet",
-			},
-			"updated_at": schema.StringAttribute{
-				CustomType:  ovhtypes.TfStringType{},
-				Computed:    true,
-				Description: "Last update date of the subnet",
-				PlanModifiers: []planmodifier.String{
-					UnknownDuringUpdateStringModifier(subnetMutableAttrs),
-				},
-			},
-			"resource_status": schema.StringAttribute{
-				CustomType:  ovhtypes.TfStringType{},
-				Computed:    true,
-				Description: "Subnet readiness in the system (CREATING, DELETING, ERROR, OUT_OF_SYNC, READY, UPDATING)",
-				PlanModifiers: []planmodifier.String{
-					OutOfSyncPlanModifier(),
-				},
-			},
-
-			// Current state (computed, read-only)
-			"current_state": schema.SingleNestedAttribute{
-				Computed:    true,
-				Description: "Current state of the subnet",
-				PlanModifiers: []planmodifier.Object{
-					UnknownDuringUpdateObjectModifier(subnetMutableAttrs),
-				},
-				Attributes: map[string]schema.Attribute{
-					"name": schema.StringAttribute{
-						CustomType:  ovhtypes.TfStringType{},
-						Computed:    true,
-						Description: "Subnet name",
-					},
-					"cidr": schema.StringAttribute{
-						CustomType:  ovhtypes.TfStringType{},
-						Computed:    true,
-						Description: "CIDR address range",
-					},
-					"description": schema.StringAttribute{
-						CustomType:  ovhtypes.TfStringType{},
-						Computed:    true,
-						Description: "Subnet description",
-					},
-					"dhcp_enabled": schema.BoolAttribute{
-						Computed:    true,
-						Description: "Whether DHCP is enabled",
-					},
-					"dns_nameservers": schema.ListAttribute{
-						ElementType: types.StringType,
-						Computed:    true,
-						Description: "DNS nameservers",
-					},
-					"gateway_ip": schema.StringAttribute{
-						CustomType:  ovhtypes.TfStringType{},
-						Computed:    true,
-						Description: "Default gateway IP address",
-					},
-					"host_routes": schema.ListNestedAttribute{
-						Computed:    true,
-						Description: "Static host routes",
-						NestedObject: schema.NestedAttributeObject{
-							Attributes: map[string]schema.Attribute{
-								"destination": schema.StringAttribute{
-									CustomType:  ovhtypes.TfStringType{},
-									Computed:    true,
-									Description: "Destination CIDR",
-								},
-								"next_hop": schema.StringAttribute{
-									CustomType:  ovhtypes.TfStringType{},
-									Computed:    true,
-									Description: "Next hop IP address",
-								},
-							},
-						},
-					},
-					"location": schema.SingleNestedAttribute{
-						Computed:    true,
-						Description: "Location details",
-						Attributes: map[string]schema.Attribute{
-							"region": schema.StringAttribute{
-								CustomType:  ovhtypes.TfStringType{},
-								Computed:    true,
-								Description: "Region code",
-							},
-						},
-					},
-				},
-			},
-		},
-	}
-}
-
-func (r *cloudNetworkPrivateVrackSubnetResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+func (r *cloudNetworkPrivateSubnetResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
 	splits := strings.Split(req.ID, "/")
 	if len(splits) != 3 {
-		resp.Diagnostics.AddError("Given ID is malformed", "ID must be formatted like the following: <service_name>/<network_id>/<subnet_id>")
+		resp.Diagnostics.AddError("Given ID is malformed", "ID must be formatted like the following: <project_id>/<network_id>/<id>")
 		return
 	}
 
-	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("service_name"), splits[0])...)
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("project_id"), splits[0])...)
 	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("network_id"), splits[1])...)
 	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("id"), splits[2])...)
 }
 
-func (r *cloudNetworkPrivateVrackSubnetResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
-	var data CloudSubnetModel
+func (r *cloudNetworkPrivateSubnetResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	var data, responseData CloudNetworkPrivateSubnetModel
 
+	// Read Terraform plan data into the model
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
 
-	createPayload := data.ToCreate()
+	base := "/v2/publicCloud/project/" + url.PathEscape(data.ProjectId.ValueString()) + "/network/" + url.PathEscape(data.NetworkId.ValueString()) + "/subnet"
 
-	endpoint := "/v2/publicCloud/project/" + url.PathEscape(data.ServiceName.ValueString()) + "/network/" + url.PathEscape(data.NetworkId.ValueString()) + "/subnet"
-
-	var responseData CloudSubnetAPIResponse
-	if err := r.config.OVHClient.Post(endpoint, createPayload, &responseData); err != nil {
+	if err := r.config.OVHClient.Post(base, data.ToCreate(), &responseData); err != nil {
 		resp.Diagnostics.AddError(
-			fmt.Sprintf("Error calling Post %s", endpoint),
+			fmt.Sprintf("Error calling Post %s", base),
 			err.Error(),
 		)
 		return
 	}
 
-	// Save state immediately so the resource ID is tracked even if the workflow fails
-	data.MergeWith(ctx, &responseData)
-	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+	// The response body does not carry the identity fields, re-attach them from
+	// the request-side model so the ID is tracked even if the wait below fails.
+	responseData.ProjectId = data.ProjectId
+	responseData.NetworkId = data.NetworkId
+	resp.Diagnostics.Append(resp.State.Set(ctx, &responseData)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
 
-	// Wait for subnet to be READY
-	_, err := r.waitForReady(ctx, data.ServiceName.ValueString(), data.NetworkId.ValueString(), responseData.Id)
-	if err != nil {
+	// Wait for the subnet to be READY. The backend recover step rewrites the
+	// targetSpec and checksum during this wait.
+	itemEndpoint := base + "/" + url.PathEscape(responseData.Id.ValueString())
+	if err := helpers.WaitForAPIv2ResourceStatusReady(ctx, r.config.OVHClient, itemEndpoint); err != nil {
+		resp.Diagnostics.AddError("Error waiting for subnet to be ready", err.Error())
+		return
+	}
+
+	// Read the final, post-recover state.
+	var finalData CloudNetworkPrivateSubnetModel
+	if err := r.config.OVHClient.Get(itemEndpoint, &finalData); err != nil {
 		resp.Diagnostics.AddError(
-			"Error waiting for subnet to be ready",
+			fmt.Sprintf("Error calling Get %s", itemEndpoint),
 			err.Error(),
 		)
 		return
 	}
 
-	// Read the final state
-	endpoint = "/v2/publicCloud/project/" + url.PathEscape(data.ServiceName.ValueString()) + "/network/" + url.PathEscape(data.NetworkId.ValueString()) + "/subnet/" + url.PathEscape(responseData.Id)
-	if err := r.config.OVHClient.Get(endpoint, &responseData); err != nil {
-		resp.Diagnostics.AddError(
-			fmt.Sprintf("Error calling Get %s", endpoint),
-			err.Error(),
-		)
-		return
-	}
+	finalData.ProjectId = data.ProjectId
+	finalData.NetworkId = data.NetworkId
 
-	data.MergeWith(ctx, &responseData)
-
-	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+	// Save data into Terraform state
+	resp.Diagnostics.Append(resp.State.Set(ctx, &finalData)...)
 }
 
-func (r *cloudNetworkPrivateVrackSubnetResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
-	var data CloudSubnetModel
+func (r *cloudNetworkPrivateSubnetResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	var data, responseData CloudNetworkPrivateSubnetModel
 
+	// Read Terraform prior state data into the model
 	resp.Diagnostics.Append(req.State.Get(ctx, &data)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
 
-	endpoint := "/v2/publicCloud/project/" + url.PathEscape(data.ServiceName.ValueString()) + "/network/" + url.PathEscape(data.NetworkId.ValueString()) + "/subnet/" + url.PathEscape(data.Id.ValueString())
+	endpoint := "/v2/publicCloud/project/" + url.PathEscape(data.ProjectId.ValueString()) + "/network/" + url.PathEscape(data.NetworkId.ValueString()) + "/subnet/" + url.PathEscape(data.Id.ValueString())
 
-	var responseData CloudSubnetAPIResponse
 	if err := r.config.OVHClient.Get(endpoint, &responseData); err != nil {
+		if errOvh, ok := err.(*ovh.APIError); ok && errOvh.Code == 404 {
+			resp.State.RemoveResource(ctx)
+			return
+		}
 		resp.Diagnostics.AddError(
 			fmt.Sprintf("Error calling Get %s", endpoint),
 			err.Error(),
@@ -330,30 +150,37 @@ func (r *cloudNetworkPrivateVrackSubnetResource) Read(ctx context.Context, req r
 		return
 	}
 
-	data.MergeWith(ctx, &responseData)
+	// Overwrite state with the API truth (re-attaching identity). We deliberately
+	// do not call the fill-only MergeWith: overwriting target_spec from the API is
+	// what surfaces drift.
+	responseData.ProjectId = data.ProjectId
+	responseData.NetworkId = data.NetworkId
 
-	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+	// Save updated data into Terraform state
+	resp.Diagnostics.Append(resp.State.Set(ctx, &responseData)...)
 }
 
-func (r *cloudNetworkPrivateVrackSubnetResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
-	var data, planData CloudSubnetModel
+func (r *cloudNetworkPrivateSubnetResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	var planData, state CloudNetworkPrivateSubnetModel
 
+	// Read Terraform plan data into the model
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &planData)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
 
-	resp.Diagnostics.Append(req.State.Get(ctx, &data)...)
+	// Read Terraform prior state data into the model
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
 
-	updatePayload := planData.ToUpdate(data.Checksum.ValueString())
+	// Use the latest post-READY checksum from state for the concurrency control.
+	planData.Checksum = state.Checksum
 
-	endpoint := "/v2/publicCloud/project/" + url.PathEscape(data.ServiceName.ValueString()) + "/network/" + url.PathEscape(data.NetworkId.ValueString()) + "/subnet/" + url.PathEscape(data.Id.ValueString())
+	endpoint := "/v2/publicCloud/project/" + url.PathEscape(state.ProjectId.ValueString()) + "/network/" + url.PathEscape(state.NetworkId.ValueString()) + "/subnet/" + url.PathEscape(state.Id.ValueString())
 
-	var responseData CloudSubnetAPIResponse
-	if err := r.config.OVHClient.Put(endpoint, updatePayload, &responseData); err != nil {
+	if err := r.config.OVHClient.Put(endpoint, planData.ToUpdate(), nil); err != nil {
 		resp.Diagnostics.AddError(
 			fmt.Sprintf("Error calling Put %s", endpoint),
 			err.Error(),
@@ -361,18 +188,15 @@ func (r *cloudNetworkPrivateVrackSubnetResource) Update(ctx context.Context, req
 		return
 	}
 
-	// Wait for subnet to be READY
-	_, err := r.waitForReady(ctx, data.ServiceName.ValueString(), data.NetworkId.ValueString(), data.Id.ValueString())
-	if err != nil {
-		resp.Diagnostics.AddError(
-			"Error waiting for subnet to be ready after update",
-			err.Error(),
-		)
+	// Wait for the subnet to be READY after the update.
+	if err := helpers.WaitForAPIv2ResourceStatusReady(ctx, r.config.OVHClient, endpoint); err != nil {
+		resp.Diagnostics.AddError("Error waiting for subnet to be ready after update", err.Error())
 		return
 	}
 
-	// Read the final state
-	if err := r.config.OVHClient.Get(endpoint, &responseData); err != nil {
+	// Read the final, post-recover state.
+	var finalData CloudNetworkPrivateSubnetModel
+	if err := r.config.OVHClient.Get(endpoint, &finalData); err != nil {
 		resp.Diagnostics.AddError(
 			fmt.Sprintf("Error calling Get %s", endpoint),
 			err.Error(),
@@ -380,20 +204,23 @@ func (r *cloudNetworkPrivateVrackSubnetResource) Update(ctx context.Context, req
 		return
 	}
 
-	planData.MergeWith(ctx, &responseData)
+	finalData.ProjectId = state.ProjectId
+	finalData.NetworkId = state.NetworkId
 
-	resp.Diagnostics.Append(resp.State.Set(ctx, &planData)...)
+	// Save updated data into Terraform state
+	resp.Diagnostics.Append(resp.State.Set(ctx, &finalData)...)
 }
 
-func (r *cloudNetworkPrivateVrackSubnetResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
-	var data CloudSubnetModel
+func (r *cloudNetworkPrivateSubnetResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	var data CloudNetworkPrivateSubnetModel
 
+	// Read Terraform prior state data into the model
 	resp.Diagnostics.Append(req.State.Get(ctx, &data)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
 
-	endpoint := "/v2/publicCloud/project/" + url.PathEscape(data.ServiceName.ValueString()) + "/network/" + url.PathEscape(data.NetworkId.ValueString()) + "/subnet/" + url.PathEscape(data.Id.ValueString())
+	endpoint := "/v2/publicCloud/project/" + url.PathEscape(data.ProjectId.ValueString()) + "/network/" + url.PathEscape(data.NetworkId.ValueString()) + "/subnet/" + url.PathEscape(data.Id.ValueString())
 
 	if err := r.config.OVHClient.Delete(endpoint, nil); err != nil {
 		if errOvh, ok := err.(*ovh.APIError); ok && errOvh.Code == 404 {
@@ -411,8 +238,7 @@ func (r *cloudNetworkPrivateVrackSubnetResource) Delete(ctx context.Context, req
 		Pending: []string{"DELETING"},
 		Target:  []string{"DELETED"},
 		Refresh: func() (interface{}, string, error) {
-			res := &CloudSubnetAPIResponse{}
-			endpoint := "/v2/publicCloud/project/" + url.PathEscape(data.ServiceName.ValueString()) + "/network/" + url.PathEscape(data.NetworkId.ValueString()) + "/subnet/" + url.PathEscape(data.Id.ValueString())
+			res := &CloudNetworkPrivateSubnetModel{}
 			err := r.config.OVHClient.GetWithContext(ctx, endpoint, res)
 			if err != nil {
 				if errOvh, ok := err.(*ovh.APIError); ok && errOvh.Code == 404 {
@@ -420,7 +246,7 @@ func (r *cloudNetworkPrivateVrackSubnetResource) Delete(ctx context.Context, req
 				}
 				return res, "", err
 			}
-			return res, res.ResourceStatus, nil
+			return res, res.ResourceStatus.ValueString(), nil
 		},
 		Timeout:    20 * time.Minute,
 		Delay:      10 * time.Second,
@@ -435,23 +261,574 @@ func (r *cloudNetworkPrivateVrackSubnetResource) Delete(ctx context.Context, req
 	}
 }
 
-func (r *cloudNetworkPrivateVrackSubnetResource) waitForReady(ctx context.Context, serviceName, networkId, subnetId string) (interface{}, error) {
-	stateConf := &retry.StateChangeConf{
-		Pending: []string{"CREATING", "UPDATING", "PENDING", "OUT_OF_SYNC"},
-		Target:  []string{"READY"},
-		Refresh: func() (interface{}, string, error) {
-			res := &CloudSubnetAPIResponse{}
-			endpoint := "/v2/publicCloud/project/" + url.PathEscape(serviceName) + "/network/" + url.PathEscape(networkId) + "/subnet/" + url.PathEscape(subnetId)
-			err := r.config.OVHClient.GetWithContext(ctx, endpoint, res)
-			if err != nil {
-				return res, "", err
-			}
-			return res, res.ResourceStatus, nil
+func CloudNetworkPrivateSubnetResourceSchema(ctx context.Context) schema.Schema {
+	attrs := map[string]schema.Attribute{
+		"checksum": schema.StringAttribute{
+			CustomType:          ovhtypes.TfStringType{},
+			Computed:            true,
+			Description:         "Computed hash representing the current target specification value",
+			MarkdownDescription: "Computed hash representing the current target specification value",
 		},
-		Timeout:    20 * time.Minute,
-		Delay:      10 * time.Second,
-		MinTimeout: 5 * time.Second,
+		"created_at": schema.StringAttribute{
+			CustomType:          ovhtypes.TfStringType{},
+			Computed:            true,
+			Description:         "Creation date of the subnet",
+			MarkdownDescription: "Creation date of the subnet",
+			PlanModifiers: []planmodifier.String{
+				stringplanmodifier.UseStateForUnknown(),
+			},
+		},
+		"current_state": schema.SingleNestedAttribute{
+			Attributes: map[string]schema.Attribute{
+				"allocation_pools": schema.ListNestedAttribute{
+					NestedObject: schema.NestedAttributeObject{
+						Attributes: map[string]schema.Attribute{
+							"end": schema.StringAttribute{
+								CustomType:          ovhtypes.TfStringType{},
+								Computed:            true,
+								Description:         "End IP address of the pool",
+								MarkdownDescription: "End IP address of the pool",
+							},
+							"start": schema.StringAttribute{
+								CustomType:          ovhtypes.TfStringType{},
+								Computed:            true,
+								Description:         "Start IP address of the pool",
+								MarkdownDescription: "Start IP address of the pool",
+							},
+						},
+						CustomType: CurrentStateAllocationPoolsType{
+							ObjectType: types.ObjectType{
+								AttrTypes: CurrentStateAllocationPoolsValue{}.AttributeTypes(ctx),
+							},
+						},
+					},
+					CustomType:          ovhtypes.NewTfListNestedType[CurrentStateAllocationPoolsValue](ctx),
+					Computed:            true,
+					Description:         "Allocation pools",
+					MarkdownDescription: "Allocation pools",
+				},
+				"cidr": schema.StringAttribute{
+					CustomType:          ovhtypes.TfStringType{},
+					Computed:            true,
+					Description:         "CIDR address range",
+					MarkdownDescription: "CIDR address range",
+				},
+				"description": schema.StringAttribute{
+					CustomType:          ovhtypes.TfStringType{},
+					Computed:            true,
+					Description:         "Subnet description",
+					MarkdownDescription: "Subnet description",
+				},
+				"dhcp_enabled": schema.BoolAttribute{
+					CustomType:          ovhtypes.TfBoolType{},
+					Computed:            true,
+					Description:         "Whether DHCP is enabled",
+					MarkdownDescription: "Whether DHCP is enabled",
+				},
+				"dns_nameservers": schema.ListAttribute{
+					CustomType:          ovhtypes.NewTfListNestedType[ovhtypes.TfStringValue](ctx),
+					Computed:            true,
+					Description:         "DNS nameservers",
+					MarkdownDescription: "DNS nameservers",
+				},
+				"gateway_ip": schema.StringAttribute{
+					CustomType:          ovhtypes.TfStringType{},
+					Computed:            true,
+					Description:         "Default gateway IP",
+					MarkdownDescription: "Default gateway IP",
+				},
+				"host_routes": schema.ListNestedAttribute{
+					NestedObject: schema.NestedAttributeObject{
+						Attributes: map[string]schema.Attribute{
+							"destination": schema.StringAttribute{
+								CustomType:          ovhtypes.TfStringType{},
+								Computed:            true,
+								Description:         "Destination CIDR",
+								MarkdownDescription: "Destination CIDR",
+							},
+							"next_hop": schema.StringAttribute{
+								CustomType:          ovhtypes.TfStringType{},
+								Computed:            true,
+								Description:         "Next hop IP address",
+								MarkdownDescription: "Next hop IP address",
+							},
+						},
+						CustomType: CurrentStateHostRoutesType{
+							ObjectType: types.ObjectType{
+								AttrTypes: CurrentStateHostRoutesValue{}.AttributeTypes(ctx),
+							},
+						},
+					},
+					CustomType:          ovhtypes.NewTfListNestedType[CurrentStateHostRoutesValue](ctx),
+					Computed:            true,
+					Description:         "Static host routes",
+					MarkdownDescription: "Static host routes",
+				},
+				"location": schema.SingleNestedAttribute{
+					Attributes: map[string]schema.Attribute{
+						"availability_zone": schema.StringAttribute{
+							CustomType:          ovhtypes.TfStringType{},
+							Computed:            true,
+							Description:         "Availability zone within the region",
+							MarkdownDescription: "Availability zone within the region",
+						},
+						"region": schema.StringAttribute{
+							CustomType:          ovhtypes.TfStringType{},
+							Computed:            true,
+							Description:         "Region code",
+							MarkdownDescription: "Region code",
+						},
+					},
+					CustomType: CurrentStateLocationType{
+						ObjectType: types.ObjectType{
+							AttrTypes: CurrentStateLocationValue{}.AttributeTypes(ctx),
+						},
+					},
+					Computed:            true,
+					Description:         "Location details",
+					MarkdownDescription: "Location details",
+				},
+				"name": schema.StringAttribute{
+					CustomType:          ovhtypes.TfStringType{},
+					Computed:            true,
+					Description:         "Subnet name",
+					MarkdownDescription: "Subnet name",
+				},
+			},
+			CustomType: CloudNetworkPrivateSubnetCurrentStateType{
+				ObjectType: types.ObjectType{
+					AttrTypes: CloudNetworkPrivateSubnetCurrentStateValue{}.AttributeTypes(ctx),
+				},
+			},
+			Computed:            true,
+			Description:         "Current state of the subnet",
+			MarkdownDescription: "Current state of the subnet",
+		},
+		"current_tasks": schema.ListNestedAttribute{
+			NestedObject: schema.NestedAttributeObject{
+				Attributes: map[string]schema.Attribute{
+					"errors": schema.ListNestedAttribute{
+						NestedObject: schema.NestedAttributeObject{
+							Attributes: map[string]schema.Attribute{
+								"message": schema.StringAttribute{
+									CustomType:          ovhtypes.TfStringType{},
+									Computed:            true,
+									Description:         "Error description",
+									MarkdownDescription: "Error description",
+								},
+							},
+							CustomType: CurrentTasksErrorsType{
+								ObjectType: types.ObjectType{
+									AttrTypes: CurrentTasksErrorsValue{}.AttributeTypes(ctx),
+								},
+							},
+						},
+						CustomType:          ovhtypes.NewTfListNestedType[CurrentTasksErrorsValue](ctx),
+						Computed:            true,
+						Description:         "Errors that occured on the task",
+						MarkdownDescription: "Errors that occured on the task",
+					},
+					"id": schema.StringAttribute{
+						CustomType:          ovhtypes.TfStringType{},
+						Computed:            true,
+						Description:         "Identifier of the current task",
+						MarkdownDescription: "Identifier of the current task",
+					},
+					"link": schema.StringAttribute{
+						CustomType:          ovhtypes.TfStringType{},
+						Computed:            true,
+						Description:         "Link to the task details",
+						MarkdownDescription: "Link to the task details",
+					},
+					"status": schema.StringAttribute{
+						CustomType:          ovhtypes.TfStringType{},
+						Computed:            true,
+						Description:         "Current global status of the current task",
+						MarkdownDescription: "Current global status of the current task",
+					},
+					"type": schema.StringAttribute{
+						CustomType:          ovhtypes.TfStringType{},
+						Computed:            true,
+						Description:         "Type of the current task",
+						MarkdownDescription: "Type of the current task",
+					},
+				},
+				CustomType: CloudNetworkPrivateSubnetCurrentTasksType{
+					ObjectType: types.ObjectType{
+						AttrTypes: CloudNetworkPrivateSubnetCurrentTasksValue{}.AttributeTypes(ctx),
+					},
+				},
+			},
+			CustomType:          ovhtypes.NewTfListNestedType[CloudNetworkPrivateSubnetCurrentTasksValue](ctx),
+			Computed:            true,
+			Description:         "Ongoing asynchronous tasks related to the subnet",
+			MarkdownDescription: "Ongoing asynchronous tasks related to the subnet",
+		},
+		"id": schema.StringAttribute{
+			CustomType:          ovhtypes.TfStringType{},
+			Computed:            true,
+			Description:         "Unique identifier of the subnet",
+			MarkdownDescription: "Unique identifier of the subnet",
+			PlanModifiers: []planmodifier.String{
+				stringplanmodifier.UseStateForUnknown(),
+			},
+		},
+		"network_id": schema.StringAttribute{
+			CustomType:          ovhtypes.TfStringType{},
+			Required:            true,
+			Description:         "Network ID",
+			MarkdownDescription: "Network ID",
+			PlanModifiers: []planmodifier.String{
+				stringplanmodifier.RequiresReplace(),
+			},
+		},
+		"project_id": schema.StringAttribute{
+			CustomType:          ovhtypes.TfStringType{},
+			Required:            true,
+			Description:         "Project ID",
+			MarkdownDescription: "Project ID",
+			PlanModifiers: []planmodifier.String{
+				stringplanmodifier.RequiresReplace(),
+			},
+		},
+		"resource_status": schema.StringAttribute{
+			CustomType:          ovhtypes.TfStringType{},
+			Computed:            true,
+			Description:         "Subnet readiness in the system",
+			MarkdownDescription: "Subnet readiness in the system",
+			PlanModifiers: []planmodifier.String{
+				OutOfSyncPlanModifier(),
+			},
+		},
+		"allocation_pools": schema.ListNestedAttribute{
+			NestedObject: schema.NestedAttributeObject{
+				Attributes: map[string]schema.Attribute{
+					"end": schema.StringAttribute{
+						CustomType:          ovhtypes.TfStringType{},
+						Optional:            true,
+						Computed:            true,
+						Description:         "End IP address of the pool",
+						MarkdownDescription: "End IP address of the pool",
+					},
+					"start": schema.StringAttribute{
+						CustomType:          ovhtypes.TfStringType{},
+						Optional:            true,
+						Computed:            true,
+						Description:         "Start IP address of the pool",
+						MarkdownDescription: "Start IP address of the pool",
+					},
+				},
+				CustomType: TargetSpecAllocationPoolsType{
+					ObjectType: types.ObjectType{
+						AttrTypes: TargetSpecAllocationPoolsValue{}.AttributeTypes(ctx),
+					},
+				},
+			},
+			CustomType:          ovhtypes.NewTfListNestedType[TargetSpecAllocationPoolsValue](ctx),
+			Optional:            true,
+			Computed:            true,
+			Description:         "IP address allocation pools",
+			MarkdownDescription: "IP address allocation pools",
+			PlanModifiers: []planmodifier.List{
+				listplanmodifier.UseStateForUnknown(),
+			},
+		},
+		"cidr": schema.StringAttribute{
+			CustomType:          ovhtypes.TfStringType{},
+			Required:            true,
+			Description:         "CIDR address range (immutable after creation)",
+			MarkdownDescription: "CIDR address range (immutable after creation)",
+			PlanModifiers: []planmodifier.String{
+				stringplanmodifier.RequiresReplace(),
+			},
+		},
+		"description": schema.StringAttribute{
+			CustomType:          ovhtypes.TfStringType{},
+			Optional:            true,
+			Description:         "Subnet description",
+			MarkdownDescription: "Subnet description",
+		},
+		"dhcp_enabled": schema.BoolAttribute{
+			CustomType:          ovhtypes.TfBoolType{},
+			Optional:            true,
+			Computed:            true,
+			Description:         "Whether DHCP is enabled",
+			MarkdownDescription: "Whether DHCP is enabled",
+			PlanModifiers: []planmodifier.Bool{
+				boolplanmodifier.UseStateForUnknown(),
+			},
+		},
+		"dns_nameservers": schema.ListAttribute{
+			CustomType:          ovhtypes.NewTfListNestedType[ovhtypes.TfStringValue](ctx),
+			Optional:            true,
+			Description:         "DNS nameservers for the subnet",
+			MarkdownDescription: "DNS nameservers for the subnet",
+		},
+		"gateway_ip": schema.StringAttribute{
+			CustomType:          ovhtypes.TfStringType{},
+			Optional:            true,
+			Computed:            true,
+			Description:         "Default gateway IP address",
+			MarkdownDescription: "Default gateway IP address",
+			PlanModifiers: []planmodifier.String{
+				stringplanmodifier.UseStateForUnknown(),
+			},
+		},
+		"location": schema.SingleNestedAttribute{
+			Attributes: map[string]schema.Attribute{
+				"availability_zone": schema.StringAttribute{
+					CustomType:          ovhtypes.TfStringType{},
+					Optional:            true,
+					Description:         "Availability zone within the region",
+					MarkdownDescription: "Availability zone within the region",
+				},
+				"region": schema.StringAttribute{
+					CustomType:          ovhtypes.TfStringType{},
+					Required:            true,
+					Description:         "Region code",
+					MarkdownDescription: "Region code",
+					PlanModifiers: []planmodifier.String{
+						stringplanmodifier.RequiresReplace(),
+					},
+				},
+			},
+			CustomType: TargetSpecLocationType{
+				ObjectType: types.ObjectType{
+					AttrTypes: TargetSpecLocationValue{}.AttributeTypes(ctx),
+				},
+			},
+			Required:            true,
+			Description:         "Target location",
+			MarkdownDescription: "Target location",
+		},
+		"name": schema.StringAttribute{
+			CustomType:          ovhtypes.TfStringType{},
+			Required:            true,
+			Description:         "Subnet name",
+			MarkdownDescription: "Subnet name",
+		},
+		"updated_at": schema.StringAttribute{
+			CustomType:          ovhtypes.TfStringType{},
+			Computed:            true,
+			Description:         "Last update date of the subnet",
+			MarkdownDescription: "Last update date of the subnet",
+		},
 	}
 
-	return stateConf.WaitForStateContext(ctx)
+	return schema.Schema{
+		Description: "",
+		Attributes:  attrs,
+	}
+}
+
+type CloudNetworkPrivateSubnetModel struct {
+	Checksum       ovhtypes.TfStringValue                                                 `tfsdk:"checksum" json:"checksum"`
+	CreatedAt      ovhtypes.TfStringValue                                                 `tfsdk:"created_at" json:"createdAt"`
+	CurrentState   CloudNetworkPrivateSubnetCurrentStateValue                             `tfsdk:"current_state" json:"currentState"`
+	CurrentTasks   ovhtypes.TfListNestedValue[CloudNetworkPrivateSubnetCurrentTasksValue] `tfsdk:"current_tasks" json:"currentTasks"`
+	Id             ovhtypes.TfStringValue                                                 `tfsdk:"id" json:"id"`
+	NetworkId      ovhtypes.TfStringValue                                                 `tfsdk:"network_id" json:"networkId"`
+	ProjectId      ovhtypes.TfStringValue                                                 `tfsdk:"project_id" json:"projectId"`
+	ResourceStatus ovhtypes.TfStringValue                                                 `tfsdk:"resource_status" json:"resourceStatus"`
+	UpdatedAt      ovhtypes.TfStringValue                                                 `tfsdk:"updated_at" json:"updatedAt"`
+
+	// Target-spec fields, lifted from the former nested target_spec object to
+	// the resource root. They carry json:"-" because the targetSpec object is
+	// (un)marshaled explicitly in MarshalJSON/UnmarshalJSON via the
+	// CloudNetworkPrivateSubnetTargetSpecValue DTO, never at the JSON root.
+	AllocationPools ovhtypes.TfListNestedValue[TargetSpecAllocationPoolsValue] `tfsdk:"allocation_pools" json:"-"`
+	Cidr            ovhtypes.TfStringValue                                     `tfsdk:"cidr" json:"-"`
+	Description     ovhtypes.TfStringValue                                     `tfsdk:"description" json:"-"`
+	DhcpEnabled     ovhtypes.TfBoolValue                                       `tfsdk:"dhcp_enabled" json:"-"`
+	DnsNameservers  ovhtypes.TfListNestedValue[ovhtypes.TfStringValue]         `tfsdk:"dns_nameservers" json:"-"`
+	GatewayIp       ovhtypes.TfStringValue                                     `tfsdk:"gateway_ip" json:"-"`
+	Location        TargetSpecLocationValue                                    `tfsdk:"location" json:"-"`
+	Name            ovhtypes.TfStringValue                                     `tfsdk:"name" json:"-"`
+}
+
+func (v *CloudNetworkPrivateSubnetModel) MergeWith(other *CloudNetworkPrivateSubnetModel) {
+
+	if (v.Checksum.IsUnknown() || v.Checksum.IsNull()) && !other.Checksum.IsUnknown() {
+		v.Checksum = other.Checksum
+	}
+
+	if (v.CreatedAt.IsUnknown() || v.CreatedAt.IsNull()) && !other.CreatedAt.IsUnknown() {
+		v.CreatedAt = other.CreatedAt
+	}
+
+	if (v.CurrentState.IsUnknown() || v.CurrentState.IsNull()) && !other.CurrentState.IsUnknown() {
+		v.CurrentState = other.CurrentState
+	}
+
+	if (v.CurrentTasks.IsUnknown() || v.CurrentTasks.IsNull()) && !other.CurrentTasks.IsUnknown() {
+		v.CurrentTasks = other.CurrentTasks
+	}
+
+	if (v.Id.IsUnknown() || v.Id.IsNull()) && !other.Id.IsUnknown() {
+		v.Id = other.Id
+	}
+
+	if (v.NetworkId.IsUnknown() || v.NetworkId.IsNull()) && !other.NetworkId.IsUnknown() {
+		v.NetworkId = other.NetworkId
+	}
+
+	if (v.ProjectId.IsUnknown() || v.ProjectId.IsNull()) && !other.ProjectId.IsUnknown() {
+		v.ProjectId = other.ProjectId
+	}
+
+	if (v.ResourceStatus.IsUnknown() || v.ResourceStatus.IsNull()) && !other.ResourceStatus.IsUnknown() {
+		v.ResourceStatus = other.ResourceStatus
+	}
+
+	if (v.UpdatedAt.IsUnknown() || v.UpdatedAt.IsNull()) && !other.UpdatedAt.IsUnknown() {
+		v.UpdatedAt = other.UpdatedAt
+	}
+
+	// Lifted target-spec fields.
+	if (v.AllocationPools.IsUnknown() || v.AllocationPools.IsNull()) && !other.AllocationPools.IsUnknown() {
+		v.AllocationPools = other.AllocationPools
+	}
+
+	if (v.Cidr.IsUnknown() || v.Cidr.IsNull()) && !other.Cidr.IsUnknown() {
+		v.Cidr = other.Cidr
+	}
+
+	if (v.Description.IsUnknown() || v.Description.IsNull()) && !other.Description.IsUnknown() {
+		v.Description = other.Description
+	}
+
+	if (v.DhcpEnabled.IsUnknown() || v.DhcpEnabled.IsNull()) && !other.DhcpEnabled.IsUnknown() {
+		v.DhcpEnabled = other.DhcpEnabled
+	}
+
+	if (v.DnsNameservers.IsUnknown() || v.DnsNameservers.IsNull()) && !other.DnsNameservers.IsUnknown() {
+		v.DnsNameservers = other.DnsNameservers
+	}
+
+	if (v.GatewayIp.IsUnknown() || v.GatewayIp.IsNull()) && !other.GatewayIp.IsUnknown() {
+		v.GatewayIp = other.GatewayIp
+	}
+
+	if v.Location.IsUnknown() && !other.Location.IsUnknown() {
+		v.Location = other.Location
+	} else if !other.Location.IsUnknown() {
+		v.Location.MergeWith(&other.Location)
+	}
+
+	if (v.Name.IsUnknown() || v.Name.IsNull()) && !other.Name.IsUnknown() {
+		v.Name = other.Name
+	}
+
+}
+
+// targetSpecValue assembles the lifted root fields back into the
+// CloudNetworkPrivateSubnetTargetSpecValue DTO used for JSON (un)marshaling.
+func (v CloudNetworkPrivateSubnetModel) targetSpecValue() CloudNetworkPrivateSubnetTargetSpecValue {
+	return CloudNetworkPrivateSubnetTargetSpecValue{
+		AllocationPools: v.AllocationPools,
+		Cidr:            v.Cidr,
+		Description:     v.Description,
+		DhcpEnabled:     v.DhcpEnabled,
+		DnsNameservers:  v.DnsNameservers,
+		GatewayIp:       v.GatewayIp,
+		Location:        v.Location,
+		Name:            v.Name,
+		state:           attr.ValueStateKnown,
+	}
+}
+
+func (v CloudNetworkPrivateSubnetModel) ToCreate() *CloudNetworkPrivateSubnetModel {
+	res := &CloudNetworkPrivateSubnetModel{}
+
+	created := v.targetSpecValue().ToCreate()
+	res.AllocationPools = created.AllocationPools
+	res.Cidr = created.Cidr
+	res.Description = created.Description
+	res.DhcpEnabled = created.DhcpEnabled
+	res.DnsNameservers = created.DnsNameservers
+	res.GatewayIp = created.GatewayIp
+	res.Location = created.Location
+	res.Name = created.Name
+
+	return res
+}
+
+func (v CloudNetworkPrivateSubnetModel) ToUpdate() *CloudNetworkPrivateSubnetModel {
+	res := &CloudNetworkPrivateSubnetModel{}
+
+	if !v.Checksum.IsUnknown() {
+		res.Checksum = v.Checksum
+	}
+
+	updated := v.targetSpecValue().ToUpdate()
+	res.AllocationPools = updated.AllocationPools
+	res.Cidr = updated.Cidr
+	res.Description = updated.Description
+	res.DhcpEnabled = updated.DhcpEnabled
+	res.DnsNameservers = updated.DnsNameservers
+	res.GatewayIp = updated.GatewayIp
+	res.Location = updated.Location
+	res.Name = updated.Name
+
+	return res
+}
+
+func (v *CloudNetworkPrivateSubnetModel) MarshalJSON() ([]byte, error) {
+	toMarshal := map[string]any{}
+	if !v.Checksum.IsNull() && !v.Checksum.IsUnknown() {
+		toMarshal["checksum"] = v.Checksum
+	}
+
+	// The lifted root fields are re-nested under targetSpec for the wire format.
+	// The DTO's own MarshalJSON only emits the non-null/non-unknown sub-fields.
+	targetSpec := v.targetSpecValue()
+	toMarshal["targetSpec"] = &targetSpec
+
+	return json.Marshal(toMarshal)
+}
+
+// UnmarshalJSON decodes the API envelope into the flat model. The nested
+// targetSpec object is decoded into the lifted root fields via the
+// CloudNetworkPrivateSubnetTargetSpecValue DTO; currentState / currentTasks
+// keep their own value-type decoders.
+func (v *CloudNetworkPrivateSubnetModel) UnmarshalJSON(data []byte) error {
+	var shadow struct {
+		Checksum       ovhtypes.TfStringValue                                                 `json:"checksum"`
+		CreatedAt      ovhtypes.TfStringValue                                                 `json:"createdAt"`
+		CurrentState   CloudNetworkPrivateSubnetCurrentStateValue                             `json:"currentState"`
+		CurrentTasks   ovhtypes.TfListNestedValue[CloudNetworkPrivateSubnetCurrentTasksValue] `json:"currentTasks"`
+		Id             ovhtypes.TfStringValue                                                 `json:"id"`
+		NetworkId      ovhtypes.TfStringValue                                                 `json:"networkId"`
+		ProjectId      ovhtypes.TfStringValue                                                 `json:"projectId"`
+		ResourceStatus ovhtypes.TfStringValue                                                 `json:"resourceStatus"`
+		UpdatedAt      ovhtypes.TfStringValue                                                 `json:"updatedAt"`
+		TargetSpec     *CloudNetworkPrivateSubnetTargetSpecValue                              `json:"targetSpec"`
+	}
+
+	if err := json.Unmarshal(data, &shadow); err != nil {
+		return err
+	}
+
+	v.Checksum = shadow.Checksum
+	v.CreatedAt = shadow.CreatedAt
+	v.CurrentState = shadow.CurrentState
+	v.CurrentTasks = shadow.CurrentTasks
+	v.Id = shadow.Id
+	v.NetworkId = shadow.NetworkId
+	v.ProjectId = shadow.ProjectId
+	v.ResourceStatus = shadow.ResourceStatus
+	v.UpdatedAt = shadow.UpdatedAt
+
+	if shadow.TargetSpec != nil {
+		v.AllocationPools = shadow.TargetSpec.AllocationPools
+		v.Cidr = shadow.TargetSpec.Cidr
+		v.Description = shadow.TargetSpec.Description
+		v.DhcpEnabled = shadow.TargetSpec.DhcpEnabled
+		v.DnsNameservers = shadow.TargetSpec.DnsNameservers
+		v.GatewayIp = shadow.TargetSpec.GatewayIp
+		v.Location = shadow.TargetSpec.Location
+		v.Name = shadow.TargetSpec.Name
+	}
+
+	return nil
 }

--- a/ovh/resource_cloud_network_private_vrack_subnet.go
+++ b/ovh/resource_cloud_network_private_vrack_subnet.go
@@ -65,11 +65,11 @@ func (r *cloudNetworkPrivateSubnetResource) Schema(ctx context.Context, req reso
 func (r *cloudNetworkPrivateSubnetResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
 	splits := strings.Split(req.ID, "/")
 	if len(splits) != 3 {
-		resp.Diagnostics.AddError("Given ID is malformed", "ID must be formatted like the following: <project_id>/<network_id>/<id>")
+		resp.Diagnostics.AddError("Given ID is malformed", "ID must be formatted like the following: <service_name>/<network_id>/<id>")
 		return
 	}
 
-	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("project_id"), splits[0])...)
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("service_name"), splits[0])...)
 	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("network_id"), splits[1])...)
 	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("id"), splits[2])...)
 }
@@ -83,7 +83,7 @@ func (r *cloudNetworkPrivateSubnetResource) Create(ctx context.Context, req reso
 		return
 	}
 
-	base := "/v2/publicCloud/project/" + url.PathEscape(data.ProjectId.ValueString()) + "/network/" + url.PathEscape(data.NetworkId.ValueString()) + "/subnet"
+	base := "/v2/publicCloud/project/" + url.PathEscape(data.ServiceName.ValueString()) + "/network/" + url.PathEscape(data.NetworkId.ValueString()) + "/subnet"
 
 	if err := r.config.OVHClient.Post(base, data.ToCreate(), &responseData); err != nil {
 		resp.Diagnostics.AddError(
@@ -95,7 +95,7 @@ func (r *cloudNetworkPrivateSubnetResource) Create(ctx context.Context, req reso
 
 	// The response body does not carry the identity fields, re-attach them from
 	// the request-side model so the ID is tracked even if the wait below fails.
-	responseData.ProjectId = data.ProjectId
+	responseData.ServiceName = data.ServiceName
 	responseData.NetworkId = data.NetworkId
 	resp.Diagnostics.Append(resp.State.Set(ctx, &responseData)...)
 	if resp.Diagnostics.HasError() {
@@ -120,7 +120,7 @@ func (r *cloudNetworkPrivateSubnetResource) Create(ctx context.Context, req reso
 		return
 	}
 
-	finalData.ProjectId = data.ProjectId
+	finalData.ServiceName = data.ServiceName
 	finalData.NetworkId = data.NetworkId
 
 	// Save data into Terraform state
@@ -136,7 +136,7 @@ func (r *cloudNetworkPrivateSubnetResource) Read(ctx context.Context, req resour
 		return
 	}
 
-	endpoint := "/v2/publicCloud/project/" + url.PathEscape(data.ProjectId.ValueString()) + "/network/" + url.PathEscape(data.NetworkId.ValueString()) + "/subnet/" + url.PathEscape(data.Id.ValueString())
+	endpoint := "/v2/publicCloud/project/" + url.PathEscape(data.ServiceName.ValueString()) + "/network/" + url.PathEscape(data.NetworkId.ValueString()) + "/subnet/" + url.PathEscape(data.Id.ValueString())
 
 	if err := r.config.OVHClient.Get(endpoint, &responseData); err != nil {
 		if errOvh, ok := err.(*ovh.APIError); ok && errOvh.Code == 404 {
@@ -153,7 +153,7 @@ func (r *cloudNetworkPrivateSubnetResource) Read(ctx context.Context, req resour
 	// Overwrite state with the API truth (re-attaching identity). We deliberately
 	// do not call the fill-only MergeWith: overwriting target_spec from the API is
 	// what surfaces drift.
-	responseData.ProjectId = data.ProjectId
+	responseData.ServiceName = data.ServiceName
 	responseData.NetworkId = data.NetworkId
 
 	// Save updated data into Terraform state
@@ -178,7 +178,7 @@ func (r *cloudNetworkPrivateSubnetResource) Update(ctx context.Context, req reso
 	// Use the latest post-READY checksum from state for the concurrency control.
 	planData.Checksum = state.Checksum
 
-	endpoint := "/v2/publicCloud/project/" + url.PathEscape(state.ProjectId.ValueString()) + "/network/" + url.PathEscape(state.NetworkId.ValueString()) + "/subnet/" + url.PathEscape(state.Id.ValueString())
+	endpoint := "/v2/publicCloud/project/" + url.PathEscape(state.ServiceName.ValueString()) + "/network/" + url.PathEscape(state.NetworkId.ValueString()) + "/subnet/" + url.PathEscape(state.Id.ValueString())
 
 	if err := r.config.OVHClient.Put(endpoint, planData.ToUpdate(), nil); err != nil {
 		resp.Diagnostics.AddError(
@@ -204,7 +204,7 @@ func (r *cloudNetworkPrivateSubnetResource) Update(ctx context.Context, req reso
 		return
 	}
 
-	finalData.ProjectId = state.ProjectId
+	finalData.ServiceName = state.ServiceName
 	finalData.NetworkId = state.NetworkId
 
 	// Save updated data into Terraform state
@@ -220,7 +220,7 @@ func (r *cloudNetworkPrivateSubnetResource) Delete(ctx context.Context, req reso
 		return
 	}
 
-	endpoint := "/v2/publicCloud/project/" + url.PathEscape(data.ProjectId.ValueString()) + "/network/" + url.PathEscape(data.NetworkId.ValueString()) + "/subnet/" + url.PathEscape(data.Id.ValueString())
+	endpoint := "/v2/publicCloud/project/" + url.PathEscape(data.ServiceName.ValueString()) + "/network/" + url.PathEscape(data.NetworkId.ValueString()) + "/subnet/" + url.PathEscape(data.Id.ValueString())
 
 	if err := r.config.OVHClient.Delete(endpoint, nil); err != nil {
 		if errOvh, ok := err.(*ovh.APIError); ok && errOvh.Code == 404 {
@@ -482,11 +482,11 @@ func CloudNetworkPrivateSubnetResourceSchema(ctx context.Context) schema.Schema 
 				stringplanmodifier.RequiresReplace(),
 			},
 		},
-		"project_id": schema.StringAttribute{
+		"service_name": schema.StringAttribute{
 			CustomType:          ovhtypes.TfStringType{},
 			Required:            true,
-			Description:         "Project ID",
-			MarkdownDescription: "Project ID",
+			Description:         "Service name",
+			MarkdownDescription: "Service name",
 			PlanModifiers: []planmodifier.String{
 				stringplanmodifier.RequiresReplace(),
 			},
@@ -628,7 +628,7 @@ type CloudNetworkPrivateSubnetModel struct {
 	CurrentTasks   ovhtypes.TfListNestedValue[CloudNetworkPrivateSubnetCurrentTasksValue] `tfsdk:"current_tasks" json:"currentTasks"`
 	Id             ovhtypes.TfStringValue                                                 `tfsdk:"id" json:"id"`
 	NetworkId      ovhtypes.TfStringValue                                                 `tfsdk:"network_id" json:"networkId"`
-	ProjectId      ovhtypes.TfStringValue                                                 `tfsdk:"project_id" json:"projectId"`
+	ServiceName    ovhtypes.TfStringValue                                                 `tfsdk:"service_name" json:"projectId"`
 	ResourceStatus ovhtypes.TfStringValue                                                 `tfsdk:"resource_status" json:"resourceStatus"`
 	UpdatedAt      ovhtypes.TfStringValue                                                 `tfsdk:"updated_at" json:"updatedAt"`
 
@@ -672,8 +672,8 @@ func (v *CloudNetworkPrivateSubnetModel) MergeWith(other *CloudNetworkPrivateSub
 		v.NetworkId = other.NetworkId
 	}
 
-	if (v.ProjectId.IsUnknown() || v.ProjectId.IsNull()) && !other.ProjectId.IsUnknown() {
-		v.ProjectId = other.ProjectId
+	if (v.ServiceName.IsUnknown() || v.ServiceName.IsNull()) && !other.ServiceName.IsUnknown() {
+		v.ServiceName = other.ServiceName
 	}
 
 	if (v.ResourceStatus.IsUnknown() || v.ResourceStatus.IsNull()) && !other.ResourceStatus.IsUnknown() {
@@ -799,7 +799,7 @@ func (v *CloudNetworkPrivateSubnetModel) UnmarshalJSON(data []byte) error {
 		CurrentTasks   ovhtypes.TfListNestedValue[CloudNetworkPrivateSubnetCurrentTasksValue] `json:"currentTasks"`
 		Id             ovhtypes.TfStringValue                                                 `json:"id"`
 		NetworkId      ovhtypes.TfStringValue                                                 `json:"networkId"`
-		ProjectId      ovhtypes.TfStringValue                                                 `json:"projectId"`
+		ServiceName    ovhtypes.TfStringValue                                                 `json:"projectId"`
 		ResourceStatus ovhtypes.TfStringValue                                                 `json:"resourceStatus"`
 		UpdatedAt      ovhtypes.TfStringValue                                                 `json:"updatedAt"`
 		TargetSpec     *CloudNetworkPrivateSubnetTargetSpecValue                              `json:"targetSpec"`
@@ -815,7 +815,7 @@ func (v *CloudNetworkPrivateSubnetModel) UnmarshalJSON(data []byte) error {
 	v.CurrentTasks = shadow.CurrentTasks
 	v.Id = shadow.Id
 	v.NetworkId = shadow.NetworkId
-	v.ProjectId = shadow.ProjectId
+	v.ServiceName = shadow.ServiceName
 	v.ResourceStatus = shadow.ResourceStatus
 	v.UpdatedAt = shadow.UpdatedAt
 

--- a/ovh/resource_cloud_network_private_vrack_subnet.go
+++ b/ovh/resource_cloud_network_private_vrack_subnet.go
@@ -1,0 +1,457 @@
+package ovh
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
+	"github.com/ovh/go-ovh/ovh"
+	ovhtypes "github.com/ovh/terraform-provider-ovh/v2/ovh/types"
+)
+
+var (
+	_ resource.Resource                = (*cloudNetworkPrivateVrackSubnetResource)(nil)
+	_ resource.ResourceWithConfigure   = (*cloudNetworkPrivateVrackSubnetResource)(nil)
+	_ resource.ResourceWithImportState = (*cloudNetworkPrivateVrackSubnetResource)(nil)
+)
+
+func NewCloudNetworkPrivateVrackSubnetResource() resource.Resource {
+	return &cloudNetworkPrivateVrackSubnetResource{}
+}
+
+type cloudNetworkPrivateVrackSubnetResource struct {
+	config *Config
+}
+
+func (r *cloudNetworkPrivateVrackSubnetResource) Metadata(ctx context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_cloud_network_private_vrack_subnet"
+}
+
+func (r *cloudNetworkPrivateVrackSubnetResource) Configure(ctx context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+
+	config, ok := req.ProviderData.(*Config)
+	if !ok {
+		resp.Diagnostics.AddError(
+			"Unexpected Resource Configure Type",
+			fmt.Sprintf("Expected *Config, got: %T. Please report this issue to the provider developers.", req.ProviderData),
+		)
+		return
+	}
+
+	r.config = config
+}
+
+var subnetMutableAttrs = MutableAttrs{
+	Strings: []string{"name", "description", "gateway_ip"},
+	Bools:   []string{"dhcp_enabled"},
+	Lists:   []string{"dns_nameservers", "allocation_pools"},
+}
+
+func (r *cloudNetworkPrivateVrackSubnetResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Description: "Creates a subnet in a private network (vRack) in a public cloud project using the v2 API.",
+		Attributes: map[string]schema.Attribute{
+			// Required attributes
+			"service_name": schema.StringAttribute{
+				CustomType:  ovhtypes.TfStringType{},
+				Required:    true,
+				Description: "Service name of the resource representing the id of the cloud project",
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+			},
+			"network_id": schema.StringAttribute{
+				CustomType:  ovhtypes.TfStringType{},
+				Required:    true,
+				Description: "Network ID of the parent private network",
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+			},
+			"name": schema.StringAttribute{
+				CustomType:  ovhtypes.TfStringType{},
+				Required:    true,
+				Description: "Subnet name",
+			},
+			"cidr": schema.StringAttribute{
+				CustomType:  ovhtypes.TfStringType{},
+				Required:    true,
+				Description: "CIDR address range for the subnet",
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+			},
+			"region": schema.StringAttribute{
+				CustomType:  ovhtypes.TfStringType{},
+				Required:    true,
+				Description: "Region where the subnet will be created",
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+			},
+
+			// Optional attributes
+			"description": schema.StringAttribute{
+				CustomType:  ovhtypes.TfStringType{},
+				Optional:    true,
+				Description: "Subnet description",
+			},
+			"dhcp_enabled": schema.BoolAttribute{
+				Optional:    true,
+				Description: "Whether DHCP is enabled on the subnet",
+			},
+			"dns_nameservers": schema.ListAttribute{
+				ElementType: types.StringType,
+				Optional:    true,
+				Description: "DNS nameservers for the subnet",
+			},
+			"gateway_ip": schema.StringAttribute{
+				CustomType:  ovhtypes.TfStringType{},
+				Optional:    true,
+				Description: "Default gateway IP address",
+			},
+			"allocation_pools": schema.ListNestedAttribute{
+				Optional:    true,
+				Description: "IP address allocation pools",
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]schema.Attribute{
+						"start": schema.StringAttribute{
+							CustomType:  ovhtypes.TfStringType{},
+							Required:    true,
+							Description: "Start IP address of the pool",
+						},
+						"end": schema.StringAttribute{
+							CustomType:  ovhtypes.TfStringType{},
+							Required:    true,
+							Description: "End IP address of the pool",
+						},
+					},
+				},
+			},
+
+			// Computed attributes
+			"id": schema.StringAttribute{
+				CustomType:  ovhtypes.TfStringType{},
+				Computed:    true,
+				Description: "Subnet ID",
+			},
+			"checksum": schema.StringAttribute{
+				CustomType:  ovhtypes.TfStringType{},
+				Computed:    true,
+				Description: "Computed hash representing the current target specification value",
+				PlanModifiers: []planmodifier.String{
+					UnknownDuringUpdateStringModifier(subnetMutableAttrs),
+				},
+			},
+			"created_at": schema.StringAttribute{
+				CustomType:  ovhtypes.TfStringType{},
+				Computed:    true,
+				Description: "Creation date of the subnet",
+			},
+			"updated_at": schema.StringAttribute{
+				CustomType:  ovhtypes.TfStringType{},
+				Computed:    true,
+				Description: "Last update date of the subnet",
+				PlanModifiers: []planmodifier.String{
+					UnknownDuringUpdateStringModifier(subnetMutableAttrs),
+				},
+			},
+			"resource_status": schema.StringAttribute{
+				CustomType:  ovhtypes.TfStringType{},
+				Computed:    true,
+				Description: "Subnet readiness in the system (CREATING, DELETING, ERROR, OUT_OF_SYNC, READY, UPDATING)",
+				PlanModifiers: []planmodifier.String{
+					OutOfSyncPlanModifier(),
+				},
+			},
+
+			// Current state (computed, read-only)
+			"current_state": schema.SingleNestedAttribute{
+				Computed:    true,
+				Description: "Current state of the subnet",
+				PlanModifiers: []planmodifier.Object{
+					UnknownDuringUpdateObjectModifier(subnetMutableAttrs),
+				},
+				Attributes: map[string]schema.Attribute{
+					"name": schema.StringAttribute{
+						CustomType:  ovhtypes.TfStringType{},
+						Computed:    true,
+						Description: "Subnet name",
+					},
+					"cidr": schema.StringAttribute{
+						CustomType:  ovhtypes.TfStringType{},
+						Computed:    true,
+						Description: "CIDR address range",
+					},
+					"description": schema.StringAttribute{
+						CustomType:  ovhtypes.TfStringType{},
+						Computed:    true,
+						Description: "Subnet description",
+					},
+					"dhcp_enabled": schema.BoolAttribute{
+						Computed:    true,
+						Description: "Whether DHCP is enabled",
+					},
+					"dns_nameservers": schema.ListAttribute{
+						ElementType: types.StringType,
+						Computed:    true,
+						Description: "DNS nameservers",
+					},
+					"gateway_ip": schema.StringAttribute{
+						CustomType:  ovhtypes.TfStringType{},
+						Computed:    true,
+						Description: "Default gateway IP address",
+					},
+					"host_routes": schema.ListNestedAttribute{
+						Computed:    true,
+						Description: "Static host routes",
+						NestedObject: schema.NestedAttributeObject{
+							Attributes: map[string]schema.Attribute{
+								"destination": schema.StringAttribute{
+									CustomType:  ovhtypes.TfStringType{},
+									Computed:    true,
+									Description: "Destination CIDR",
+								},
+								"next_hop": schema.StringAttribute{
+									CustomType:  ovhtypes.TfStringType{},
+									Computed:    true,
+									Description: "Next hop IP address",
+								},
+							},
+						},
+					},
+					"location": schema.SingleNestedAttribute{
+						Computed:    true,
+						Description: "Location details",
+						Attributes: map[string]schema.Attribute{
+							"region": schema.StringAttribute{
+								CustomType:  ovhtypes.TfStringType{},
+								Computed:    true,
+								Description: "Region code",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func (r *cloudNetworkPrivateVrackSubnetResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	splits := strings.Split(req.ID, "/")
+	if len(splits) != 3 {
+		resp.Diagnostics.AddError("Given ID is malformed", "ID must be formatted like the following: <service_name>/<network_id>/<subnet_id>")
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("service_name"), splits[0])...)
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("network_id"), splits[1])...)
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("id"), splits[2])...)
+}
+
+func (r *cloudNetworkPrivateVrackSubnetResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	var data CloudSubnetModel
+
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	createPayload := data.ToCreate()
+
+	endpoint := "/v2/publicCloud/project/" + url.PathEscape(data.ServiceName.ValueString()) + "/network/" + url.PathEscape(data.NetworkId.ValueString()) + "/subnet"
+
+	var responseData CloudSubnetAPIResponse
+	if err := r.config.OVHClient.Post(endpoint, createPayload, &responseData); err != nil {
+		resp.Diagnostics.AddError(
+			fmt.Sprintf("Error calling Post %s", endpoint),
+			err.Error(),
+		)
+		return
+	}
+
+	// Save state immediately so the resource ID is tracked even if the workflow fails
+	data.MergeWith(ctx, &responseData)
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+
+	// Wait for subnet to be READY
+	_, err := r.waitForReady(ctx, data.ServiceName.ValueString(), data.NetworkId.ValueString(), responseData.Id)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Error waiting for subnet to be ready",
+			err.Error(),
+		)
+		return
+	}
+
+	// Read the final state
+	endpoint = "/v2/publicCloud/project/" + url.PathEscape(data.ServiceName.ValueString()) + "/network/" + url.PathEscape(data.NetworkId.ValueString()) + "/subnet/" + url.PathEscape(responseData.Id)
+	if err := r.config.OVHClient.Get(endpoint, &responseData); err != nil {
+		resp.Diagnostics.AddError(
+			fmt.Sprintf("Error calling Get %s", endpoint),
+			err.Error(),
+		)
+		return
+	}
+
+	data.MergeWith(ctx, &responseData)
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+func (r *cloudNetworkPrivateVrackSubnetResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	var data CloudSubnetModel
+
+	resp.Diagnostics.Append(req.State.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	endpoint := "/v2/publicCloud/project/" + url.PathEscape(data.ServiceName.ValueString()) + "/network/" + url.PathEscape(data.NetworkId.ValueString()) + "/subnet/" + url.PathEscape(data.Id.ValueString())
+
+	var responseData CloudSubnetAPIResponse
+	if err := r.config.OVHClient.Get(endpoint, &responseData); err != nil {
+		resp.Diagnostics.AddError(
+			fmt.Sprintf("Error calling Get %s", endpoint),
+			err.Error(),
+		)
+		return
+	}
+
+	data.MergeWith(ctx, &responseData)
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+func (r *cloudNetworkPrivateVrackSubnetResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	var data, planData CloudSubnetModel
+
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &planData)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	resp.Diagnostics.Append(req.State.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	updatePayload := planData.ToUpdate(data.Checksum.ValueString())
+
+	endpoint := "/v2/publicCloud/project/" + url.PathEscape(data.ServiceName.ValueString()) + "/network/" + url.PathEscape(data.NetworkId.ValueString()) + "/subnet/" + url.PathEscape(data.Id.ValueString())
+
+	var responseData CloudSubnetAPIResponse
+	if err := r.config.OVHClient.Put(endpoint, updatePayload, &responseData); err != nil {
+		resp.Diagnostics.AddError(
+			fmt.Sprintf("Error calling Put %s", endpoint),
+			err.Error(),
+		)
+		return
+	}
+
+	// Wait for subnet to be READY
+	_, err := r.waitForReady(ctx, data.ServiceName.ValueString(), data.NetworkId.ValueString(), data.Id.ValueString())
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Error waiting for subnet to be ready after update",
+			err.Error(),
+		)
+		return
+	}
+
+	// Read the final state
+	if err := r.config.OVHClient.Get(endpoint, &responseData); err != nil {
+		resp.Diagnostics.AddError(
+			fmt.Sprintf("Error calling Get %s", endpoint),
+			err.Error(),
+		)
+		return
+	}
+
+	planData.MergeWith(ctx, &responseData)
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &planData)...)
+}
+
+func (r *cloudNetworkPrivateVrackSubnetResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	var data CloudSubnetModel
+
+	resp.Diagnostics.Append(req.State.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	endpoint := "/v2/publicCloud/project/" + url.PathEscape(data.ServiceName.ValueString()) + "/network/" + url.PathEscape(data.NetworkId.ValueString()) + "/subnet/" + url.PathEscape(data.Id.ValueString())
+
+	if err := r.config.OVHClient.Delete(endpoint, nil); err != nil {
+		if errOvh, ok := err.(*ovh.APIError); ok && errOvh.Code == 404 {
+			return
+		}
+		resp.Diagnostics.AddError(
+			fmt.Sprintf("Error calling Delete %s", endpoint),
+			err.Error(),
+		)
+		return
+	}
+
+	// Wait for deletion to complete
+	stateConf := &retry.StateChangeConf{
+		Pending: []string{"DELETING"},
+		Target:  []string{"DELETED"},
+		Refresh: func() (interface{}, string, error) {
+			res := &CloudSubnetAPIResponse{}
+			endpoint := "/v2/publicCloud/project/" + url.PathEscape(data.ServiceName.ValueString()) + "/network/" + url.PathEscape(data.NetworkId.ValueString()) + "/subnet/" + url.PathEscape(data.Id.ValueString())
+			err := r.config.OVHClient.GetWithContext(ctx, endpoint, res)
+			if err != nil {
+				if errOvh, ok := err.(*ovh.APIError); ok && errOvh.Code == 404 {
+					return res, "DELETED", nil
+				}
+				return res, "", err
+			}
+			return res, res.ResourceStatus, nil
+		},
+		Timeout:    20 * time.Minute,
+		Delay:      10 * time.Second,
+		MinTimeout: 5 * time.Second,
+	}
+
+	if _, err := stateConf.WaitForStateContext(ctx); err != nil {
+		resp.Diagnostics.AddError(
+			"Error waiting for subnet to be deleted",
+			err.Error(),
+		)
+	}
+}
+
+func (r *cloudNetworkPrivateVrackSubnetResource) waitForReady(ctx context.Context, serviceName, networkId, subnetId string) (interface{}, error) {
+	stateConf := &retry.StateChangeConf{
+		Pending: []string{"CREATING", "UPDATING", "PENDING", "OUT_OF_SYNC"},
+		Target:  []string{"READY"},
+		Refresh: func() (interface{}, string, error) {
+			res := &CloudSubnetAPIResponse{}
+			endpoint := "/v2/publicCloud/project/" + url.PathEscape(serviceName) + "/network/" + url.PathEscape(networkId) + "/subnet/" + url.PathEscape(subnetId)
+			err := r.config.OVHClient.GetWithContext(ctx, endpoint, res)
+			if err != nil {
+				return res, "", err
+			}
+			return res, res.ResourceStatus, nil
+		},
+		Timeout:    20 * time.Minute,
+		Delay:      10 * time.Second,
+		MinTimeout: 5 * time.Second,
+	}
+
+	return stateConf.WaitForStateContext(ctx)
+}

--- a/ovh/resource_cloud_network_private_vrack_subnet_gen.go
+++ b/ovh/resource_cloud_network_private_vrack_subnet_gen.go
@@ -1,0 +1,4874 @@
+package ovh
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+	ovhtypes "github.com/ovh/terraform-provider-ovh/v2/ovh/types"
+)
+
+var _ basetypes.ObjectTypable = CloudNetworkPrivateSubnetCurrentStateType{}
+
+type CloudNetworkPrivateSubnetCurrentStateType struct {
+	basetypes.ObjectType
+}
+
+func (t CloudNetworkPrivateSubnetCurrentStateType) Equal(o attr.Type) bool {
+	other, ok := o.(CloudNetworkPrivateSubnetCurrentStateType)
+
+	if !ok {
+		return false
+	}
+
+	return t.ObjectType.Equal(other.ObjectType)
+}
+
+func (t CloudNetworkPrivateSubnetCurrentStateType) String() string {
+	return "CloudNetworkPrivateSubnetCurrentStateType"
+}
+
+func (t CloudNetworkPrivateSubnetCurrentStateType) ValueFromObject(ctx context.Context, in basetypes.ObjectValue) (basetypes.ObjectValuable, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	attributes := in.Attributes()
+
+	allocationPoolsAttribute, ok := attributes["allocation_pools"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`allocation_pools is missing from object`)
+
+		return nil, diags
+	}
+
+	allocationPoolsVal, ok := allocationPoolsAttribute.(ovhtypes.TfListNestedValue[CurrentStateAllocationPoolsValue])
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`allocation_pools expected to be ovhtypes.TfListNestedValue[CurrentStateAllocationPoolsValue], was: %T`, allocationPoolsAttribute))
+	}
+
+	cidrAttribute, ok := attributes["cidr"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`cidr is missing from object`)
+
+		return nil, diags
+	}
+
+	cidrVal, ok := cidrAttribute.(ovhtypes.TfStringValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`cidr expected to be ovhtypes.TfStringValue, was: %T`, cidrAttribute))
+	}
+
+	descriptionAttribute, ok := attributes["description"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`description is missing from object`)
+
+		return nil, diags
+	}
+
+	descriptionVal, ok := descriptionAttribute.(ovhtypes.TfStringValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`description expected to be ovhtypes.TfStringValue, was: %T`, descriptionAttribute))
+	}
+
+	dhcpEnabledAttribute, ok := attributes["dhcp_enabled"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`dhcp_enabled is missing from object`)
+
+		return nil, diags
+	}
+
+	dhcpEnabledVal, ok := dhcpEnabledAttribute.(ovhtypes.TfBoolValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`dhcp_enabled expected to be ovhtypes.TfBoolValue, was: %T`, dhcpEnabledAttribute))
+	}
+
+	dnsNameserversAttribute, ok := attributes["dns_nameservers"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`dns_nameservers is missing from object`)
+
+		return nil, diags
+	}
+
+	dnsNameserversVal, ok := dnsNameserversAttribute.(ovhtypes.TfListNestedValue[ovhtypes.TfStringValue])
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`dns_nameservers expected to be ovhtypes.TfListNestedValue[ovhtypes.TfStringValue], was: %T`, dnsNameserversAttribute))
+	}
+
+	gatewayIpAttribute, ok := attributes["gateway_ip"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`gateway_ip is missing from object`)
+
+		return nil, diags
+	}
+
+	gatewayIpVal, ok := gatewayIpAttribute.(ovhtypes.TfStringValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`gateway_ip expected to be ovhtypes.TfStringValue, was: %T`, gatewayIpAttribute))
+	}
+
+	hostRoutesAttribute, ok := attributes["host_routes"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`host_routes is missing from object`)
+
+		return nil, diags
+	}
+
+	hostRoutesVal, ok := hostRoutesAttribute.(ovhtypes.TfListNestedValue[CurrentStateHostRoutesValue])
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`host_routes expected to be ovhtypes.TfListNestedValue[CurrentStateHostRoutesValue], was: %T`, hostRoutesAttribute))
+	}
+
+	locationAttribute, ok := attributes["location"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`location is missing from object`)
+
+		return nil, diags
+	}
+
+	locationVal, ok := locationAttribute.(CurrentStateLocationValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`location expected to be CurrentStateLocationValue, was: %T`, locationAttribute))
+	}
+
+	nameAttribute, ok := attributes["name"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`name is missing from object`)
+
+		return nil, diags
+	}
+
+	nameVal, ok := nameAttribute.(ovhtypes.TfStringValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`name expected to be ovhtypes.TfStringValue, was: %T`, nameAttribute))
+	}
+
+	if diags.HasError() {
+		return nil, diags
+	}
+
+	return CloudNetworkPrivateSubnetCurrentStateValue{
+		AllocationPools: allocationPoolsVal,
+		Cidr:            cidrVal,
+		Description:     descriptionVal,
+		DhcpEnabled:     dhcpEnabledVal,
+		DnsNameservers:  dnsNameserversVal,
+		GatewayIp:       gatewayIpVal,
+		HostRoutes:      hostRoutesVal,
+		Location:        locationVal,
+		Name:            nameVal,
+		state:           attr.ValueStateKnown,
+	}, diags
+}
+
+func NewCloudNetworkPrivateSubnetCurrentStateValueNull() CloudNetworkPrivateSubnetCurrentStateValue {
+	return CloudNetworkPrivateSubnetCurrentStateValue{
+		state: attr.ValueStateNull,
+	}
+}
+
+func NewCloudNetworkPrivateSubnetCurrentStateValueUnknown() CloudNetworkPrivateSubnetCurrentStateValue {
+	return CloudNetworkPrivateSubnetCurrentStateValue{
+		state: attr.ValueStateUnknown,
+	}
+}
+
+func NewCloudNetworkPrivateSubnetCurrentStateValue(attributeTypes map[string]attr.Type, attributes map[string]attr.Value) (CloudNetworkPrivateSubnetCurrentStateValue, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	// Reference: https://github.com/hashicorp/terraform-plugin-framework/issues/521
+	ctx := context.Background()
+
+	for name, attributeType := range attributeTypes {
+		attribute, ok := attributes[name]
+
+		if !ok {
+			diags.AddError(
+				"Missing CloudNetworkPrivateSubnetCurrentStateValue Attribute Value",
+				"While creating a CloudNetworkPrivateSubnetCurrentStateValue value, a missing attribute value was detected. "+
+					"A CloudNetworkPrivateSubnetCurrentStateValue must contain values for all attributes, even if null or unknown. "+
+					"This is always an issue with the provider and should be reported to the provider developers.\n\n"+
+					fmt.Sprintf("CloudNetworkPrivateSubnetCurrentStateValue Attribute Name (%s) Expected Type: %s", name, attributeType.String()),
+			)
+
+			continue
+		}
+
+		if !attributeType.Equal(attribute.Type(ctx)) {
+			diags.AddError(
+				"Invalid CloudNetworkPrivateSubnetCurrentStateValue Attribute Type",
+				"While creating a CloudNetworkPrivateSubnetCurrentStateValue value, an invalid attribute value was detected. "+
+					"A CloudNetworkPrivateSubnetCurrentStateValue must use a matching attribute type for the value. "+
+					"This is always an issue with the provider and should be reported to the provider developers.\n\n"+
+					fmt.Sprintf("CloudNetworkPrivateSubnetCurrentStateValue Attribute Name (%s) Expected Type: %s\n", name, attributeType.String())+
+					fmt.Sprintf("CloudNetworkPrivateSubnetCurrentStateValue Attribute Name (%s) Given Type: %s", name, attribute.Type(ctx)),
+			)
+		}
+	}
+
+	for name := range attributes {
+		_, ok := attributeTypes[name]
+
+		if !ok {
+			diags.AddError(
+				"Extra CloudNetworkPrivateSubnetCurrentStateValue Attribute Value",
+				"While creating a CloudNetworkPrivateSubnetCurrentStateValue value, an extra attribute value was detected. "+
+					"A CloudNetworkPrivateSubnetCurrentStateValue must not contain values beyond the expected attribute types. "+
+					"This is always an issue with the provider and should be reported to the provider developers.\n\n"+
+					fmt.Sprintf("Extra CloudNetworkPrivateSubnetCurrentStateValue Attribute Name: %s", name),
+			)
+		}
+	}
+
+	if diags.HasError() {
+		return NewCloudNetworkPrivateSubnetCurrentStateValueUnknown(), diags
+	}
+
+	allocationPoolsAttribute, ok := attributes["allocation_pools"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`allocation_pools is missing from object`)
+
+		return NewCloudNetworkPrivateSubnetCurrentStateValueUnknown(), diags
+	}
+
+	allocationPoolsVal, ok := allocationPoolsAttribute.(ovhtypes.TfListNestedValue[CurrentStateAllocationPoolsValue])
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`allocation_pools expected to be ovhtypes.TfListNestedValue[CurrentStateAllocationPoolsValue], was: %T`, allocationPoolsAttribute))
+	}
+
+	cidrAttribute, ok := attributes["cidr"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`cidr is missing from object`)
+
+		return NewCloudNetworkPrivateSubnetCurrentStateValueUnknown(), diags
+	}
+
+	cidrVal, ok := cidrAttribute.(ovhtypes.TfStringValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`cidr expected to be ovhtypes.TfStringValue, was: %T`, cidrAttribute))
+	}
+
+	descriptionAttribute, ok := attributes["description"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`description is missing from object`)
+
+		return NewCloudNetworkPrivateSubnetCurrentStateValueUnknown(), diags
+	}
+
+	descriptionVal, ok := descriptionAttribute.(ovhtypes.TfStringValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`description expected to be ovhtypes.TfStringValue, was: %T`, descriptionAttribute))
+	}
+
+	dhcpEnabledAttribute, ok := attributes["dhcp_enabled"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`dhcp_enabled is missing from object`)
+
+		return NewCloudNetworkPrivateSubnetCurrentStateValueUnknown(), diags
+	}
+
+	dhcpEnabledVal, ok := dhcpEnabledAttribute.(ovhtypes.TfBoolValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`dhcp_enabled expected to be ovhtypes.TfBoolValue, was: %T`, dhcpEnabledAttribute))
+	}
+
+	dnsNameserversAttribute, ok := attributes["dns_nameservers"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`dns_nameservers is missing from object`)
+
+		return NewCloudNetworkPrivateSubnetCurrentStateValueUnknown(), diags
+	}
+
+	dnsNameserversVal, ok := dnsNameserversAttribute.(ovhtypes.TfListNestedValue[ovhtypes.TfStringValue])
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`dns_nameservers expected to be ovhtypes.TfListNestedValue[ovhtypes.TfStringValue], was: %T`, dnsNameserversAttribute))
+	}
+
+	gatewayIpAttribute, ok := attributes["gateway_ip"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`gateway_ip is missing from object`)
+
+		return NewCloudNetworkPrivateSubnetCurrentStateValueUnknown(), diags
+	}
+
+	gatewayIpVal, ok := gatewayIpAttribute.(ovhtypes.TfStringValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`gateway_ip expected to be ovhtypes.TfStringValue, was: %T`, gatewayIpAttribute))
+	}
+
+	hostRoutesAttribute, ok := attributes["host_routes"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`host_routes is missing from object`)
+
+		return NewCloudNetworkPrivateSubnetCurrentStateValueUnknown(), diags
+	}
+
+	hostRoutesVal, ok := hostRoutesAttribute.(ovhtypes.TfListNestedValue[CurrentStateHostRoutesValue])
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`host_routes expected to be ovhtypes.TfListNestedValue[CurrentStateHostRoutesValue], was: %T`, hostRoutesAttribute))
+	}
+
+	locationAttribute, ok := attributes["location"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`location is missing from object`)
+
+		return NewCloudNetworkPrivateSubnetCurrentStateValueUnknown(), diags
+	}
+
+	locationVal, ok := locationAttribute.(CurrentStateLocationValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`location expected to be CurrentStateLocationValue, was: %T`, locationAttribute))
+	}
+
+	nameAttribute, ok := attributes["name"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`name is missing from object`)
+
+		return NewCloudNetworkPrivateSubnetCurrentStateValueUnknown(), diags
+	}
+
+	nameVal, ok := nameAttribute.(ovhtypes.TfStringValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`name expected to be ovhtypes.TfStringValue, was: %T`, nameAttribute))
+	}
+
+	if diags.HasError() {
+		return NewCloudNetworkPrivateSubnetCurrentStateValueUnknown(), diags
+	}
+
+	return CloudNetworkPrivateSubnetCurrentStateValue{
+		AllocationPools: allocationPoolsVal,
+		Cidr:            cidrVal,
+		Description:     descriptionVal,
+		DhcpEnabled:     dhcpEnabledVal,
+		DnsNameservers:  dnsNameserversVal,
+		GatewayIp:       gatewayIpVal,
+		HostRoutes:      hostRoutesVal,
+		Location:        locationVal,
+		Name:            nameVal,
+		state:           attr.ValueStateKnown,
+	}, diags
+}
+
+func NewCloudNetworkPrivateSubnetCurrentStateValueMust(attributeTypes map[string]attr.Type, attributes map[string]attr.Value) CloudNetworkPrivateSubnetCurrentStateValue {
+	object, diags := NewCloudNetworkPrivateSubnetCurrentStateValue(attributeTypes, attributes)
+
+	if diags.HasError() {
+		// This could potentially be added to the diag package.
+		diagsStrings := make([]string, 0, len(diags))
+
+		for _, diagnostic := range diags {
+			diagsStrings = append(diagsStrings, fmt.Sprintf(
+				"%s | %s | %s",
+				diagnostic.Severity(),
+				diagnostic.Summary(),
+				diagnostic.Detail()))
+		}
+
+		panic("NewCloudNetworkPrivateSubnetCurrentStateValueMust received error(s): " + strings.Join(diagsStrings, "\n"))
+	}
+
+	return object
+}
+
+func (t CloudNetworkPrivateSubnetCurrentStateType) ValueFromTerraform(ctx context.Context, in tftypes.Value) (attr.Value, error) {
+	if in.Type() == nil {
+		return NewCloudNetworkPrivateSubnetCurrentStateValueNull(), nil
+	}
+
+	if !in.Type().Equal(t.TerraformType(ctx)) {
+		return nil, fmt.Errorf("expected %s, got %s", t.TerraformType(ctx), in.Type())
+	}
+
+	if !in.IsKnown() {
+		return NewCloudNetworkPrivateSubnetCurrentStateValueUnknown(), nil
+	}
+
+	if in.IsNull() {
+		return NewCloudNetworkPrivateSubnetCurrentStateValueNull(), nil
+	}
+
+	attributes := map[string]attr.Value{}
+
+	val := map[string]tftypes.Value{}
+
+	err := in.As(&val)
+
+	if err != nil {
+		return nil, err
+	}
+
+	for k, v := range val {
+		a, err := t.AttrTypes[k].ValueFromTerraform(ctx, v)
+
+		if err != nil {
+			return nil, err
+		}
+
+		attributes[k] = a
+	}
+
+	return NewCloudNetworkPrivateSubnetCurrentStateValueMust(CloudNetworkPrivateSubnetCurrentStateValue{}.AttributeTypes(ctx), attributes), nil
+}
+
+func (t CloudNetworkPrivateSubnetCurrentStateType) ValueType(ctx context.Context) attr.Value {
+	return CloudNetworkPrivateSubnetCurrentStateValue{}
+}
+
+var _ basetypes.ObjectValuable = CloudNetworkPrivateSubnetCurrentStateValue{}
+
+type CloudNetworkPrivateSubnetCurrentStateValue struct {
+	AllocationPools ovhtypes.TfListNestedValue[CurrentStateAllocationPoolsValue] `tfsdk:"allocation_pools" json:"allocationPools"`
+	Cidr            ovhtypes.TfStringValue                                       `tfsdk:"cidr" json:"cidr"`
+	Description     ovhtypes.TfStringValue                                       `tfsdk:"description" json:"description"`
+	DhcpEnabled     ovhtypes.TfBoolValue                                         `tfsdk:"dhcp_enabled" json:"dhcpEnabled"`
+	DnsNameservers  ovhtypes.TfListNestedValue[ovhtypes.TfStringValue]           `tfsdk:"dns_nameservers" json:"dnsNameservers"`
+	GatewayIp       ovhtypes.TfStringValue                                       `tfsdk:"gateway_ip" json:"gatewayIp"`
+	HostRoutes      ovhtypes.TfListNestedValue[CurrentStateHostRoutesValue]      `tfsdk:"host_routes" json:"hostRoutes"`
+	Location        CurrentStateLocationValue                                    `tfsdk:"location" json:"location"`
+	Name            ovhtypes.TfStringValue                                       `tfsdk:"name" json:"name"`
+	state           attr.ValueState
+}
+
+func (v CloudNetworkPrivateSubnetCurrentStateValue) ToCreate() *CloudNetworkPrivateSubnetCurrentStateValue {
+	res := &CloudNetworkPrivateSubnetCurrentStateValue{}
+
+	if !v.DhcpEnabled.IsNull() {
+		res.DhcpEnabled = v.DhcpEnabled
+	}
+
+	res.state = attr.ValueStateKnown
+
+	return res
+}
+
+func (v CloudNetworkPrivateSubnetCurrentStateValue) MarshalJSON() ([]byte, error) {
+	toMarshal := map[string]any{}
+	if !v.DhcpEnabled.IsNull() && !v.DhcpEnabled.IsUnknown() {
+		toMarshal["dhcpEnabled"] = v.DhcpEnabled
+	}
+
+	return json.Marshal(toMarshal)
+}
+
+func (v *CloudNetworkPrivateSubnetCurrentStateValue) UnmarshalJSON(data []byte) error {
+	type JsonCurrentStateValue CloudNetworkPrivateSubnetCurrentStateValue
+
+	var tmp JsonCurrentStateValue
+	if err := json.Unmarshal(data, &tmp); err != nil {
+		return err
+	}
+	v.AllocationPools = tmp.AllocationPools
+	v.Cidr = tmp.Cidr
+	v.Description = tmp.Description
+	v.DhcpEnabled = tmp.DhcpEnabled
+	v.DnsNameservers = tmp.DnsNameservers
+	v.GatewayIp = tmp.GatewayIp
+	v.HostRoutes = tmp.HostRoutes
+	v.Location = tmp.Location
+	v.Name = tmp.Name
+
+	v.state = attr.ValueStateKnown
+
+	return nil
+}
+
+func (v *CloudNetworkPrivateSubnetCurrentStateValue) MergeWith(other *CloudNetworkPrivateSubnetCurrentStateValue) {
+
+	if (v.AllocationPools.IsUnknown() || v.AllocationPools.IsNull()) && !other.AllocationPools.IsUnknown() {
+		v.AllocationPools = other.AllocationPools
+	} else if !other.AllocationPools.IsUnknown() {
+		newSlice := make([]attr.Value, 0)
+		elems := v.AllocationPools.Elements()
+		newElems := other.AllocationPools.Elements()
+
+		if len(elems) != len(newElems) {
+			v.AllocationPools = other.AllocationPools
+		} else {
+			for idx, e := range elems {
+				tmp := e.(CurrentStateAllocationPoolsValue)
+				tmp2 := newElems[idx].(CurrentStateAllocationPoolsValue)
+				tmp.MergeWith(&tmp2)
+				newSlice = append(newSlice, tmp)
+			}
+
+			v.AllocationPools = ovhtypes.TfListNestedValue[CurrentStateAllocationPoolsValue]{
+				ListValue: basetypes.NewListValueMust(CurrentStateAllocationPoolsValue{}.Type(context.Background()), newSlice),
+			}
+		}
+	}
+
+	if (v.Cidr.IsUnknown() || v.Cidr.IsNull()) && !other.Cidr.IsUnknown() {
+		v.Cidr = other.Cidr
+	}
+
+	if (v.Description.IsUnknown() || v.Description.IsNull()) && !other.Description.IsUnknown() {
+		v.Description = other.Description
+	}
+
+	if (v.DhcpEnabled.IsUnknown() || v.DhcpEnabled.IsNull()) && !other.DhcpEnabled.IsUnknown() {
+		v.DhcpEnabled = other.DhcpEnabled
+	}
+
+	if (v.DnsNameservers.IsUnknown() || v.DnsNameservers.IsNull()) && !other.DnsNameservers.IsUnknown() {
+		v.DnsNameservers = other.DnsNameservers
+	}
+
+	if (v.GatewayIp.IsUnknown() || v.GatewayIp.IsNull()) && !other.GatewayIp.IsUnknown() {
+		v.GatewayIp = other.GatewayIp
+	}
+
+	if (v.HostRoutes.IsUnknown() || v.HostRoutes.IsNull()) && !other.HostRoutes.IsUnknown() {
+		v.HostRoutes = other.HostRoutes
+	} else if !other.HostRoutes.IsUnknown() {
+		newSlice := make([]attr.Value, 0)
+		elems := v.HostRoutes.Elements()
+		newElems := other.HostRoutes.Elements()
+
+		if len(elems) != len(newElems) {
+			v.HostRoutes = other.HostRoutes
+		} else {
+			for idx, e := range elems {
+				tmp := e.(CurrentStateHostRoutesValue)
+				tmp2 := newElems[idx].(CurrentStateHostRoutesValue)
+				tmp.MergeWith(&tmp2)
+				newSlice = append(newSlice, tmp)
+			}
+
+			v.HostRoutes = ovhtypes.TfListNestedValue[CurrentStateHostRoutesValue]{
+				ListValue: basetypes.NewListValueMust(CurrentStateHostRoutesValue{}.Type(context.Background()), newSlice),
+			}
+		}
+	}
+
+	if v.Location.IsUnknown() && !other.Location.IsUnknown() {
+		v.Location = other.Location
+	} else if !other.Location.IsUnknown() {
+		v.Location.MergeWith(&other.Location)
+	}
+
+	if (v.Name.IsUnknown() || v.Name.IsNull()) && !other.Name.IsUnknown() {
+		v.Name = other.Name
+	}
+
+	if (v.state == attr.ValueStateUnknown || v.state == attr.ValueStateNull) && other.state != attr.ValueStateUnknown {
+		v.state = other.state
+	}
+}
+
+func (v CloudNetworkPrivateSubnetCurrentStateValue) Attributes() map[string]attr.Value {
+	return map[string]attr.Value{
+		"allocationPools": v.AllocationPools,
+		"cidr":            v.Cidr,
+		"description":     v.Description,
+		"dhcpEnabled":     v.DhcpEnabled,
+		"dnsNameservers":  v.DnsNameservers,
+		"gatewayIp":       v.GatewayIp,
+		"hostRoutes":      v.HostRoutes,
+		"location":        v.Location,
+		"name":            v.Name,
+	}
+}
+func (v CloudNetworkPrivateSubnetCurrentStateValue) ToTerraformValue(ctx context.Context) (tftypes.Value, error) {
+	attrTypes := make(map[string]tftypes.Type, 9)
+
+	var val tftypes.Value
+	var err error
+
+	attrTypes["allocation_pools"] = basetypes.ListType{
+		ElemType: CurrentStateAllocationPoolsValue{}.Type(ctx),
+	}.TerraformType(ctx)
+	attrTypes["cidr"] = basetypes.StringType{}.TerraformType(ctx)
+	attrTypes["description"] = basetypes.StringType{}.TerraformType(ctx)
+	attrTypes["dhcp_enabled"] = basetypes.BoolType{}.TerraformType(ctx)
+	attrTypes["dns_nameservers"] = basetypes.ListType{
+		ElemType: types.StringType,
+	}.TerraformType(ctx)
+	attrTypes["gateway_ip"] = basetypes.StringType{}.TerraformType(ctx)
+	attrTypes["host_routes"] = basetypes.ListType{
+		ElemType: CurrentStateHostRoutesValue{}.Type(ctx),
+	}.TerraformType(ctx)
+	attrTypes["location"] = basetypes.ObjectType{
+		AttrTypes: CurrentStateLocationValue{}.AttributeTypes(ctx),
+	}.TerraformType(ctx)
+	attrTypes["name"] = basetypes.StringType{}.TerraformType(ctx)
+
+	objectType := tftypes.Object{AttributeTypes: attrTypes}
+
+	switch v.state {
+	case attr.ValueStateKnown:
+		vals := make(map[string]tftypes.Value, 9)
+
+		val, err = v.AllocationPools.ToTerraformValue(ctx)
+
+		if err != nil {
+			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
+		}
+
+		vals["allocation_pools"] = val
+
+		val, err = v.Cidr.ToTerraformValue(ctx)
+
+		if err != nil {
+			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
+		}
+
+		vals["cidr"] = val
+
+		val, err = v.Description.ToTerraformValue(ctx)
+
+		if err != nil {
+			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
+		}
+
+		vals["description"] = val
+
+		val, err = v.DhcpEnabled.ToTerraformValue(ctx)
+
+		if err != nil {
+			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
+		}
+
+		vals["dhcp_enabled"] = val
+
+		val, err = v.DnsNameservers.ToTerraformValue(ctx)
+
+		if err != nil {
+			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
+		}
+
+		vals["dns_nameservers"] = val
+
+		val, err = v.GatewayIp.ToTerraformValue(ctx)
+
+		if err != nil {
+			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
+		}
+
+		vals["gateway_ip"] = val
+
+		val, err = v.HostRoutes.ToTerraformValue(ctx)
+
+		if err != nil {
+			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
+		}
+
+		vals["host_routes"] = val
+
+		val, err = v.Location.ToTerraformValue(ctx)
+
+		if err != nil {
+			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
+		}
+
+		vals["location"] = val
+
+		val, err = v.Name.ToTerraformValue(ctx)
+
+		if err != nil {
+			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
+		}
+
+		vals["name"] = val
+
+		if err := tftypes.ValidateValue(objectType, vals); err != nil {
+			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
+		}
+
+		return tftypes.NewValue(objectType, vals), nil
+	case attr.ValueStateNull:
+		return tftypes.NewValue(objectType, nil), nil
+	case attr.ValueStateUnknown:
+		return tftypes.NewValue(objectType, tftypes.UnknownValue), nil
+	default:
+		panic(fmt.Sprintf("unhandled Object state in ToTerraformValue: %s", v.state))
+	}
+}
+
+func (v CloudNetworkPrivateSubnetCurrentStateValue) IsNull() bool {
+	return v.state == attr.ValueStateNull
+}
+
+func (v CloudNetworkPrivateSubnetCurrentStateValue) IsUnknown() bool {
+	return v.state == attr.ValueStateUnknown
+}
+
+func (v CloudNetworkPrivateSubnetCurrentStateValue) String() string {
+	return "CloudNetworkPrivateSubnetCurrentStateValue"
+}
+
+func (v CloudNetworkPrivateSubnetCurrentStateValue) ToObjectValue(ctx context.Context) (basetypes.ObjectValue, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	objVal, diags := types.ObjectValue(
+		map[string]attr.Type{
+			"allocation_pools": ovhtypes.NewTfListNestedType[CurrentStateAllocationPoolsValue](ctx),
+			"cidr":             ovhtypes.TfStringType{},
+			"description":      ovhtypes.TfStringType{},
+			"dhcp_enabled":     ovhtypes.TfBoolType{},
+			"dns_nameservers":  ovhtypes.NewTfListNestedType[ovhtypes.TfStringValue](ctx),
+			"gateway_ip":       ovhtypes.TfStringType{},
+			"host_routes":      ovhtypes.NewTfListNestedType[CurrentStateHostRoutesValue](ctx),
+			"location": CurrentStateLocationType{
+				basetypes.ObjectType{
+					AttrTypes: CurrentStateLocationValue{}.AttributeTypes(ctx),
+				},
+			},
+			"name": ovhtypes.TfStringType{},
+		},
+		map[string]attr.Value{
+			"allocation_pools": v.AllocationPools,
+			"cidr":             v.Cidr,
+			"description":      v.Description,
+			"dhcp_enabled":     v.DhcpEnabled,
+			"dns_nameservers":  v.DnsNameservers,
+			"gateway_ip":       v.GatewayIp,
+			"host_routes":      v.HostRoutes,
+			"location":         v.Location,
+			"name":             v.Name,
+		})
+
+	return objVal, diags
+}
+
+func (v CloudNetworkPrivateSubnetCurrentStateValue) Equal(o attr.Value) bool {
+	other, ok := o.(CloudNetworkPrivateSubnetCurrentStateValue)
+
+	if !ok {
+		return false
+	}
+
+	if v.state != other.state {
+		return false
+	}
+
+	if v.state != attr.ValueStateKnown {
+		return true
+	}
+
+	if !v.AllocationPools.Equal(other.AllocationPools) {
+		return false
+	}
+
+	if !v.Cidr.Equal(other.Cidr) {
+		return false
+	}
+
+	if !v.Description.Equal(other.Description) {
+		return false
+	}
+
+	if !v.DhcpEnabled.Equal(other.DhcpEnabled) {
+		return false
+	}
+
+	if !v.DnsNameservers.Equal(other.DnsNameservers) {
+		return false
+	}
+
+	if !v.GatewayIp.Equal(other.GatewayIp) {
+		return false
+	}
+
+	if !v.HostRoutes.Equal(other.HostRoutes) {
+		return false
+	}
+
+	if !v.Location.Equal(other.Location) {
+		return false
+	}
+
+	if !v.Name.Equal(other.Name) {
+		return false
+	}
+
+	return true
+}
+
+func (v CloudNetworkPrivateSubnetCurrentStateValue) Type(ctx context.Context) attr.Type {
+	return CloudNetworkPrivateSubnetCurrentStateType{
+		basetypes.ObjectType{
+			AttrTypes: v.AttributeTypes(ctx),
+		},
+	}
+}
+
+func (v CloudNetworkPrivateSubnetCurrentStateValue) AttributeTypes(ctx context.Context) map[string]attr.Type {
+	return map[string]attr.Type{
+		"allocation_pools": ovhtypes.NewTfListNestedType[CurrentStateAllocationPoolsValue](ctx),
+		"cidr":             ovhtypes.TfStringType{},
+		"description":      ovhtypes.TfStringType{},
+		"dhcp_enabled":     ovhtypes.TfBoolType{},
+		"dns_nameservers":  ovhtypes.NewTfListNestedType[ovhtypes.TfStringValue](ctx),
+		"gateway_ip":       ovhtypes.TfStringType{},
+		"host_routes":      ovhtypes.NewTfListNestedType[CurrentStateHostRoutesValue](ctx),
+		"location":         CurrentStateLocationValue{}.Type(ctx),
+		"name":             ovhtypes.TfStringType{},
+	}
+}
+
+var _ basetypes.ObjectTypable = CurrentStateAllocationPoolsType{}
+
+type CurrentStateAllocationPoolsType struct {
+	basetypes.ObjectType
+}
+
+func (t CurrentStateAllocationPoolsType) Equal(o attr.Type) bool {
+	other, ok := o.(CurrentStateAllocationPoolsType)
+
+	if !ok {
+		return false
+	}
+
+	return t.ObjectType.Equal(other.ObjectType)
+}
+
+func (t CurrentStateAllocationPoolsType) String() string {
+	return "CurrentStateAllocationPoolsType"
+}
+
+func (t CurrentStateAllocationPoolsType) ValueFromObject(ctx context.Context, in basetypes.ObjectValue) (basetypes.ObjectValuable, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	attributes := in.Attributes()
+
+	endAttribute, ok := attributes["end"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`end is missing from object`)
+
+		return nil, diags
+	}
+
+	endVal, ok := endAttribute.(ovhtypes.TfStringValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`end expected to be ovhtypes.TfStringValue, was: %T`, endAttribute))
+	}
+
+	startAttribute, ok := attributes["start"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`start is missing from object`)
+
+		return nil, diags
+	}
+
+	startVal, ok := startAttribute.(ovhtypes.TfStringValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`start expected to be ovhtypes.TfStringValue, was: %T`, startAttribute))
+	}
+
+	if diags.HasError() {
+		return nil, diags
+	}
+
+	return CurrentStateAllocationPoolsValue{
+		End:   endVal,
+		Start: startVal,
+		state: attr.ValueStateKnown,
+	}, diags
+}
+
+func NewCurrentStateAllocationPoolsValueNull() CurrentStateAllocationPoolsValue {
+	return CurrentStateAllocationPoolsValue{
+		state: attr.ValueStateNull,
+	}
+}
+
+func NewCurrentStateAllocationPoolsValueUnknown() CurrentStateAllocationPoolsValue {
+	return CurrentStateAllocationPoolsValue{
+		state: attr.ValueStateUnknown,
+	}
+}
+
+func NewCurrentStateAllocationPoolsValue(attributeTypes map[string]attr.Type, attributes map[string]attr.Value) (CurrentStateAllocationPoolsValue, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	// Reference: https://github.com/hashicorp/terraform-plugin-framework/issues/521
+	ctx := context.Background()
+
+	for name, attributeType := range attributeTypes {
+		attribute, ok := attributes[name]
+
+		if !ok {
+			diags.AddError(
+				"Missing CurrentStateAllocationPoolsValue Attribute Value",
+				"While creating a CurrentStateAllocationPoolsValue value, a missing attribute value was detected. "+
+					"A CurrentStateAllocationPoolsValue must contain values for all attributes, even if null or unknown. "+
+					"This is always an issue with the provider and should be reported to the provider developers.\n\n"+
+					fmt.Sprintf("CurrentStateAllocationPoolsValue Attribute Name (%s) Expected Type: %s", name, attributeType.String()),
+			)
+
+			continue
+		}
+
+		if !attributeType.Equal(attribute.Type(ctx)) {
+			diags.AddError(
+				"Invalid CurrentStateAllocationPoolsValue Attribute Type",
+				"While creating a CurrentStateAllocationPoolsValue value, an invalid attribute value was detected. "+
+					"A CurrentStateAllocationPoolsValue must use a matching attribute type for the value. "+
+					"This is always an issue with the provider and should be reported to the provider developers.\n\n"+
+					fmt.Sprintf("CurrentStateAllocationPoolsValue Attribute Name (%s) Expected Type: %s\n", name, attributeType.String())+
+					fmt.Sprintf("CurrentStateAllocationPoolsValue Attribute Name (%s) Given Type: %s", name, attribute.Type(ctx)),
+			)
+		}
+	}
+
+	for name := range attributes {
+		_, ok := attributeTypes[name]
+
+		if !ok {
+			diags.AddError(
+				"Extra CurrentStateAllocationPoolsValue Attribute Value",
+				"While creating a CurrentStateAllocationPoolsValue value, an extra attribute value was detected. "+
+					"A CurrentStateAllocationPoolsValue must not contain values beyond the expected attribute types. "+
+					"This is always an issue with the provider and should be reported to the provider developers.\n\n"+
+					fmt.Sprintf("Extra CurrentStateAllocationPoolsValue Attribute Name: %s", name),
+			)
+		}
+	}
+
+	if diags.HasError() {
+		return NewCurrentStateAllocationPoolsValueUnknown(), diags
+	}
+
+	endAttribute, ok := attributes["end"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`end is missing from object`)
+
+		return NewCurrentStateAllocationPoolsValueUnknown(), diags
+	}
+
+	endVal, ok := endAttribute.(ovhtypes.TfStringValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`end expected to be ovhtypes.TfStringValue, was: %T`, endAttribute))
+	}
+
+	startAttribute, ok := attributes["start"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`start is missing from object`)
+
+		return NewCurrentStateAllocationPoolsValueUnknown(), diags
+	}
+
+	startVal, ok := startAttribute.(ovhtypes.TfStringValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`start expected to be ovhtypes.TfStringValue, was: %T`, startAttribute))
+	}
+
+	if diags.HasError() {
+		return NewCurrentStateAllocationPoolsValueUnknown(), diags
+	}
+
+	return CurrentStateAllocationPoolsValue{
+		End:   endVal,
+		Start: startVal,
+		state: attr.ValueStateKnown,
+	}, diags
+}
+
+func NewCurrentStateAllocationPoolsValueMust(attributeTypes map[string]attr.Type, attributes map[string]attr.Value) CurrentStateAllocationPoolsValue {
+	object, diags := NewCurrentStateAllocationPoolsValue(attributeTypes, attributes)
+
+	if diags.HasError() {
+		// This could potentially be added to the diag package.
+		diagsStrings := make([]string, 0, len(diags))
+
+		for _, diagnostic := range diags {
+			diagsStrings = append(diagsStrings, fmt.Sprintf(
+				"%s | %s | %s",
+				diagnostic.Severity(),
+				diagnostic.Summary(),
+				diagnostic.Detail()))
+		}
+
+		panic("NewCurrentStateAllocationPoolsValueMust received error(s): " + strings.Join(diagsStrings, "\n"))
+	}
+
+	return object
+}
+
+func (t CurrentStateAllocationPoolsType) ValueFromTerraform(ctx context.Context, in tftypes.Value) (attr.Value, error) {
+	if in.Type() == nil {
+		return NewCurrentStateAllocationPoolsValueNull(), nil
+	}
+
+	if !in.Type().Equal(t.TerraformType(ctx)) {
+		return nil, fmt.Errorf("expected %s, got %s", t.TerraformType(ctx), in.Type())
+	}
+
+	if !in.IsKnown() {
+		return NewCurrentStateAllocationPoolsValueUnknown(), nil
+	}
+
+	if in.IsNull() {
+		return NewCurrentStateAllocationPoolsValueNull(), nil
+	}
+
+	attributes := map[string]attr.Value{}
+
+	val := map[string]tftypes.Value{}
+
+	err := in.As(&val)
+
+	if err != nil {
+		return nil, err
+	}
+
+	for k, v := range val {
+		a, err := t.AttrTypes[k].ValueFromTerraform(ctx, v)
+
+		if err != nil {
+			return nil, err
+		}
+
+		attributes[k] = a
+	}
+
+	return NewCurrentStateAllocationPoolsValueMust(CurrentStateAllocationPoolsValue{}.AttributeTypes(ctx), attributes), nil
+}
+
+func (t CurrentStateAllocationPoolsType) ValueType(ctx context.Context) attr.Value {
+	return CurrentStateAllocationPoolsValue{}
+}
+
+var _ basetypes.ObjectValuable = CurrentStateAllocationPoolsValue{}
+
+type CurrentStateAllocationPoolsValue struct {
+	End   ovhtypes.TfStringValue `tfsdk:"end" json:"end"`
+	Start ovhtypes.TfStringValue `tfsdk:"start" json:"start"`
+	state attr.ValueState
+}
+
+func (v *CurrentStateAllocationPoolsValue) UnmarshalJSON(data []byte) error {
+	type JsonCurrentStateAllocationPoolsValue CurrentStateAllocationPoolsValue
+
+	var tmp JsonCurrentStateAllocationPoolsValue
+	if err := json.Unmarshal(data, &tmp); err != nil {
+		return err
+	}
+	v.End = tmp.End
+	v.Start = tmp.Start
+
+	v.state = attr.ValueStateKnown
+
+	return nil
+}
+
+func (v *CurrentStateAllocationPoolsValue) MergeWith(other *CurrentStateAllocationPoolsValue) {
+
+	if (v.End.IsUnknown() || v.End.IsNull()) && !other.End.IsUnknown() {
+		v.End = other.End
+	}
+
+	if (v.Start.IsUnknown() || v.Start.IsNull()) && !other.Start.IsUnknown() {
+		v.Start = other.Start
+	}
+
+	if (v.state == attr.ValueStateUnknown || v.state == attr.ValueStateNull) && other.state != attr.ValueStateUnknown {
+		v.state = other.state
+	}
+}
+
+func (v CurrentStateAllocationPoolsValue) Attributes() map[string]attr.Value {
+	return map[string]attr.Value{
+		"end":   v.End,
+		"start": v.Start,
+	}
+}
+func (v CurrentStateAllocationPoolsValue) ToTerraformValue(ctx context.Context) (tftypes.Value, error) {
+	attrTypes := make(map[string]tftypes.Type, 2)
+
+	var val tftypes.Value
+	var err error
+
+	attrTypes["end"] = basetypes.StringType{}.TerraformType(ctx)
+	attrTypes["start"] = basetypes.StringType{}.TerraformType(ctx)
+
+	objectType := tftypes.Object{AttributeTypes: attrTypes}
+
+	switch v.state {
+	case attr.ValueStateKnown:
+		vals := make(map[string]tftypes.Value, 2)
+
+		val, err = v.End.ToTerraformValue(ctx)
+
+		if err != nil {
+			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
+		}
+
+		vals["end"] = val
+
+		val, err = v.Start.ToTerraformValue(ctx)
+
+		if err != nil {
+			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
+		}
+
+		vals["start"] = val
+
+		if err := tftypes.ValidateValue(objectType, vals); err != nil {
+			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
+		}
+
+		return tftypes.NewValue(objectType, vals), nil
+	case attr.ValueStateNull:
+		return tftypes.NewValue(objectType, nil), nil
+	case attr.ValueStateUnknown:
+		return tftypes.NewValue(objectType, tftypes.UnknownValue), nil
+	default:
+		panic(fmt.Sprintf("unhandled Object state in ToTerraformValue: %s", v.state))
+	}
+}
+
+func (v CurrentStateAllocationPoolsValue) IsNull() bool {
+	return v.state == attr.ValueStateNull
+}
+
+func (v CurrentStateAllocationPoolsValue) IsUnknown() bool {
+	return v.state == attr.ValueStateUnknown
+}
+
+func (v CurrentStateAllocationPoolsValue) String() string {
+	return "CurrentStateAllocationPoolsValue"
+}
+
+func (v CurrentStateAllocationPoolsValue) ToObjectValue(ctx context.Context) (basetypes.ObjectValue, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	objVal, diags := types.ObjectValue(
+		map[string]attr.Type{
+			"end":   ovhtypes.TfStringType{},
+			"start": ovhtypes.TfStringType{},
+		},
+		map[string]attr.Value{
+			"end":   v.End,
+			"start": v.Start,
+		})
+
+	return objVal, diags
+}
+
+func (v CurrentStateAllocationPoolsValue) Equal(o attr.Value) bool {
+	other, ok := o.(CurrentStateAllocationPoolsValue)
+
+	if !ok {
+		return false
+	}
+
+	if v.state != other.state {
+		return false
+	}
+
+	if v.state != attr.ValueStateKnown {
+		return true
+	}
+
+	if !v.End.Equal(other.End) {
+		return false
+	}
+
+	if !v.Start.Equal(other.Start) {
+		return false
+	}
+
+	return true
+}
+
+func (v CurrentStateAllocationPoolsValue) Type(ctx context.Context) attr.Type {
+	return CurrentStateAllocationPoolsType{
+		basetypes.ObjectType{
+			AttrTypes: v.AttributeTypes(ctx),
+		},
+	}
+}
+
+func (v CurrentStateAllocationPoolsValue) AttributeTypes(ctx context.Context) map[string]attr.Type {
+	return map[string]attr.Type{
+		"end":   ovhtypes.TfStringType{},
+		"start": ovhtypes.TfStringType{},
+	}
+}
+
+var _ basetypes.ObjectTypable = CurrentStateHostRoutesType{}
+
+type CurrentStateHostRoutesType struct {
+	basetypes.ObjectType
+}
+
+func (t CurrentStateHostRoutesType) Equal(o attr.Type) bool {
+	other, ok := o.(CurrentStateHostRoutesType)
+
+	if !ok {
+		return false
+	}
+
+	return t.ObjectType.Equal(other.ObjectType)
+}
+
+func (t CurrentStateHostRoutesType) String() string {
+	return "CurrentStateHostRoutesType"
+}
+
+func (t CurrentStateHostRoutesType) ValueFromObject(ctx context.Context, in basetypes.ObjectValue) (basetypes.ObjectValuable, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	attributes := in.Attributes()
+
+	destinationAttribute, ok := attributes["destination"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`destination is missing from object`)
+
+		return nil, diags
+	}
+
+	destinationVal, ok := destinationAttribute.(ovhtypes.TfStringValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`destination expected to be ovhtypes.TfStringValue, was: %T`, destinationAttribute))
+	}
+
+	nextHopAttribute, ok := attributes["next_hop"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`next_hop is missing from object`)
+
+		return nil, diags
+	}
+
+	nextHopVal, ok := nextHopAttribute.(ovhtypes.TfStringValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`next_hop expected to be ovhtypes.TfStringValue, was: %T`, nextHopAttribute))
+	}
+
+	if diags.HasError() {
+		return nil, diags
+	}
+
+	return CurrentStateHostRoutesValue{
+		Destination: destinationVal,
+		NextHop:     nextHopVal,
+		state:       attr.ValueStateKnown,
+	}, diags
+}
+
+func NewCurrentStateHostRoutesValueNull() CurrentStateHostRoutesValue {
+	return CurrentStateHostRoutesValue{
+		state: attr.ValueStateNull,
+	}
+}
+
+func NewCurrentStateHostRoutesValueUnknown() CurrentStateHostRoutesValue {
+	return CurrentStateHostRoutesValue{
+		state: attr.ValueStateUnknown,
+	}
+}
+
+func NewCurrentStateHostRoutesValue(attributeTypes map[string]attr.Type, attributes map[string]attr.Value) (CurrentStateHostRoutesValue, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	// Reference: https://github.com/hashicorp/terraform-plugin-framework/issues/521
+	ctx := context.Background()
+
+	for name, attributeType := range attributeTypes {
+		attribute, ok := attributes[name]
+
+		if !ok {
+			diags.AddError(
+				"Missing CurrentStateHostRoutesValue Attribute Value",
+				"While creating a CurrentStateHostRoutesValue value, a missing attribute value was detected. "+
+					"A CurrentStateHostRoutesValue must contain values for all attributes, even if null or unknown. "+
+					"This is always an issue with the provider and should be reported to the provider developers.\n\n"+
+					fmt.Sprintf("CurrentStateHostRoutesValue Attribute Name (%s) Expected Type: %s", name, attributeType.String()),
+			)
+
+			continue
+		}
+
+		if !attributeType.Equal(attribute.Type(ctx)) {
+			diags.AddError(
+				"Invalid CurrentStateHostRoutesValue Attribute Type",
+				"While creating a CurrentStateHostRoutesValue value, an invalid attribute value was detected. "+
+					"A CurrentStateHostRoutesValue must use a matching attribute type for the value. "+
+					"This is always an issue with the provider and should be reported to the provider developers.\n\n"+
+					fmt.Sprintf("CurrentStateHostRoutesValue Attribute Name (%s) Expected Type: %s\n", name, attributeType.String())+
+					fmt.Sprintf("CurrentStateHostRoutesValue Attribute Name (%s) Given Type: %s", name, attribute.Type(ctx)),
+			)
+		}
+	}
+
+	for name := range attributes {
+		_, ok := attributeTypes[name]
+
+		if !ok {
+			diags.AddError(
+				"Extra CurrentStateHostRoutesValue Attribute Value",
+				"While creating a CurrentStateHostRoutesValue value, an extra attribute value was detected. "+
+					"A CurrentStateHostRoutesValue must not contain values beyond the expected attribute types. "+
+					"This is always an issue with the provider and should be reported to the provider developers.\n\n"+
+					fmt.Sprintf("Extra CurrentStateHostRoutesValue Attribute Name: %s", name),
+			)
+		}
+	}
+
+	if diags.HasError() {
+		return NewCurrentStateHostRoutesValueUnknown(), diags
+	}
+
+	destinationAttribute, ok := attributes["destination"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`destination is missing from object`)
+
+		return NewCurrentStateHostRoutesValueUnknown(), diags
+	}
+
+	destinationVal, ok := destinationAttribute.(ovhtypes.TfStringValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`destination expected to be ovhtypes.TfStringValue, was: %T`, destinationAttribute))
+	}
+
+	nextHopAttribute, ok := attributes["next_hop"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`next_hop is missing from object`)
+
+		return NewCurrentStateHostRoutesValueUnknown(), diags
+	}
+
+	nextHopVal, ok := nextHopAttribute.(ovhtypes.TfStringValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`next_hop expected to be ovhtypes.TfStringValue, was: %T`, nextHopAttribute))
+	}
+
+	if diags.HasError() {
+		return NewCurrentStateHostRoutesValueUnknown(), diags
+	}
+
+	return CurrentStateHostRoutesValue{
+		Destination: destinationVal,
+		NextHop:     nextHopVal,
+		state:       attr.ValueStateKnown,
+	}, diags
+}
+
+func NewCurrentStateHostRoutesValueMust(attributeTypes map[string]attr.Type, attributes map[string]attr.Value) CurrentStateHostRoutesValue {
+	object, diags := NewCurrentStateHostRoutesValue(attributeTypes, attributes)
+
+	if diags.HasError() {
+		// This could potentially be added to the diag package.
+		diagsStrings := make([]string, 0, len(diags))
+
+		for _, diagnostic := range diags {
+			diagsStrings = append(diagsStrings, fmt.Sprintf(
+				"%s | %s | %s",
+				diagnostic.Severity(),
+				diagnostic.Summary(),
+				diagnostic.Detail()))
+		}
+
+		panic("NewCurrentStateHostRoutesValueMust received error(s): " + strings.Join(diagsStrings, "\n"))
+	}
+
+	return object
+}
+
+func (t CurrentStateHostRoutesType) ValueFromTerraform(ctx context.Context, in tftypes.Value) (attr.Value, error) {
+	if in.Type() == nil {
+		return NewCurrentStateHostRoutesValueNull(), nil
+	}
+
+	if !in.Type().Equal(t.TerraformType(ctx)) {
+		return nil, fmt.Errorf("expected %s, got %s", t.TerraformType(ctx), in.Type())
+	}
+
+	if !in.IsKnown() {
+		return NewCurrentStateHostRoutesValueUnknown(), nil
+	}
+
+	if in.IsNull() {
+		return NewCurrentStateHostRoutesValueNull(), nil
+	}
+
+	attributes := map[string]attr.Value{}
+
+	val := map[string]tftypes.Value{}
+
+	err := in.As(&val)
+
+	if err != nil {
+		return nil, err
+	}
+
+	for k, v := range val {
+		a, err := t.AttrTypes[k].ValueFromTerraform(ctx, v)
+
+		if err != nil {
+			return nil, err
+		}
+
+		attributes[k] = a
+	}
+
+	return NewCurrentStateHostRoutesValueMust(CurrentStateHostRoutesValue{}.AttributeTypes(ctx), attributes), nil
+}
+
+func (t CurrentStateHostRoutesType) ValueType(ctx context.Context) attr.Value {
+	return CurrentStateHostRoutesValue{}
+}
+
+var _ basetypes.ObjectValuable = CurrentStateHostRoutesValue{}
+
+type CurrentStateHostRoutesValue struct {
+	Destination ovhtypes.TfStringValue `tfsdk:"destination" json:"destination"`
+	NextHop     ovhtypes.TfStringValue `tfsdk:"next_hop" json:"nextHop"`
+	state       attr.ValueState
+}
+
+func (v *CurrentStateHostRoutesValue) UnmarshalJSON(data []byte) error {
+	type JsonCurrentStateHostRoutesValue CurrentStateHostRoutesValue
+
+	var tmp JsonCurrentStateHostRoutesValue
+	if err := json.Unmarshal(data, &tmp); err != nil {
+		return err
+	}
+	v.Destination = tmp.Destination
+	v.NextHop = tmp.NextHop
+
+	v.state = attr.ValueStateKnown
+
+	return nil
+}
+
+func (v *CurrentStateHostRoutesValue) MergeWith(other *CurrentStateHostRoutesValue) {
+
+	if (v.Destination.IsUnknown() || v.Destination.IsNull()) && !other.Destination.IsUnknown() {
+		v.Destination = other.Destination
+	}
+
+	if (v.NextHop.IsUnknown() || v.NextHop.IsNull()) && !other.NextHop.IsUnknown() {
+		v.NextHop = other.NextHop
+	}
+
+	if (v.state == attr.ValueStateUnknown || v.state == attr.ValueStateNull) && other.state != attr.ValueStateUnknown {
+		v.state = other.state
+	}
+}
+
+func (v CurrentStateHostRoutesValue) Attributes() map[string]attr.Value {
+	return map[string]attr.Value{
+		"destination": v.Destination,
+		"nextHop":     v.NextHop,
+	}
+}
+func (v CurrentStateHostRoutesValue) ToTerraformValue(ctx context.Context) (tftypes.Value, error) {
+	attrTypes := make(map[string]tftypes.Type, 2)
+
+	var val tftypes.Value
+	var err error
+
+	attrTypes["destination"] = basetypes.StringType{}.TerraformType(ctx)
+	attrTypes["next_hop"] = basetypes.StringType{}.TerraformType(ctx)
+
+	objectType := tftypes.Object{AttributeTypes: attrTypes}
+
+	switch v.state {
+	case attr.ValueStateKnown:
+		vals := make(map[string]tftypes.Value, 2)
+
+		val, err = v.Destination.ToTerraformValue(ctx)
+
+		if err != nil {
+			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
+		}
+
+		vals["destination"] = val
+
+		val, err = v.NextHop.ToTerraformValue(ctx)
+
+		if err != nil {
+			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
+		}
+
+		vals["next_hop"] = val
+
+		if err := tftypes.ValidateValue(objectType, vals); err != nil {
+			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
+		}
+
+		return tftypes.NewValue(objectType, vals), nil
+	case attr.ValueStateNull:
+		return tftypes.NewValue(objectType, nil), nil
+	case attr.ValueStateUnknown:
+		return tftypes.NewValue(objectType, tftypes.UnknownValue), nil
+	default:
+		panic(fmt.Sprintf("unhandled Object state in ToTerraformValue: %s", v.state))
+	}
+}
+
+func (v CurrentStateHostRoutesValue) IsNull() bool {
+	return v.state == attr.ValueStateNull
+}
+
+func (v CurrentStateHostRoutesValue) IsUnknown() bool {
+	return v.state == attr.ValueStateUnknown
+}
+
+func (v CurrentStateHostRoutesValue) String() string {
+	return "CurrentStateHostRoutesValue"
+}
+
+func (v CurrentStateHostRoutesValue) ToObjectValue(ctx context.Context) (basetypes.ObjectValue, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	objVal, diags := types.ObjectValue(
+		map[string]attr.Type{
+			"destination": ovhtypes.TfStringType{},
+			"next_hop":    ovhtypes.TfStringType{},
+		},
+		map[string]attr.Value{
+			"destination": v.Destination,
+			"next_hop":    v.NextHop,
+		})
+
+	return objVal, diags
+}
+
+func (v CurrentStateHostRoutesValue) Equal(o attr.Value) bool {
+	other, ok := o.(CurrentStateHostRoutesValue)
+
+	if !ok {
+		return false
+	}
+
+	if v.state != other.state {
+		return false
+	}
+
+	if v.state != attr.ValueStateKnown {
+		return true
+	}
+
+	if !v.Destination.Equal(other.Destination) {
+		return false
+	}
+
+	if !v.NextHop.Equal(other.NextHop) {
+		return false
+	}
+
+	return true
+}
+
+func (v CurrentStateHostRoutesValue) Type(ctx context.Context) attr.Type {
+	return CurrentStateHostRoutesType{
+		basetypes.ObjectType{
+			AttrTypes: v.AttributeTypes(ctx),
+		},
+	}
+}
+
+func (v CurrentStateHostRoutesValue) AttributeTypes(ctx context.Context) map[string]attr.Type {
+	return map[string]attr.Type{
+		"destination": ovhtypes.TfStringType{},
+		"next_hop":    ovhtypes.TfStringType{},
+	}
+}
+
+var _ basetypes.ObjectTypable = CurrentStateLocationType{}
+
+type CurrentStateLocationType struct {
+	basetypes.ObjectType
+}
+
+func (t CurrentStateLocationType) Equal(o attr.Type) bool {
+	other, ok := o.(CurrentStateLocationType)
+
+	if !ok {
+		return false
+	}
+
+	return t.ObjectType.Equal(other.ObjectType)
+}
+
+func (t CurrentStateLocationType) String() string {
+	return "CurrentStateLocationType"
+}
+
+func (t CurrentStateLocationType) ValueFromObject(ctx context.Context, in basetypes.ObjectValue) (basetypes.ObjectValuable, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	attributes := in.Attributes()
+
+	availabilityZoneAttribute, ok := attributes["availability_zone"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`availability_zone is missing from object`)
+
+		return nil, diags
+	}
+
+	availabilityZoneVal, ok := availabilityZoneAttribute.(ovhtypes.TfStringValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`availability_zone expected to be ovhtypes.TfStringValue, was: %T`, availabilityZoneAttribute))
+	}
+
+	regionAttribute, ok := attributes["region"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`region is missing from object`)
+
+		return nil, diags
+	}
+
+	regionVal, ok := regionAttribute.(ovhtypes.TfStringValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`region expected to be ovhtypes.TfStringValue, was: %T`, regionAttribute))
+	}
+
+	if diags.HasError() {
+		return nil, diags
+	}
+
+	return CurrentStateLocationValue{
+		AvailabilityZone: availabilityZoneVal,
+		Region:           regionVal,
+		state:            attr.ValueStateKnown,
+	}, diags
+}
+
+func NewCurrentStateLocationValueNull() CurrentStateLocationValue {
+	return CurrentStateLocationValue{
+		state: attr.ValueStateNull,
+	}
+}
+
+func NewCurrentStateLocationValueUnknown() CurrentStateLocationValue {
+	return CurrentStateLocationValue{
+		state: attr.ValueStateUnknown,
+	}
+}
+
+func NewCurrentStateLocationValue(attributeTypes map[string]attr.Type, attributes map[string]attr.Value) (CurrentStateLocationValue, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	// Reference: https://github.com/hashicorp/terraform-plugin-framework/issues/521
+	ctx := context.Background()
+
+	for name, attributeType := range attributeTypes {
+		attribute, ok := attributes[name]
+
+		if !ok {
+			diags.AddError(
+				"Missing CurrentStateLocationValue Attribute Value",
+				"While creating a CurrentStateLocationValue value, a missing attribute value was detected. "+
+					"A CurrentStateLocationValue must contain values for all attributes, even if null or unknown. "+
+					"This is always an issue with the provider and should be reported to the provider developers.\n\n"+
+					fmt.Sprintf("CurrentStateLocationValue Attribute Name (%s) Expected Type: %s", name, attributeType.String()),
+			)
+
+			continue
+		}
+
+		if !attributeType.Equal(attribute.Type(ctx)) {
+			diags.AddError(
+				"Invalid CurrentStateLocationValue Attribute Type",
+				"While creating a CurrentStateLocationValue value, an invalid attribute value was detected. "+
+					"A CurrentStateLocationValue must use a matching attribute type for the value. "+
+					"This is always an issue with the provider and should be reported to the provider developers.\n\n"+
+					fmt.Sprintf("CurrentStateLocationValue Attribute Name (%s) Expected Type: %s\n", name, attributeType.String())+
+					fmt.Sprintf("CurrentStateLocationValue Attribute Name (%s) Given Type: %s", name, attribute.Type(ctx)),
+			)
+		}
+	}
+
+	for name := range attributes {
+		_, ok := attributeTypes[name]
+
+		if !ok {
+			diags.AddError(
+				"Extra CurrentStateLocationValue Attribute Value",
+				"While creating a CurrentStateLocationValue value, an extra attribute value was detected. "+
+					"A CurrentStateLocationValue must not contain values beyond the expected attribute types. "+
+					"This is always an issue with the provider and should be reported to the provider developers.\n\n"+
+					fmt.Sprintf("Extra CurrentStateLocationValue Attribute Name: %s", name),
+			)
+		}
+	}
+
+	if diags.HasError() {
+		return NewCurrentStateLocationValueUnknown(), diags
+	}
+
+	availabilityZoneAttribute, ok := attributes["availability_zone"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`availability_zone is missing from object`)
+
+		return NewCurrentStateLocationValueUnknown(), diags
+	}
+
+	availabilityZoneVal, ok := availabilityZoneAttribute.(ovhtypes.TfStringValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`availability_zone expected to be ovhtypes.TfStringValue, was: %T`, availabilityZoneAttribute))
+	}
+
+	regionAttribute, ok := attributes["region"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`region is missing from object`)
+
+		return NewCurrentStateLocationValueUnknown(), diags
+	}
+
+	regionVal, ok := regionAttribute.(ovhtypes.TfStringValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`region expected to be ovhtypes.TfStringValue, was: %T`, regionAttribute))
+	}
+
+	if diags.HasError() {
+		return NewCurrentStateLocationValueUnknown(), diags
+	}
+
+	return CurrentStateLocationValue{
+		AvailabilityZone: availabilityZoneVal,
+		Region:           regionVal,
+		state:            attr.ValueStateKnown,
+	}, diags
+}
+
+func NewCurrentStateLocationValueMust(attributeTypes map[string]attr.Type, attributes map[string]attr.Value) CurrentStateLocationValue {
+	object, diags := NewCurrentStateLocationValue(attributeTypes, attributes)
+
+	if diags.HasError() {
+		// This could potentially be added to the diag package.
+		diagsStrings := make([]string, 0, len(diags))
+
+		for _, diagnostic := range diags {
+			diagsStrings = append(diagsStrings, fmt.Sprintf(
+				"%s | %s | %s",
+				diagnostic.Severity(),
+				diagnostic.Summary(),
+				diagnostic.Detail()))
+		}
+
+		panic("NewCurrentStateLocationValueMust received error(s): " + strings.Join(diagsStrings, "\n"))
+	}
+
+	return object
+}
+
+func (t CurrentStateLocationType) ValueFromTerraform(ctx context.Context, in tftypes.Value) (attr.Value, error) {
+	if in.Type() == nil {
+		return NewCurrentStateLocationValueNull(), nil
+	}
+
+	if !in.Type().Equal(t.TerraformType(ctx)) {
+		return nil, fmt.Errorf("expected %s, got %s", t.TerraformType(ctx), in.Type())
+	}
+
+	if !in.IsKnown() {
+		return NewCurrentStateLocationValueUnknown(), nil
+	}
+
+	if in.IsNull() {
+		return NewCurrentStateLocationValueNull(), nil
+	}
+
+	attributes := map[string]attr.Value{}
+
+	val := map[string]tftypes.Value{}
+
+	err := in.As(&val)
+
+	if err != nil {
+		return nil, err
+	}
+
+	for k, v := range val {
+		a, err := t.AttrTypes[k].ValueFromTerraform(ctx, v)
+
+		if err != nil {
+			return nil, err
+		}
+
+		attributes[k] = a
+	}
+
+	return NewCurrentStateLocationValueMust(CurrentStateLocationValue{}.AttributeTypes(ctx), attributes), nil
+}
+
+func (t CurrentStateLocationType) ValueType(ctx context.Context) attr.Value {
+	return CurrentStateLocationValue{}
+}
+
+var _ basetypes.ObjectValuable = CurrentStateLocationValue{}
+
+type CurrentStateLocationValue struct {
+	AvailabilityZone ovhtypes.TfStringValue `tfsdk:"availability_zone" json:"availabilityZone"`
+	Region           ovhtypes.TfStringValue `tfsdk:"region" json:"region"`
+	state            attr.ValueState
+}
+
+func (v *CurrentStateLocationValue) UnmarshalJSON(data []byte) error {
+	type JsonCurrentStateLocationValue CurrentStateLocationValue
+
+	var tmp JsonCurrentStateLocationValue
+	if err := json.Unmarshal(data, &tmp); err != nil {
+		return err
+	}
+	v.AvailabilityZone = tmp.AvailabilityZone
+	v.Region = tmp.Region
+
+	v.state = attr.ValueStateKnown
+
+	return nil
+}
+
+func (v *CurrentStateLocationValue) MergeWith(other *CurrentStateLocationValue) {
+
+	if (v.AvailabilityZone.IsUnknown() || v.AvailabilityZone.IsNull()) && !other.AvailabilityZone.IsUnknown() {
+		v.AvailabilityZone = other.AvailabilityZone
+	}
+
+	if (v.Region.IsUnknown() || v.Region.IsNull()) && !other.Region.IsUnknown() {
+		v.Region = other.Region
+	}
+
+	if (v.state == attr.ValueStateUnknown || v.state == attr.ValueStateNull) && other.state != attr.ValueStateUnknown {
+		v.state = other.state
+	}
+}
+
+func (v CurrentStateLocationValue) Attributes() map[string]attr.Value {
+	return map[string]attr.Value{
+		"availabilityZone": v.AvailabilityZone,
+		"region":           v.Region,
+	}
+}
+func (v CurrentStateLocationValue) ToTerraformValue(ctx context.Context) (tftypes.Value, error) {
+	attrTypes := make(map[string]tftypes.Type, 2)
+
+	var val tftypes.Value
+	var err error
+
+	attrTypes["availability_zone"] = basetypes.StringType{}.TerraformType(ctx)
+	attrTypes["region"] = basetypes.StringType{}.TerraformType(ctx)
+
+	objectType := tftypes.Object{AttributeTypes: attrTypes}
+
+	switch v.state {
+	case attr.ValueStateKnown:
+		vals := make(map[string]tftypes.Value, 2)
+
+		val, err = v.AvailabilityZone.ToTerraformValue(ctx)
+
+		if err != nil {
+			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
+		}
+
+		vals["availability_zone"] = val
+
+		val, err = v.Region.ToTerraformValue(ctx)
+
+		if err != nil {
+			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
+		}
+
+		vals["region"] = val
+
+		if err := tftypes.ValidateValue(objectType, vals); err != nil {
+			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
+		}
+
+		return tftypes.NewValue(objectType, vals), nil
+	case attr.ValueStateNull:
+		return tftypes.NewValue(objectType, nil), nil
+	case attr.ValueStateUnknown:
+		return tftypes.NewValue(objectType, tftypes.UnknownValue), nil
+	default:
+		panic(fmt.Sprintf("unhandled Object state in ToTerraformValue: %s", v.state))
+	}
+}
+
+func (v CurrentStateLocationValue) IsNull() bool {
+	return v.state == attr.ValueStateNull
+}
+
+func (v CurrentStateLocationValue) IsUnknown() bool {
+	return v.state == attr.ValueStateUnknown
+}
+
+func (v CurrentStateLocationValue) String() string {
+	return "CurrentStateLocationValue"
+}
+
+func (v CurrentStateLocationValue) ToObjectValue(ctx context.Context) (basetypes.ObjectValue, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	objVal, diags := types.ObjectValue(
+		map[string]attr.Type{
+			"availability_zone": ovhtypes.TfStringType{},
+			"region":            ovhtypes.TfStringType{},
+		},
+		map[string]attr.Value{
+			"availability_zone": v.AvailabilityZone,
+			"region":            v.Region,
+		})
+
+	return objVal, diags
+}
+
+func (v CurrentStateLocationValue) Equal(o attr.Value) bool {
+	other, ok := o.(CurrentStateLocationValue)
+
+	if !ok {
+		return false
+	}
+
+	if v.state != other.state {
+		return false
+	}
+
+	if v.state != attr.ValueStateKnown {
+		return true
+	}
+
+	if !v.AvailabilityZone.Equal(other.AvailabilityZone) {
+		return false
+	}
+
+	if !v.Region.Equal(other.Region) {
+		return false
+	}
+
+	return true
+}
+
+func (v CurrentStateLocationValue) Type(ctx context.Context) attr.Type {
+	return CurrentStateLocationType{
+		basetypes.ObjectType{
+			AttrTypes: v.AttributeTypes(ctx),
+		},
+	}
+}
+
+func (v CurrentStateLocationValue) AttributeTypes(ctx context.Context) map[string]attr.Type {
+	return map[string]attr.Type{
+		"availability_zone": ovhtypes.TfStringType{},
+		"region":            ovhtypes.TfStringType{},
+	}
+}
+
+var _ basetypes.ObjectTypable = CloudNetworkPrivateSubnetCurrentTasksType{}
+
+type CloudNetworkPrivateSubnetCurrentTasksType struct {
+	basetypes.ObjectType
+}
+
+func (t CloudNetworkPrivateSubnetCurrentTasksType) Equal(o attr.Type) bool {
+	other, ok := o.(CloudNetworkPrivateSubnetCurrentTasksType)
+
+	if !ok {
+		return false
+	}
+
+	return t.ObjectType.Equal(other.ObjectType)
+}
+
+func (t CloudNetworkPrivateSubnetCurrentTasksType) String() string {
+	return "CloudNetworkPrivateSubnetCurrentTasksType"
+}
+
+func (t CloudNetworkPrivateSubnetCurrentTasksType) ValueFromObject(ctx context.Context, in basetypes.ObjectValue) (basetypes.ObjectValuable, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	attributes := in.Attributes()
+
+	errorsAttribute, ok := attributes["errors"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`errors is missing from object`)
+
+		return nil, diags
+	}
+
+	errorsVal, ok := errorsAttribute.(ovhtypes.TfListNestedValue[CurrentTasksErrorsValue])
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`errors expected to be ovhtypes.TfListNestedValue[CurrentTasksErrorsValue], was: %T`, errorsAttribute))
+	}
+
+	idAttribute, ok := attributes["id"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`id is missing from object`)
+
+		return nil, diags
+	}
+
+	idVal, ok := idAttribute.(ovhtypes.TfStringValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`id expected to be ovhtypes.TfStringValue, was: %T`, idAttribute))
+	}
+
+	linkAttribute, ok := attributes["link"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`link is missing from object`)
+
+		return nil, diags
+	}
+
+	linkVal, ok := linkAttribute.(ovhtypes.TfStringValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`link expected to be ovhtypes.TfStringValue, was: %T`, linkAttribute))
+	}
+
+	statusAttribute, ok := attributes["status"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`status is missing from object`)
+
+		return nil, diags
+	}
+
+	statusVal, ok := statusAttribute.(ovhtypes.TfStringValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`status expected to be ovhtypes.TfStringValue, was: %T`, statusAttribute))
+	}
+
+	typeAttribute, ok := attributes["type"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`type is missing from object`)
+
+		return nil, diags
+	}
+
+	typeVal, ok := typeAttribute.(ovhtypes.TfStringValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`type expected to be ovhtypes.TfStringValue, was: %T`, typeAttribute))
+	}
+
+	if diags.HasError() {
+		return nil, diags
+	}
+
+	return CloudNetworkPrivateSubnetCurrentTasksValue{
+		Errors: errorsVal,
+		Id:     idVal,
+		Link:   linkVal,
+		Status: statusVal,
+		CloudNetworkPrivateSubnetCurrentTasksType: typeVal,
+		state: attr.ValueStateKnown,
+	}, diags
+}
+
+func NewCloudNetworkPrivateSubnetCurrentTasksValueNull() CloudNetworkPrivateSubnetCurrentTasksValue {
+	return CloudNetworkPrivateSubnetCurrentTasksValue{
+		state: attr.ValueStateNull,
+	}
+}
+
+func NewCloudNetworkPrivateSubnetCurrentTasksValueUnknown() CloudNetworkPrivateSubnetCurrentTasksValue {
+	return CloudNetworkPrivateSubnetCurrentTasksValue{
+		state: attr.ValueStateUnknown,
+	}
+}
+
+func NewCloudNetworkPrivateSubnetCurrentTasksValue(attributeTypes map[string]attr.Type, attributes map[string]attr.Value) (CloudNetworkPrivateSubnetCurrentTasksValue, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	// Reference: https://github.com/hashicorp/terraform-plugin-framework/issues/521
+	ctx := context.Background()
+
+	for name, attributeType := range attributeTypes {
+		attribute, ok := attributes[name]
+
+		if !ok {
+			diags.AddError(
+				"Missing CloudNetworkPrivateSubnetCurrentTasksValue Attribute Value",
+				"While creating a CloudNetworkPrivateSubnetCurrentTasksValue value, a missing attribute value was detected. "+
+					"A CloudNetworkPrivateSubnetCurrentTasksValue must contain values for all attributes, even if null or unknown. "+
+					"This is always an issue with the provider and should be reported to the provider developers.\n\n"+
+					fmt.Sprintf("CloudNetworkPrivateSubnetCurrentTasksValue Attribute Name (%s) Expected Type: %s", name, attributeType.String()),
+			)
+
+			continue
+		}
+
+		if !attributeType.Equal(attribute.Type(ctx)) {
+			diags.AddError(
+				"Invalid CloudNetworkPrivateSubnetCurrentTasksValue Attribute Type",
+				"While creating a CloudNetworkPrivateSubnetCurrentTasksValue value, an invalid attribute value was detected. "+
+					"A CloudNetworkPrivateSubnetCurrentTasksValue must use a matching attribute type for the value. "+
+					"This is always an issue with the provider and should be reported to the provider developers.\n\n"+
+					fmt.Sprintf("CloudNetworkPrivateSubnetCurrentTasksValue Attribute Name (%s) Expected Type: %s\n", name, attributeType.String())+
+					fmt.Sprintf("CloudNetworkPrivateSubnetCurrentTasksValue Attribute Name (%s) Given Type: %s", name, attribute.Type(ctx)),
+			)
+		}
+	}
+
+	for name := range attributes {
+		_, ok := attributeTypes[name]
+
+		if !ok {
+			diags.AddError(
+				"Extra CloudNetworkPrivateSubnetCurrentTasksValue Attribute Value",
+				"While creating a CloudNetworkPrivateSubnetCurrentTasksValue value, an extra attribute value was detected. "+
+					"A CloudNetworkPrivateSubnetCurrentTasksValue must not contain values beyond the expected attribute types. "+
+					"This is always an issue with the provider and should be reported to the provider developers.\n\n"+
+					fmt.Sprintf("Extra CloudNetworkPrivateSubnetCurrentTasksValue Attribute Name: %s", name),
+			)
+		}
+	}
+
+	if diags.HasError() {
+		return NewCloudNetworkPrivateSubnetCurrentTasksValueUnknown(), diags
+	}
+
+	errorsAttribute, ok := attributes["errors"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`errors is missing from object`)
+
+		return NewCloudNetworkPrivateSubnetCurrentTasksValueUnknown(), diags
+	}
+
+	errorsVal, ok := errorsAttribute.(ovhtypes.TfListNestedValue[CurrentTasksErrorsValue])
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`errors expected to be ovhtypes.TfListNestedValue[CurrentTasksErrorsValue], was: %T`, errorsAttribute))
+	}
+
+	idAttribute, ok := attributes["id"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`id is missing from object`)
+
+		return NewCloudNetworkPrivateSubnetCurrentTasksValueUnknown(), diags
+	}
+
+	idVal, ok := idAttribute.(ovhtypes.TfStringValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`id expected to be ovhtypes.TfStringValue, was: %T`, idAttribute))
+	}
+
+	linkAttribute, ok := attributes["link"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`link is missing from object`)
+
+		return NewCloudNetworkPrivateSubnetCurrentTasksValueUnknown(), diags
+	}
+
+	linkVal, ok := linkAttribute.(ovhtypes.TfStringValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`link expected to be ovhtypes.TfStringValue, was: %T`, linkAttribute))
+	}
+
+	statusAttribute, ok := attributes["status"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`status is missing from object`)
+
+		return NewCloudNetworkPrivateSubnetCurrentTasksValueUnknown(), diags
+	}
+
+	statusVal, ok := statusAttribute.(ovhtypes.TfStringValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`status expected to be ovhtypes.TfStringValue, was: %T`, statusAttribute))
+	}
+
+	typeAttribute, ok := attributes["type"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`type is missing from object`)
+
+		return NewCloudNetworkPrivateSubnetCurrentTasksValueUnknown(), diags
+	}
+
+	typeVal, ok := typeAttribute.(ovhtypes.TfStringValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`type expected to be ovhtypes.TfStringValue, was: %T`, typeAttribute))
+	}
+
+	if diags.HasError() {
+		return NewCloudNetworkPrivateSubnetCurrentTasksValueUnknown(), diags
+	}
+
+	return CloudNetworkPrivateSubnetCurrentTasksValue{
+		Errors: errorsVal,
+		Id:     idVal,
+		Link:   linkVal,
+		Status: statusVal,
+		CloudNetworkPrivateSubnetCurrentTasksType: typeVal,
+		state: attr.ValueStateKnown,
+	}, diags
+}
+
+func NewCloudNetworkPrivateSubnetCurrentTasksValueMust(attributeTypes map[string]attr.Type, attributes map[string]attr.Value) CloudNetworkPrivateSubnetCurrentTasksValue {
+	object, diags := NewCloudNetworkPrivateSubnetCurrentTasksValue(attributeTypes, attributes)
+
+	if diags.HasError() {
+		// This could potentially be added to the diag package.
+		diagsStrings := make([]string, 0, len(diags))
+
+		for _, diagnostic := range diags {
+			diagsStrings = append(diagsStrings, fmt.Sprintf(
+				"%s | %s | %s",
+				diagnostic.Severity(),
+				diagnostic.Summary(),
+				diagnostic.Detail()))
+		}
+
+		panic("NewCloudNetworkPrivateSubnetCurrentTasksValueMust received error(s): " + strings.Join(diagsStrings, "\n"))
+	}
+
+	return object
+}
+
+func (t CloudNetworkPrivateSubnetCurrentTasksType) ValueFromTerraform(ctx context.Context, in tftypes.Value) (attr.Value, error) {
+	if in.Type() == nil {
+		return NewCloudNetworkPrivateSubnetCurrentTasksValueNull(), nil
+	}
+
+	if !in.Type().Equal(t.TerraformType(ctx)) {
+		return nil, fmt.Errorf("expected %s, got %s", t.TerraformType(ctx), in.Type())
+	}
+
+	if !in.IsKnown() {
+		return NewCloudNetworkPrivateSubnetCurrentTasksValueUnknown(), nil
+	}
+
+	if in.IsNull() {
+		return NewCloudNetworkPrivateSubnetCurrentTasksValueNull(), nil
+	}
+
+	attributes := map[string]attr.Value{}
+
+	val := map[string]tftypes.Value{}
+
+	err := in.As(&val)
+
+	if err != nil {
+		return nil, err
+	}
+
+	for k, v := range val {
+		a, err := t.AttrTypes[k].ValueFromTerraform(ctx, v)
+
+		if err != nil {
+			return nil, err
+		}
+
+		attributes[k] = a
+	}
+
+	return NewCloudNetworkPrivateSubnetCurrentTasksValueMust(CloudNetworkPrivateSubnetCurrentTasksValue{}.AttributeTypes(ctx), attributes), nil
+}
+
+func (t CloudNetworkPrivateSubnetCurrentTasksType) ValueType(ctx context.Context) attr.Value {
+	return CloudNetworkPrivateSubnetCurrentTasksValue{}
+}
+
+var _ basetypes.ObjectValuable = CloudNetworkPrivateSubnetCurrentTasksValue{}
+
+type CloudNetworkPrivateSubnetCurrentTasksValue struct {
+	Errors                                    ovhtypes.TfListNestedValue[CurrentTasksErrorsValue] `tfsdk:"errors" json:"errors"`
+	Id                                        ovhtypes.TfStringValue                              `tfsdk:"id" json:"id"`
+	Link                                      ovhtypes.TfStringValue                              `tfsdk:"link" json:"link"`
+	Status                                    ovhtypes.TfStringValue                              `tfsdk:"status" json:"status"`
+	CloudNetworkPrivateSubnetCurrentTasksType ovhtypes.TfStringValue                              `tfsdk:"type" json:"type"`
+	state                                     attr.ValueState
+}
+
+func (v *CloudNetworkPrivateSubnetCurrentTasksValue) UnmarshalJSON(data []byte) error {
+	type JsonCurrentTasksValue CloudNetworkPrivateSubnetCurrentTasksValue
+
+	var tmp JsonCurrentTasksValue
+	if err := json.Unmarshal(data, &tmp); err != nil {
+		return err
+	}
+	v.Errors = tmp.Errors
+	v.Id = tmp.Id
+	v.Link = tmp.Link
+	v.Status = tmp.Status
+	v.CloudNetworkPrivateSubnetCurrentTasksType = tmp.CloudNetworkPrivateSubnetCurrentTasksType
+
+	v.state = attr.ValueStateKnown
+
+	return nil
+}
+
+func (v *CloudNetworkPrivateSubnetCurrentTasksValue) MergeWith(other *CloudNetworkPrivateSubnetCurrentTasksValue) {
+
+	if (v.Errors.IsUnknown() || v.Errors.IsNull()) && !other.Errors.IsUnknown() {
+		v.Errors = other.Errors
+	} else if !other.Errors.IsUnknown() {
+		newSlice := make([]attr.Value, 0)
+		elems := v.Errors.Elements()
+		newElems := other.Errors.Elements()
+
+		if len(elems) != len(newElems) {
+			v.Errors = other.Errors
+		} else {
+			for idx, e := range elems {
+				tmp := e.(CurrentTasksErrorsValue)
+				tmp2 := newElems[idx].(CurrentTasksErrorsValue)
+				tmp.MergeWith(&tmp2)
+				newSlice = append(newSlice, tmp)
+			}
+
+			v.Errors = ovhtypes.TfListNestedValue[CurrentTasksErrorsValue]{
+				ListValue: basetypes.NewListValueMust(CurrentTasksErrorsValue{}.Type(context.Background()), newSlice),
+			}
+		}
+	}
+
+	if (v.Id.IsUnknown() || v.Id.IsNull()) && !other.Id.IsUnknown() {
+		v.Id = other.Id
+	}
+
+	if (v.Link.IsUnknown() || v.Link.IsNull()) && !other.Link.IsUnknown() {
+		v.Link = other.Link
+	}
+
+	if (v.Status.IsUnknown() || v.Status.IsNull()) && !other.Status.IsUnknown() {
+		v.Status = other.Status
+	}
+
+	if (v.CloudNetworkPrivateSubnetCurrentTasksType.IsUnknown() || v.CloudNetworkPrivateSubnetCurrentTasksType.IsNull()) && !other.CloudNetworkPrivateSubnetCurrentTasksType.IsUnknown() {
+		v.CloudNetworkPrivateSubnetCurrentTasksType = other.CloudNetworkPrivateSubnetCurrentTasksType
+	}
+
+	if (v.state == attr.ValueStateUnknown || v.state == attr.ValueStateNull) && other.state != attr.ValueStateUnknown {
+		v.state = other.state
+	}
+}
+
+func (v CloudNetworkPrivateSubnetCurrentTasksValue) Attributes() map[string]attr.Value {
+	return map[string]attr.Value{
+		"errors": v.Errors,
+		"id":     v.Id,
+		"link":   v.Link,
+		"status": v.Status,
+		"type":   v.CloudNetworkPrivateSubnetCurrentTasksType,
+	}
+}
+func (v CloudNetworkPrivateSubnetCurrentTasksValue) ToTerraformValue(ctx context.Context) (tftypes.Value, error) {
+	attrTypes := make(map[string]tftypes.Type, 5)
+
+	var val tftypes.Value
+	var err error
+
+	attrTypes["errors"] = basetypes.ListType{
+		ElemType: CurrentTasksErrorsValue{}.Type(ctx),
+	}.TerraformType(ctx)
+	attrTypes["id"] = basetypes.StringType{}.TerraformType(ctx)
+	attrTypes["link"] = basetypes.StringType{}.TerraformType(ctx)
+	attrTypes["status"] = basetypes.StringType{}.TerraformType(ctx)
+	attrTypes["type"] = basetypes.StringType{}.TerraformType(ctx)
+
+	objectType := tftypes.Object{AttributeTypes: attrTypes}
+
+	switch v.state {
+	case attr.ValueStateKnown:
+		vals := make(map[string]tftypes.Value, 5)
+
+		val, err = v.Errors.ToTerraformValue(ctx)
+
+		if err != nil {
+			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
+		}
+
+		vals["errors"] = val
+
+		val, err = v.Id.ToTerraformValue(ctx)
+
+		if err != nil {
+			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
+		}
+
+		vals["id"] = val
+
+		val, err = v.Link.ToTerraformValue(ctx)
+
+		if err != nil {
+			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
+		}
+
+		vals["link"] = val
+
+		val, err = v.Status.ToTerraformValue(ctx)
+
+		if err != nil {
+			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
+		}
+
+		vals["status"] = val
+
+		val, err = v.CloudNetworkPrivateSubnetCurrentTasksType.ToTerraformValue(ctx)
+
+		if err != nil {
+			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
+		}
+
+		vals["type"] = val
+
+		if err := tftypes.ValidateValue(objectType, vals); err != nil {
+			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
+		}
+
+		return tftypes.NewValue(objectType, vals), nil
+	case attr.ValueStateNull:
+		return tftypes.NewValue(objectType, nil), nil
+	case attr.ValueStateUnknown:
+		return tftypes.NewValue(objectType, tftypes.UnknownValue), nil
+	default:
+		panic(fmt.Sprintf("unhandled Object state in ToTerraformValue: %s", v.state))
+	}
+}
+
+func (v CloudNetworkPrivateSubnetCurrentTasksValue) IsNull() bool {
+	return v.state == attr.ValueStateNull
+}
+
+func (v CloudNetworkPrivateSubnetCurrentTasksValue) IsUnknown() bool {
+	return v.state == attr.ValueStateUnknown
+}
+
+func (v CloudNetworkPrivateSubnetCurrentTasksValue) String() string {
+	return "CloudNetworkPrivateSubnetCurrentTasksValue"
+}
+
+func (v CloudNetworkPrivateSubnetCurrentTasksValue) ToObjectValue(ctx context.Context) (basetypes.ObjectValue, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	objVal, diags := types.ObjectValue(
+		map[string]attr.Type{
+			"errors": ovhtypes.NewTfListNestedType[CurrentTasksErrorsValue](ctx),
+			"id":     ovhtypes.TfStringType{},
+			"link":   ovhtypes.TfStringType{},
+			"status": ovhtypes.TfStringType{},
+			"type":   ovhtypes.TfStringType{},
+		},
+		map[string]attr.Value{
+			"errors": v.Errors,
+			"id":     v.Id,
+			"link":   v.Link,
+			"status": v.Status,
+			"type":   v.CloudNetworkPrivateSubnetCurrentTasksType,
+		})
+
+	return objVal, diags
+}
+
+func (v CloudNetworkPrivateSubnetCurrentTasksValue) Equal(o attr.Value) bool {
+	other, ok := o.(CloudNetworkPrivateSubnetCurrentTasksValue)
+
+	if !ok {
+		return false
+	}
+
+	if v.state != other.state {
+		return false
+	}
+
+	if v.state != attr.ValueStateKnown {
+		return true
+	}
+
+	if !v.Errors.Equal(other.Errors) {
+		return false
+	}
+
+	if !v.Id.Equal(other.Id) {
+		return false
+	}
+
+	if !v.Link.Equal(other.Link) {
+		return false
+	}
+
+	if !v.Status.Equal(other.Status) {
+		return false
+	}
+
+	if !v.CloudNetworkPrivateSubnetCurrentTasksType.Equal(other.CloudNetworkPrivateSubnetCurrentTasksType) {
+		return false
+	}
+
+	return true
+}
+
+func (v CloudNetworkPrivateSubnetCurrentTasksValue) Type(ctx context.Context) attr.Type {
+	return CloudNetworkPrivateSubnetCurrentTasksType{
+		basetypes.ObjectType{
+			AttrTypes: v.AttributeTypes(ctx),
+		},
+	}
+}
+
+func (v CloudNetworkPrivateSubnetCurrentTasksValue) AttributeTypes(ctx context.Context) map[string]attr.Type {
+	return map[string]attr.Type{
+		"errors": ovhtypes.NewTfListNestedType[CurrentTasksErrorsValue](ctx),
+		"id":     ovhtypes.TfStringType{},
+		"link":   ovhtypes.TfStringType{},
+		"status": ovhtypes.TfStringType{},
+		"type":   ovhtypes.TfStringType{},
+	}
+}
+
+var _ basetypes.ObjectTypable = CurrentTasksErrorsType{}
+
+type CurrentTasksErrorsType struct {
+	basetypes.ObjectType
+}
+
+func (t CurrentTasksErrorsType) Equal(o attr.Type) bool {
+	other, ok := o.(CurrentTasksErrorsType)
+
+	if !ok {
+		return false
+	}
+
+	return t.ObjectType.Equal(other.ObjectType)
+}
+
+func (t CurrentTasksErrorsType) String() string {
+	return "CurrentTasksErrorsType"
+}
+
+func (t CurrentTasksErrorsType) ValueFromObject(ctx context.Context, in basetypes.ObjectValue) (basetypes.ObjectValuable, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	attributes := in.Attributes()
+
+	messageAttribute, ok := attributes["message"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`message is missing from object`)
+
+		return nil, diags
+	}
+
+	messageVal, ok := messageAttribute.(ovhtypes.TfStringValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`message expected to be ovhtypes.TfStringValue, was: %T`, messageAttribute))
+	}
+
+	if diags.HasError() {
+		return nil, diags
+	}
+
+	return CurrentTasksErrorsValue{
+		Message: messageVal,
+		state:   attr.ValueStateKnown,
+	}, diags
+}
+
+func NewCurrentTasksErrorsValueNull() CurrentTasksErrorsValue {
+	return CurrentTasksErrorsValue{
+		state: attr.ValueStateNull,
+	}
+}
+
+func NewCurrentTasksErrorsValueUnknown() CurrentTasksErrorsValue {
+	return CurrentTasksErrorsValue{
+		state: attr.ValueStateUnknown,
+	}
+}
+
+func NewCurrentTasksErrorsValue(attributeTypes map[string]attr.Type, attributes map[string]attr.Value) (CurrentTasksErrorsValue, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	// Reference: https://github.com/hashicorp/terraform-plugin-framework/issues/521
+	ctx := context.Background()
+
+	for name, attributeType := range attributeTypes {
+		attribute, ok := attributes[name]
+
+		if !ok {
+			diags.AddError(
+				"Missing CurrentTasksErrorsValue Attribute Value",
+				"While creating a CurrentTasksErrorsValue value, a missing attribute value was detected. "+
+					"A CurrentTasksErrorsValue must contain values for all attributes, even if null or unknown. "+
+					"This is always an issue with the provider and should be reported to the provider developers.\n\n"+
+					fmt.Sprintf("CurrentTasksErrorsValue Attribute Name (%s) Expected Type: %s", name, attributeType.String()),
+			)
+
+			continue
+		}
+
+		if !attributeType.Equal(attribute.Type(ctx)) {
+			diags.AddError(
+				"Invalid CurrentTasksErrorsValue Attribute Type",
+				"While creating a CurrentTasksErrorsValue value, an invalid attribute value was detected. "+
+					"A CurrentTasksErrorsValue must use a matching attribute type for the value. "+
+					"This is always an issue with the provider and should be reported to the provider developers.\n\n"+
+					fmt.Sprintf("CurrentTasksErrorsValue Attribute Name (%s) Expected Type: %s\n", name, attributeType.String())+
+					fmt.Sprintf("CurrentTasksErrorsValue Attribute Name (%s) Given Type: %s", name, attribute.Type(ctx)),
+			)
+		}
+	}
+
+	for name := range attributes {
+		_, ok := attributeTypes[name]
+
+		if !ok {
+			diags.AddError(
+				"Extra CurrentTasksErrorsValue Attribute Value",
+				"While creating a CurrentTasksErrorsValue value, an extra attribute value was detected. "+
+					"A CurrentTasksErrorsValue must not contain values beyond the expected attribute types. "+
+					"This is always an issue with the provider and should be reported to the provider developers.\n\n"+
+					fmt.Sprintf("Extra CurrentTasksErrorsValue Attribute Name: %s", name),
+			)
+		}
+	}
+
+	if diags.HasError() {
+		return NewCurrentTasksErrorsValueUnknown(), diags
+	}
+
+	messageAttribute, ok := attributes["message"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`message is missing from object`)
+
+		return NewCurrentTasksErrorsValueUnknown(), diags
+	}
+
+	messageVal, ok := messageAttribute.(ovhtypes.TfStringValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`message expected to be ovhtypes.TfStringValue, was: %T`, messageAttribute))
+	}
+
+	if diags.HasError() {
+		return NewCurrentTasksErrorsValueUnknown(), diags
+	}
+
+	return CurrentTasksErrorsValue{
+		Message: messageVal,
+		state:   attr.ValueStateKnown,
+	}, diags
+}
+
+func NewCurrentTasksErrorsValueMust(attributeTypes map[string]attr.Type, attributes map[string]attr.Value) CurrentTasksErrorsValue {
+	object, diags := NewCurrentTasksErrorsValue(attributeTypes, attributes)
+
+	if diags.HasError() {
+		// This could potentially be added to the diag package.
+		diagsStrings := make([]string, 0, len(diags))
+
+		for _, diagnostic := range diags {
+			diagsStrings = append(diagsStrings, fmt.Sprintf(
+				"%s | %s | %s",
+				diagnostic.Severity(),
+				diagnostic.Summary(),
+				diagnostic.Detail()))
+		}
+
+		panic("NewCurrentTasksErrorsValueMust received error(s): " + strings.Join(diagsStrings, "\n"))
+	}
+
+	return object
+}
+
+func (t CurrentTasksErrorsType) ValueFromTerraform(ctx context.Context, in tftypes.Value) (attr.Value, error) {
+	if in.Type() == nil {
+		return NewCurrentTasksErrorsValueNull(), nil
+	}
+
+	if !in.Type().Equal(t.TerraformType(ctx)) {
+		return nil, fmt.Errorf("expected %s, got %s", t.TerraformType(ctx), in.Type())
+	}
+
+	if !in.IsKnown() {
+		return NewCurrentTasksErrorsValueUnknown(), nil
+	}
+
+	if in.IsNull() {
+		return NewCurrentTasksErrorsValueNull(), nil
+	}
+
+	attributes := map[string]attr.Value{}
+
+	val := map[string]tftypes.Value{}
+
+	err := in.As(&val)
+
+	if err != nil {
+		return nil, err
+	}
+
+	for k, v := range val {
+		a, err := t.AttrTypes[k].ValueFromTerraform(ctx, v)
+
+		if err != nil {
+			return nil, err
+		}
+
+		attributes[k] = a
+	}
+
+	return NewCurrentTasksErrorsValueMust(CurrentTasksErrorsValue{}.AttributeTypes(ctx), attributes), nil
+}
+
+func (t CurrentTasksErrorsType) ValueType(ctx context.Context) attr.Value {
+	return CurrentTasksErrorsValue{}
+}
+
+var _ basetypes.ObjectValuable = CurrentTasksErrorsValue{}
+
+type CurrentTasksErrorsValue struct {
+	Message ovhtypes.TfStringValue `tfsdk:"message" json:"message"`
+	state   attr.ValueState
+}
+
+func (v *CurrentTasksErrorsValue) UnmarshalJSON(data []byte) error {
+	type JsonCurrentTasksErrorsValue CurrentTasksErrorsValue
+
+	var tmp JsonCurrentTasksErrorsValue
+	if err := json.Unmarshal(data, &tmp); err != nil {
+		return err
+	}
+	v.Message = tmp.Message
+
+	v.state = attr.ValueStateKnown
+
+	return nil
+}
+
+func (v *CurrentTasksErrorsValue) MergeWith(other *CurrentTasksErrorsValue) {
+
+	if (v.Message.IsUnknown() || v.Message.IsNull()) && !other.Message.IsUnknown() {
+		v.Message = other.Message
+	}
+
+	if (v.state == attr.ValueStateUnknown || v.state == attr.ValueStateNull) && other.state != attr.ValueStateUnknown {
+		v.state = other.state
+	}
+}
+
+func (v CurrentTasksErrorsValue) Attributes() map[string]attr.Value {
+	return map[string]attr.Value{
+		"message": v.Message,
+	}
+}
+func (v CurrentTasksErrorsValue) ToTerraformValue(ctx context.Context) (tftypes.Value, error) {
+	attrTypes := make(map[string]tftypes.Type, 1)
+
+	var val tftypes.Value
+	var err error
+
+	attrTypes["message"] = basetypes.StringType{}.TerraformType(ctx)
+
+	objectType := tftypes.Object{AttributeTypes: attrTypes}
+
+	switch v.state {
+	case attr.ValueStateKnown:
+		vals := make(map[string]tftypes.Value, 1)
+
+		val, err = v.Message.ToTerraformValue(ctx)
+
+		if err != nil {
+			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
+		}
+
+		vals["message"] = val
+
+		if err := tftypes.ValidateValue(objectType, vals); err != nil {
+			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
+		}
+
+		return tftypes.NewValue(objectType, vals), nil
+	case attr.ValueStateNull:
+		return tftypes.NewValue(objectType, nil), nil
+	case attr.ValueStateUnknown:
+		return tftypes.NewValue(objectType, tftypes.UnknownValue), nil
+	default:
+		panic(fmt.Sprintf("unhandled Object state in ToTerraformValue: %s", v.state))
+	}
+}
+
+func (v CurrentTasksErrorsValue) IsNull() bool {
+	return v.state == attr.ValueStateNull
+}
+
+func (v CurrentTasksErrorsValue) IsUnknown() bool {
+	return v.state == attr.ValueStateUnknown
+}
+
+func (v CurrentTasksErrorsValue) String() string {
+	return "CurrentTasksErrorsValue"
+}
+
+func (v CurrentTasksErrorsValue) ToObjectValue(ctx context.Context) (basetypes.ObjectValue, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	objVal, diags := types.ObjectValue(
+		map[string]attr.Type{
+			"message": ovhtypes.TfStringType{},
+		},
+		map[string]attr.Value{
+			"message": v.Message,
+		})
+
+	return objVal, diags
+}
+
+func (v CurrentTasksErrorsValue) Equal(o attr.Value) bool {
+	other, ok := o.(CurrentTasksErrorsValue)
+
+	if !ok {
+		return false
+	}
+
+	if v.state != other.state {
+		return false
+	}
+
+	if v.state != attr.ValueStateKnown {
+		return true
+	}
+
+	if !v.Message.Equal(other.Message) {
+		return false
+	}
+
+	return true
+}
+
+func (v CurrentTasksErrorsValue) Type(ctx context.Context) attr.Type {
+	return CurrentTasksErrorsType{
+		basetypes.ObjectType{
+			AttrTypes: v.AttributeTypes(ctx),
+		},
+	}
+}
+
+func (v CurrentTasksErrorsValue) AttributeTypes(ctx context.Context) map[string]attr.Type {
+	return map[string]attr.Type{
+		"message": ovhtypes.TfStringType{},
+	}
+}
+
+var _ basetypes.ObjectTypable = CloudNetworkPrivateSubnetTargetSpecType{}
+
+type CloudNetworkPrivateSubnetTargetSpecType struct {
+	basetypes.ObjectType
+}
+
+func (t CloudNetworkPrivateSubnetTargetSpecType) Equal(o attr.Type) bool {
+	other, ok := o.(CloudNetworkPrivateSubnetTargetSpecType)
+
+	if !ok {
+		return false
+	}
+
+	return t.ObjectType.Equal(other.ObjectType)
+}
+
+func (t CloudNetworkPrivateSubnetTargetSpecType) String() string {
+	return "CloudNetworkPrivateSubnetTargetSpecType"
+}
+
+func (t CloudNetworkPrivateSubnetTargetSpecType) ValueFromObject(ctx context.Context, in basetypes.ObjectValue) (basetypes.ObjectValuable, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	attributes := in.Attributes()
+
+	allocationPoolsAttribute, ok := attributes["allocation_pools"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`allocation_pools is missing from object`)
+
+		return nil, diags
+	}
+
+	allocationPoolsVal, ok := allocationPoolsAttribute.(ovhtypes.TfListNestedValue[TargetSpecAllocationPoolsValue])
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`allocation_pools expected to be ovhtypes.TfListNestedValue[TargetSpecAllocationPoolsValue], was: %T`, allocationPoolsAttribute))
+	}
+
+	cidrAttribute, ok := attributes["cidr"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`cidr is missing from object`)
+
+		return nil, diags
+	}
+
+	cidrVal, ok := cidrAttribute.(ovhtypes.TfStringValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`cidr expected to be ovhtypes.TfStringValue, was: %T`, cidrAttribute))
+	}
+
+	descriptionAttribute, ok := attributes["description"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`description is missing from object`)
+
+		return nil, diags
+	}
+
+	descriptionVal, ok := descriptionAttribute.(ovhtypes.TfStringValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`description expected to be ovhtypes.TfStringValue, was: %T`, descriptionAttribute))
+	}
+
+	dhcpEnabledAttribute, ok := attributes["dhcp_enabled"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`dhcp_enabled is missing from object`)
+
+		return nil, diags
+	}
+
+	dhcpEnabledVal, ok := dhcpEnabledAttribute.(ovhtypes.TfBoolValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`dhcp_enabled expected to be ovhtypes.TfBoolValue, was: %T`, dhcpEnabledAttribute))
+	}
+
+	dnsNameserversAttribute, ok := attributes["dns_nameservers"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`dns_nameservers is missing from object`)
+
+		return nil, diags
+	}
+
+	dnsNameserversVal, ok := dnsNameserversAttribute.(ovhtypes.TfListNestedValue[ovhtypes.TfStringValue])
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`dns_nameservers expected to be ovhtypes.TfListNestedValue[ovhtypes.TfStringValue], was: %T`, dnsNameserversAttribute))
+	}
+
+	gatewayIpAttribute, ok := attributes["gateway_ip"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`gateway_ip is missing from object`)
+
+		return nil, diags
+	}
+
+	gatewayIpVal, ok := gatewayIpAttribute.(ovhtypes.TfStringValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`gateway_ip expected to be ovhtypes.TfStringValue, was: %T`, gatewayIpAttribute))
+	}
+
+	locationAttribute, ok := attributes["location"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`location is missing from object`)
+
+		return nil, diags
+	}
+
+	locationVal, ok := locationAttribute.(TargetSpecLocationValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`location expected to be TargetSpecLocationValue, was: %T`, locationAttribute))
+	}
+
+	nameAttribute, ok := attributes["name"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`name is missing from object`)
+
+		return nil, diags
+	}
+
+	nameVal, ok := nameAttribute.(ovhtypes.TfStringValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`name expected to be ovhtypes.TfStringValue, was: %T`, nameAttribute))
+	}
+
+	if diags.HasError() {
+		return nil, diags
+	}
+
+	return CloudNetworkPrivateSubnetTargetSpecValue{
+		AllocationPools: allocationPoolsVal,
+		Cidr:            cidrVal,
+		Description:     descriptionVal,
+		DhcpEnabled:     dhcpEnabledVal,
+		DnsNameservers:  dnsNameserversVal,
+		GatewayIp:       gatewayIpVal,
+		Location:        locationVal,
+		Name:            nameVal,
+		state:           attr.ValueStateKnown,
+	}, diags
+}
+
+func NewCloudNetworkPrivateSubnetTargetSpecValueNull() CloudNetworkPrivateSubnetTargetSpecValue {
+	return CloudNetworkPrivateSubnetTargetSpecValue{
+		state: attr.ValueStateNull,
+	}
+}
+
+func NewCloudNetworkPrivateSubnetTargetSpecValueUnknown() CloudNetworkPrivateSubnetTargetSpecValue {
+	return CloudNetworkPrivateSubnetTargetSpecValue{
+		state: attr.ValueStateUnknown,
+	}
+}
+
+func NewCloudNetworkPrivateSubnetTargetSpecValue(attributeTypes map[string]attr.Type, attributes map[string]attr.Value) (CloudNetworkPrivateSubnetTargetSpecValue, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	// Reference: https://github.com/hashicorp/terraform-plugin-framework/issues/521
+	ctx := context.Background()
+
+	for name, attributeType := range attributeTypes {
+		attribute, ok := attributes[name]
+
+		if !ok {
+			diags.AddError(
+				"Missing CloudNetworkPrivateSubnetTargetSpecValue Attribute Value",
+				"While creating a CloudNetworkPrivateSubnetTargetSpecValue value, a missing attribute value was detected. "+
+					"A CloudNetworkPrivateSubnetTargetSpecValue must contain values for all attributes, even if null or unknown. "+
+					"This is always an issue with the provider and should be reported to the provider developers.\n\n"+
+					fmt.Sprintf("CloudNetworkPrivateSubnetTargetSpecValue Attribute Name (%s) Expected Type: %s", name, attributeType.String()),
+			)
+
+			continue
+		}
+
+		if !attributeType.Equal(attribute.Type(ctx)) {
+			diags.AddError(
+				"Invalid CloudNetworkPrivateSubnetTargetSpecValue Attribute Type",
+				"While creating a CloudNetworkPrivateSubnetTargetSpecValue value, an invalid attribute value was detected. "+
+					"A CloudNetworkPrivateSubnetTargetSpecValue must use a matching attribute type for the value. "+
+					"This is always an issue with the provider and should be reported to the provider developers.\n\n"+
+					fmt.Sprintf("CloudNetworkPrivateSubnetTargetSpecValue Attribute Name (%s) Expected Type: %s\n", name, attributeType.String())+
+					fmt.Sprintf("CloudNetworkPrivateSubnetTargetSpecValue Attribute Name (%s) Given Type: %s", name, attribute.Type(ctx)),
+			)
+		}
+	}
+
+	for name := range attributes {
+		_, ok := attributeTypes[name]
+
+		if !ok {
+			diags.AddError(
+				"Extra CloudNetworkPrivateSubnetTargetSpecValue Attribute Value",
+				"While creating a CloudNetworkPrivateSubnetTargetSpecValue value, an extra attribute value was detected. "+
+					"A CloudNetworkPrivateSubnetTargetSpecValue must not contain values beyond the expected attribute types. "+
+					"This is always an issue with the provider and should be reported to the provider developers.\n\n"+
+					fmt.Sprintf("Extra CloudNetworkPrivateSubnetTargetSpecValue Attribute Name: %s", name),
+			)
+		}
+	}
+
+	if diags.HasError() {
+		return NewCloudNetworkPrivateSubnetTargetSpecValueUnknown(), diags
+	}
+
+	allocationPoolsAttribute, ok := attributes["allocation_pools"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`allocation_pools is missing from object`)
+
+		return NewCloudNetworkPrivateSubnetTargetSpecValueUnknown(), diags
+	}
+
+	allocationPoolsVal, ok := allocationPoolsAttribute.(ovhtypes.TfListNestedValue[TargetSpecAllocationPoolsValue])
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`allocation_pools expected to be ovhtypes.TfListNestedValue[TargetSpecAllocationPoolsValue], was: %T`, allocationPoolsAttribute))
+	}
+
+	cidrAttribute, ok := attributes["cidr"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`cidr is missing from object`)
+
+		return NewCloudNetworkPrivateSubnetTargetSpecValueUnknown(), diags
+	}
+
+	cidrVal, ok := cidrAttribute.(ovhtypes.TfStringValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`cidr expected to be ovhtypes.TfStringValue, was: %T`, cidrAttribute))
+	}
+
+	descriptionAttribute, ok := attributes["description"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`description is missing from object`)
+
+		return NewCloudNetworkPrivateSubnetTargetSpecValueUnknown(), diags
+	}
+
+	descriptionVal, ok := descriptionAttribute.(ovhtypes.TfStringValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`description expected to be ovhtypes.TfStringValue, was: %T`, descriptionAttribute))
+	}
+
+	dhcpEnabledAttribute, ok := attributes["dhcp_enabled"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`dhcp_enabled is missing from object`)
+
+		return NewCloudNetworkPrivateSubnetTargetSpecValueUnknown(), diags
+	}
+
+	dhcpEnabledVal, ok := dhcpEnabledAttribute.(ovhtypes.TfBoolValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`dhcp_enabled expected to be ovhtypes.TfBoolValue, was: %T`, dhcpEnabledAttribute))
+	}
+
+	dnsNameserversAttribute, ok := attributes["dns_nameservers"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`dns_nameservers is missing from object`)
+
+		return NewCloudNetworkPrivateSubnetTargetSpecValueUnknown(), diags
+	}
+
+	dnsNameserversVal, ok := dnsNameserversAttribute.(ovhtypes.TfListNestedValue[ovhtypes.TfStringValue])
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`dns_nameservers expected to be ovhtypes.TfListNestedValue[ovhtypes.TfStringValue], was: %T`, dnsNameserversAttribute))
+	}
+
+	gatewayIpAttribute, ok := attributes["gateway_ip"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`gateway_ip is missing from object`)
+
+		return NewCloudNetworkPrivateSubnetTargetSpecValueUnknown(), diags
+	}
+
+	gatewayIpVal, ok := gatewayIpAttribute.(ovhtypes.TfStringValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`gateway_ip expected to be ovhtypes.TfStringValue, was: %T`, gatewayIpAttribute))
+	}
+
+	locationAttribute, ok := attributes["location"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`location is missing from object`)
+
+		return NewCloudNetworkPrivateSubnetTargetSpecValueUnknown(), diags
+	}
+
+	locationVal, ok := locationAttribute.(TargetSpecLocationValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`location expected to be TargetSpecLocationValue, was: %T`, locationAttribute))
+	}
+
+	nameAttribute, ok := attributes["name"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`name is missing from object`)
+
+		return NewCloudNetworkPrivateSubnetTargetSpecValueUnknown(), diags
+	}
+
+	nameVal, ok := nameAttribute.(ovhtypes.TfStringValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`name expected to be ovhtypes.TfStringValue, was: %T`, nameAttribute))
+	}
+
+	if diags.HasError() {
+		return NewCloudNetworkPrivateSubnetTargetSpecValueUnknown(), diags
+	}
+
+	return CloudNetworkPrivateSubnetTargetSpecValue{
+		AllocationPools: allocationPoolsVal,
+		Cidr:            cidrVal,
+		Description:     descriptionVal,
+		DhcpEnabled:     dhcpEnabledVal,
+		DnsNameservers:  dnsNameserversVal,
+		GatewayIp:       gatewayIpVal,
+		Location:        locationVal,
+		Name:            nameVal,
+		state:           attr.ValueStateKnown,
+	}, diags
+}
+
+func NewCloudNetworkPrivateSubnetTargetSpecValueMust(attributeTypes map[string]attr.Type, attributes map[string]attr.Value) CloudNetworkPrivateSubnetTargetSpecValue {
+	object, diags := NewCloudNetworkPrivateSubnetTargetSpecValue(attributeTypes, attributes)
+
+	if diags.HasError() {
+		// This could potentially be added to the diag package.
+		diagsStrings := make([]string, 0, len(diags))
+
+		for _, diagnostic := range diags {
+			diagsStrings = append(diagsStrings, fmt.Sprintf(
+				"%s | %s | %s",
+				diagnostic.Severity(),
+				diagnostic.Summary(),
+				diagnostic.Detail()))
+		}
+
+		panic("NewCloudNetworkPrivateSubnetTargetSpecValueMust received error(s): " + strings.Join(diagsStrings, "\n"))
+	}
+
+	return object
+}
+
+func (t CloudNetworkPrivateSubnetTargetSpecType) ValueFromTerraform(ctx context.Context, in tftypes.Value) (attr.Value, error) {
+	if in.Type() == nil {
+		return NewCloudNetworkPrivateSubnetTargetSpecValueNull(), nil
+	}
+
+	if !in.Type().Equal(t.TerraformType(ctx)) {
+		return nil, fmt.Errorf("expected %s, got %s", t.TerraformType(ctx), in.Type())
+	}
+
+	if !in.IsKnown() {
+		return NewCloudNetworkPrivateSubnetTargetSpecValueUnknown(), nil
+	}
+
+	if in.IsNull() {
+		return NewCloudNetworkPrivateSubnetTargetSpecValueNull(), nil
+	}
+
+	attributes := map[string]attr.Value{}
+
+	val := map[string]tftypes.Value{}
+
+	err := in.As(&val)
+
+	if err != nil {
+		return nil, err
+	}
+
+	for k, v := range val {
+		a, err := t.AttrTypes[k].ValueFromTerraform(ctx, v)
+
+		if err != nil {
+			return nil, err
+		}
+
+		attributes[k] = a
+	}
+
+	return NewCloudNetworkPrivateSubnetTargetSpecValueMust(CloudNetworkPrivateSubnetTargetSpecValue{}.AttributeTypes(ctx), attributes), nil
+}
+
+func (t CloudNetworkPrivateSubnetTargetSpecType) ValueType(ctx context.Context) attr.Value {
+	return CloudNetworkPrivateSubnetTargetSpecValue{}
+}
+
+var _ basetypes.ObjectValuable = CloudNetworkPrivateSubnetTargetSpecValue{}
+
+type CloudNetworkPrivateSubnetTargetSpecValue struct {
+	AllocationPools ovhtypes.TfListNestedValue[TargetSpecAllocationPoolsValue] `tfsdk:"allocation_pools" json:"allocationPools"`
+	Cidr            ovhtypes.TfStringValue                                     `tfsdk:"cidr" json:"cidr"`
+	Description     ovhtypes.TfStringValue                                     `tfsdk:"description" json:"description"`
+	DhcpEnabled     ovhtypes.TfBoolValue                                       `tfsdk:"dhcp_enabled" json:"dhcpEnabled"`
+	DnsNameservers  ovhtypes.TfListNestedValue[ovhtypes.TfStringValue]         `tfsdk:"dns_nameservers" json:"dnsNameservers"`
+	GatewayIp       ovhtypes.TfStringValue                                     `tfsdk:"gateway_ip" json:"gatewayIp"`
+	Location        TargetSpecLocationValue                                    `tfsdk:"location" json:"location"`
+	Name            ovhtypes.TfStringValue                                     `tfsdk:"name" json:"name"`
+	state           attr.ValueState
+}
+
+func (v CloudNetworkPrivateSubnetTargetSpecValue) ToCreate() *CloudNetworkPrivateSubnetTargetSpecValue {
+	res := &CloudNetworkPrivateSubnetTargetSpecValue{}
+
+	if !v.Description.IsNull() {
+		res.Description = v.Description
+	}
+
+	if !v.DhcpEnabled.IsNull() {
+		res.DhcpEnabled = v.DhcpEnabled
+	}
+
+	if !v.DnsNameservers.IsNull() {
+		res.DnsNameservers = v.DnsNameservers
+	}
+
+	if !v.GatewayIp.IsNull() {
+		res.GatewayIp = v.GatewayIp
+	}
+
+	if !v.Location.IsNull() {
+		res.Location = v.Location
+	}
+
+	if !v.Name.IsNull() {
+		res.Name = v.Name
+	}
+
+	if !v.AllocationPools.IsNull() {
+		res.AllocationPools = v.AllocationPools
+	}
+
+	if !v.Cidr.IsNull() {
+		res.Cidr = v.Cidr
+	}
+
+	res.state = attr.ValueStateKnown
+
+	return res
+}
+
+func (v CloudNetworkPrivateSubnetTargetSpecValue) ToUpdate() *CloudNetworkPrivateSubnetTargetSpecValue {
+	res := &CloudNetworkPrivateSubnetTargetSpecValue{}
+
+	if !v.Description.IsNull() {
+		res.Description = v.Description
+	}
+
+	if !v.DhcpEnabled.IsNull() {
+		res.DhcpEnabled = v.DhcpEnabled
+	}
+
+	if !v.DnsNameservers.IsNull() {
+		res.DnsNameservers = v.DnsNameservers
+	}
+
+	if !v.GatewayIp.IsNull() {
+		res.GatewayIp = v.GatewayIp
+	}
+
+	if !v.Name.IsNull() {
+		res.Name = v.Name
+	}
+
+	if !v.AllocationPools.IsNull() {
+		res.AllocationPools = v.AllocationPools
+	}
+
+	res.state = attr.ValueStateKnown
+
+	return res
+}
+
+func (v CloudNetworkPrivateSubnetTargetSpecValue) MarshalJSON() ([]byte, error) {
+	toMarshal := map[string]any{}
+	if !v.AllocationPools.IsNull() && !v.AllocationPools.IsUnknown() {
+		toMarshal["allocationPools"] = v.AllocationPools
+	}
+	if !v.Cidr.IsNull() && !v.Cidr.IsUnknown() {
+		toMarshal["cidr"] = v.Cidr
+	}
+	if !v.Description.IsNull() && !v.Description.IsUnknown() {
+		toMarshal["description"] = v.Description
+	}
+	if !v.DhcpEnabled.IsNull() && !v.DhcpEnabled.IsUnknown() {
+		toMarshal["dhcpEnabled"] = v.DhcpEnabled
+	}
+	if !v.DnsNameservers.IsNull() && !v.DnsNameservers.IsUnknown() {
+		toMarshal["dnsNameservers"] = v.DnsNameservers
+	}
+	if !v.GatewayIp.IsNull() && !v.GatewayIp.IsUnknown() {
+		toMarshal["gatewayIp"] = v.GatewayIp
+	}
+	if !v.Location.IsNull() && !v.Location.IsUnknown() {
+		toMarshal["location"] = v.Location
+	}
+	if !v.Name.IsNull() && !v.Name.IsUnknown() {
+		toMarshal["name"] = v.Name
+	}
+
+	return json.Marshal(toMarshal)
+}
+
+func (v *CloudNetworkPrivateSubnetTargetSpecValue) UnmarshalJSON(data []byte) error {
+	type JsonTargetSpecValue CloudNetworkPrivateSubnetTargetSpecValue
+
+	var tmp JsonTargetSpecValue
+	if err := json.Unmarshal(data, &tmp); err != nil {
+		return err
+	}
+	v.AllocationPools = tmp.AllocationPools
+	v.Cidr = tmp.Cidr
+	v.Description = tmp.Description
+	v.DhcpEnabled = tmp.DhcpEnabled
+	v.DnsNameservers = tmp.DnsNameservers
+	v.GatewayIp = tmp.GatewayIp
+	v.Location = tmp.Location
+	v.Name = tmp.Name
+
+	v.state = attr.ValueStateKnown
+
+	return nil
+}
+
+func (v *CloudNetworkPrivateSubnetTargetSpecValue) MergeWith(other *CloudNetworkPrivateSubnetTargetSpecValue) {
+
+	if (v.AllocationPools.IsUnknown() || v.AllocationPools.IsNull()) && !other.AllocationPools.IsUnknown() {
+		v.AllocationPools = other.AllocationPools
+	} else if !other.AllocationPools.IsUnknown() {
+		newSlice := make([]attr.Value, 0)
+		elems := v.AllocationPools.Elements()
+		newElems := other.AllocationPools.Elements()
+
+		if len(elems) != len(newElems) {
+			v.AllocationPools = other.AllocationPools
+		} else {
+			for idx, e := range elems {
+				tmp := e.(TargetSpecAllocationPoolsValue)
+				tmp2 := newElems[idx].(TargetSpecAllocationPoolsValue)
+				tmp.MergeWith(&tmp2)
+				newSlice = append(newSlice, tmp)
+			}
+
+			v.AllocationPools = ovhtypes.TfListNestedValue[TargetSpecAllocationPoolsValue]{
+				ListValue: basetypes.NewListValueMust(TargetSpecAllocationPoolsValue{}.Type(context.Background()), newSlice),
+			}
+		}
+	}
+
+	if (v.Cidr.IsUnknown() || v.Cidr.IsNull()) && !other.Cidr.IsUnknown() {
+		v.Cidr = other.Cidr
+	}
+
+	if (v.Description.IsUnknown() || v.Description.IsNull()) && !other.Description.IsUnknown() {
+		v.Description = other.Description
+	}
+
+	if (v.DhcpEnabled.IsUnknown() || v.DhcpEnabled.IsNull()) && !other.DhcpEnabled.IsUnknown() {
+		v.DhcpEnabled = other.DhcpEnabled
+	}
+
+	if (v.DnsNameservers.IsUnknown() || v.DnsNameservers.IsNull()) && !other.DnsNameservers.IsUnknown() {
+		v.DnsNameservers = other.DnsNameservers
+	}
+
+	if (v.GatewayIp.IsUnknown() || v.GatewayIp.IsNull()) && !other.GatewayIp.IsUnknown() {
+		v.GatewayIp = other.GatewayIp
+	}
+
+	if v.Location.IsUnknown() && !other.Location.IsUnknown() {
+		v.Location = other.Location
+	} else if !other.Location.IsUnknown() {
+		v.Location.MergeWith(&other.Location)
+	}
+
+	if (v.Name.IsUnknown() || v.Name.IsNull()) && !other.Name.IsUnknown() {
+		v.Name = other.Name
+	}
+
+	if (v.state == attr.ValueStateUnknown || v.state == attr.ValueStateNull) && other.state != attr.ValueStateUnknown {
+		v.state = other.state
+	}
+}
+
+func (v CloudNetworkPrivateSubnetTargetSpecValue) Attributes() map[string]attr.Value {
+	return map[string]attr.Value{
+		"allocationPools": v.AllocationPools,
+		"cidr":            v.Cidr,
+		"description":     v.Description,
+		"dhcpEnabled":     v.DhcpEnabled,
+		"dnsNameservers":  v.DnsNameservers,
+		"gatewayIp":       v.GatewayIp,
+		"location":        v.Location,
+		"name":            v.Name,
+	}
+}
+func (v CloudNetworkPrivateSubnetTargetSpecValue) ToTerraformValue(ctx context.Context) (tftypes.Value, error) {
+	attrTypes := make(map[string]tftypes.Type, 8)
+
+	var val tftypes.Value
+	var err error
+
+	attrTypes["allocation_pools"] = basetypes.ListType{
+		ElemType: TargetSpecAllocationPoolsValue{}.Type(ctx),
+	}.TerraformType(ctx)
+	attrTypes["cidr"] = basetypes.StringType{}.TerraformType(ctx)
+	attrTypes["description"] = basetypes.StringType{}.TerraformType(ctx)
+	attrTypes["dhcp_enabled"] = basetypes.BoolType{}.TerraformType(ctx)
+	attrTypes["dns_nameservers"] = basetypes.ListType{
+		ElemType: types.StringType,
+	}.TerraformType(ctx)
+	attrTypes["gateway_ip"] = basetypes.StringType{}.TerraformType(ctx)
+	attrTypes["location"] = basetypes.ObjectType{
+		AttrTypes: TargetSpecLocationValue{}.AttributeTypes(ctx),
+	}.TerraformType(ctx)
+	attrTypes["name"] = basetypes.StringType{}.TerraformType(ctx)
+
+	objectType := tftypes.Object{AttributeTypes: attrTypes}
+
+	switch v.state {
+	case attr.ValueStateKnown:
+		vals := make(map[string]tftypes.Value, 8)
+
+		val, err = v.AllocationPools.ToTerraformValue(ctx)
+
+		if err != nil {
+			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
+		}
+
+		vals["allocation_pools"] = val
+
+		val, err = v.Cidr.ToTerraformValue(ctx)
+
+		if err != nil {
+			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
+		}
+
+		vals["cidr"] = val
+
+		val, err = v.Description.ToTerraformValue(ctx)
+
+		if err != nil {
+			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
+		}
+
+		vals["description"] = val
+
+		val, err = v.DhcpEnabled.ToTerraformValue(ctx)
+
+		if err != nil {
+			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
+		}
+
+		vals["dhcp_enabled"] = val
+
+		val, err = v.DnsNameservers.ToTerraformValue(ctx)
+
+		if err != nil {
+			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
+		}
+
+		vals["dns_nameservers"] = val
+
+		val, err = v.GatewayIp.ToTerraformValue(ctx)
+
+		if err != nil {
+			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
+		}
+
+		vals["gateway_ip"] = val
+
+		val, err = v.Location.ToTerraformValue(ctx)
+
+		if err != nil {
+			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
+		}
+
+		vals["location"] = val
+
+		val, err = v.Name.ToTerraformValue(ctx)
+
+		if err != nil {
+			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
+		}
+
+		vals["name"] = val
+
+		if err := tftypes.ValidateValue(objectType, vals); err != nil {
+			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
+		}
+
+		return tftypes.NewValue(objectType, vals), nil
+	case attr.ValueStateNull:
+		return tftypes.NewValue(objectType, nil), nil
+	case attr.ValueStateUnknown:
+		return tftypes.NewValue(objectType, tftypes.UnknownValue), nil
+	default:
+		panic(fmt.Sprintf("unhandled Object state in ToTerraformValue: %s", v.state))
+	}
+}
+
+func (v CloudNetworkPrivateSubnetTargetSpecValue) IsNull() bool {
+	return v.state == attr.ValueStateNull
+}
+
+func (v CloudNetworkPrivateSubnetTargetSpecValue) IsUnknown() bool {
+	return v.state == attr.ValueStateUnknown
+}
+
+func (v CloudNetworkPrivateSubnetTargetSpecValue) String() string {
+	return "CloudNetworkPrivateSubnetTargetSpecValue"
+}
+
+func (v CloudNetworkPrivateSubnetTargetSpecValue) ToObjectValue(ctx context.Context) (basetypes.ObjectValue, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	objVal, diags := types.ObjectValue(
+		map[string]attr.Type{
+			"allocation_pools": ovhtypes.NewTfListNestedType[TargetSpecAllocationPoolsValue](ctx),
+			"cidr":             ovhtypes.TfStringType{},
+			"description":      ovhtypes.TfStringType{},
+			"dhcp_enabled":     ovhtypes.TfBoolType{},
+			"dns_nameservers":  ovhtypes.NewTfListNestedType[ovhtypes.TfStringValue](ctx),
+			"gateway_ip":       ovhtypes.TfStringType{},
+			"location": TargetSpecLocationType{
+				basetypes.ObjectType{
+					AttrTypes: TargetSpecLocationValue{}.AttributeTypes(ctx),
+				},
+			},
+			"name": ovhtypes.TfStringType{},
+		},
+		map[string]attr.Value{
+			"allocation_pools": v.AllocationPools,
+			"cidr":             v.Cidr,
+			"description":      v.Description,
+			"dhcp_enabled":     v.DhcpEnabled,
+			"dns_nameservers":  v.DnsNameservers,
+			"gateway_ip":       v.GatewayIp,
+			"location":         v.Location,
+			"name":             v.Name,
+		})
+
+	return objVal, diags
+}
+
+func (v CloudNetworkPrivateSubnetTargetSpecValue) Equal(o attr.Value) bool {
+	other, ok := o.(CloudNetworkPrivateSubnetTargetSpecValue)
+
+	if !ok {
+		return false
+	}
+
+	if v.state != other.state {
+		return false
+	}
+
+	if v.state != attr.ValueStateKnown {
+		return true
+	}
+
+	if !v.AllocationPools.Equal(other.AllocationPools) {
+		return false
+	}
+
+	if !v.Cidr.Equal(other.Cidr) {
+		return false
+	}
+
+	if !v.Description.Equal(other.Description) {
+		return false
+	}
+
+	if !v.DhcpEnabled.Equal(other.DhcpEnabled) {
+		return false
+	}
+
+	if !v.DnsNameservers.Equal(other.DnsNameservers) {
+		return false
+	}
+
+	if !v.GatewayIp.Equal(other.GatewayIp) {
+		return false
+	}
+
+	if !v.Location.Equal(other.Location) {
+		return false
+	}
+
+	if !v.Name.Equal(other.Name) {
+		return false
+	}
+
+	return true
+}
+
+func (v CloudNetworkPrivateSubnetTargetSpecValue) Type(ctx context.Context) attr.Type {
+	return CloudNetworkPrivateSubnetTargetSpecType{
+		basetypes.ObjectType{
+			AttrTypes: v.AttributeTypes(ctx),
+		},
+	}
+}
+
+func (v CloudNetworkPrivateSubnetTargetSpecValue) AttributeTypes(ctx context.Context) map[string]attr.Type {
+	return map[string]attr.Type{
+		"allocation_pools": ovhtypes.NewTfListNestedType[TargetSpecAllocationPoolsValue](ctx),
+		"cidr":             ovhtypes.TfStringType{},
+		"description":      ovhtypes.TfStringType{},
+		"dhcp_enabled":     ovhtypes.TfBoolType{},
+		"dns_nameservers":  ovhtypes.NewTfListNestedType[ovhtypes.TfStringValue](ctx),
+		"gateway_ip":       ovhtypes.TfStringType{},
+		"location":         TargetSpecLocationValue{}.Type(ctx),
+		"name":             ovhtypes.TfStringType{},
+	}
+}
+
+var _ basetypes.ObjectTypable = TargetSpecAllocationPoolsType{}
+
+type TargetSpecAllocationPoolsType struct {
+	basetypes.ObjectType
+}
+
+func (t TargetSpecAllocationPoolsType) Equal(o attr.Type) bool {
+	other, ok := o.(TargetSpecAllocationPoolsType)
+
+	if !ok {
+		return false
+	}
+
+	return t.ObjectType.Equal(other.ObjectType)
+}
+
+func (t TargetSpecAllocationPoolsType) String() string {
+	return "TargetSpecAllocationPoolsType"
+}
+
+func (t TargetSpecAllocationPoolsType) ValueFromObject(ctx context.Context, in basetypes.ObjectValue) (basetypes.ObjectValuable, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	attributes := in.Attributes()
+
+	endAttribute, ok := attributes["end"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`end is missing from object`)
+
+		return nil, diags
+	}
+
+	endVal, ok := endAttribute.(ovhtypes.TfStringValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`end expected to be ovhtypes.TfStringValue, was: %T`, endAttribute))
+	}
+
+	startAttribute, ok := attributes["start"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`start is missing from object`)
+
+		return nil, diags
+	}
+
+	startVal, ok := startAttribute.(ovhtypes.TfStringValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`start expected to be ovhtypes.TfStringValue, was: %T`, startAttribute))
+	}
+
+	if diags.HasError() {
+		return nil, diags
+	}
+
+	return TargetSpecAllocationPoolsValue{
+		End:   endVal,
+		Start: startVal,
+		state: attr.ValueStateKnown,
+	}, diags
+}
+
+func NewTargetSpecAllocationPoolsValueNull() TargetSpecAllocationPoolsValue {
+	return TargetSpecAllocationPoolsValue{
+		state: attr.ValueStateNull,
+	}
+}
+
+func NewTargetSpecAllocationPoolsValueUnknown() TargetSpecAllocationPoolsValue {
+	return TargetSpecAllocationPoolsValue{
+		state: attr.ValueStateUnknown,
+	}
+}
+
+func NewTargetSpecAllocationPoolsValue(attributeTypes map[string]attr.Type, attributes map[string]attr.Value) (TargetSpecAllocationPoolsValue, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	// Reference: https://github.com/hashicorp/terraform-plugin-framework/issues/521
+	ctx := context.Background()
+
+	for name, attributeType := range attributeTypes {
+		attribute, ok := attributes[name]
+
+		if !ok {
+			diags.AddError(
+				"Missing TargetSpecAllocationPoolsValue Attribute Value",
+				"While creating a TargetSpecAllocationPoolsValue value, a missing attribute value was detected. "+
+					"A TargetSpecAllocationPoolsValue must contain values for all attributes, even if null or unknown. "+
+					"This is always an issue with the provider and should be reported to the provider developers.\n\n"+
+					fmt.Sprintf("TargetSpecAllocationPoolsValue Attribute Name (%s) Expected Type: %s", name, attributeType.String()),
+			)
+
+			continue
+		}
+
+		if !attributeType.Equal(attribute.Type(ctx)) {
+			diags.AddError(
+				"Invalid TargetSpecAllocationPoolsValue Attribute Type",
+				"While creating a TargetSpecAllocationPoolsValue value, an invalid attribute value was detected. "+
+					"A TargetSpecAllocationPoolsValue must use a matching attribute type for the value. "+
+					"This is always an issue with the provider and should be reported to the provider developers.\n\n"+
+					fmt.Sprintf("TargetSpecAllocationPoolsValue Attribute Name (%s) Expected Type: %s\n", name, attributeType.String())+
+					fmt.Sprintf("TargetSpecAllocationPoolsValue Attribute Name (%s) Given Type: %s", name, attribute.Type(ctx)),
+			)
+		}
+	}
+
+	for name := range attributes {
+		_, ok := attributeTypes[name]
+
+		if !ok {
+			diags.AddError(
+				"Extra TargetSpecAllocationPoolsValue Attribute Value",
+				"While creating a TargetSpecAllocationPoolsValue value, an extra attribute value was detected. "+
+					"A TargetSpecAllocationPoolsValue must not contain values beyond the expected attribute types. "+
+					"This is always an issue with the provider and should be reported to the provider developers.\n\n"+
+					fmt.Sprintf("Extra TargetSpecAllocationPoolsValue Attribute Name: %s", name),
+			)
+		}
+	}
+
+	if diags.HasError() {
+		return NewTargetSpecAllocationPoolsValueUnknown(), diags
+	}
+
+	endAttribute, ok := attributes["end"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`end is missing from object`)
+
+		return NewTargetSpecAllocationPoolsValueUnknown(), diags
+	}
+
+	endVal, ok := endAttribute.(ovhtypes.TfStringValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`end expected to be ovhtypes.TfStringValue, was: %T`, endAttribute))
+	}
+
+	startAttribute, ok := attributes["start"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`start is missing from object`)
+
+		return NewTargetSpecAllocationPoolsValueUnknown(), diags
+	}
+
+	startVal, ok := startAttribute.(ovhtypes.TfStringValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`start expected to be ovhtypes.TfStringValue, was: %T`, startAttribute))
+	}
+
+	if diags.HasError() {
+		return NewTargetSpecAllocationPoolsValueUnknown(), diags
+	}
+
+	return TargetSpecAllocationPoolsValue{
+		End:   endVal,
+		Start: startVal,
+		state: attr.ValueStateKnown,
+	}, diags
+}
+
+func NewTargetSpecAllocationPoolsValueMust(attributeTypes map[string]attr.Type, attributes map[string]attr.Value) TargetSpecAllocationPoolsValue {
+	object, diags := NewTargetSpecAllocationPoolsValue(attributeTypes, attributes)
+
+	if diags.HasError() {
+		// This could potentially be added to the diag package.
+		diagsStrings := make([]string, 0, len(diags))
+
+		for _, diagnostic := range diags {
+			diagsStrings = append(diagsStrings, fmt.Sprintf(
+				"%s | %s | %s",
+				diagnostic.Severity(),
+				diagnostic.Summary(),
+				diagnostic.Detail()))
+		}
+
+		panic("NewTargetSpecAllocationPoolsValueMust received error(s): " + strings.Join(diagsStrings, "\n"))
+	}
+
+	return object
+}
+
+func (t TargetSpecAllocationPoolsType) ValueFromTerraform(ctx context.Context, in tftypes.Value) (attr.Value, error) {
+	if in.Type() == nil {
+		return NewTargetSpecAllocationPoolsValueNull(), nil
+	}
+
+	if !in.Type().Equal(t.TerraformType(ctx)) {
+		return nil, fmt.Errorf("expected %s, got %s", t.TerraformType(ctx), in.Type())
+	}
+
+	if !in.IsKnown() {
+		return NewTargetSpecAllocationPoolsValueUnknown(), nil
+	}
+
+	if in.IsNull() {
+		return NewTargetSpecAllocationPoolsValueNull(), nil
+	}
+
+	attributes := map[string]attr.Value{}
+
+	val := map[string]tftypes.Value{}
+
+	err := in.As(&val)
+
+	if err != nil {
+		return nil, err
+	}
+
+	for k, v := range val {
+		a, err := t.AttrTypes[k].ValueFromTerraform(ctx, v)
+
+		if err != nil {
+			return nil, err
+		}
+
+		attributes[k] = a
+	}
+
+	return NewTargetSpecAllocationPoolsValueMust(TargetSpecAllocationPoolsValue{}.AttributeTypes(ctx), attributes), nil
+}
+
+func (t TargetSpecAllocationPoolsType) ValueType(ctx context.Context) attr.Value {
+	return TargetSpecAllocationPoolsValue{}
+}
+
+var _ basetypes.ObjectValuable = TargetSpecAllocationPoolsValue{}
+
+type TargetSpecAllocationPoolsValue struct {
+	End   ovhtypes.TfStringValue `tfsdk:"end" json:"end"`
+	Start ovhtypes.TfStringValue `tfsdk:"start" json:"start"`
+	state attr.ValueState
+}
+
+func (v TargetSpecAllocationPoolsValue) ToCreate() *TargetSpecAllocationPoolsValue {
+	res := &TargetSpecAllocationPoolsValue{}
+
+	if !v.End.IsNull() {
+		res.End = v.End
+	}
+
+	if !v.Start.IsNull() {
+		res.Start = v.Start
+	}
+
+	res.state = attr.ValueStateKnown
+
+	return res
+}
+
+func (v TargetSpecAllocationPoolsValue) ToUpdate() *TargetSpecAllocationPoolsValue {
+	res := &TargetSpecAllocationPoolsValue{}
+
+	if !v.End.IsNull() {
+		res.End = v.End
+	}
+
+	if !v.Start.IsNull() {
+		res.Start = v.Start
+	}
+
+	res.state = attr.ValueStateKnown
+
+	return res
+}
+
+func (v TargetSpecAllocationPoolsValue) MarshalJSON() ([]byte, error) {
+	toMarshal := map[string]any{}
+	if !v.End.IsNull() && !v.End.IsUnknown() {
+		toMarshal["end"] = v.End
+	}
+	if !v.Start.IsNull() && !v.Start.IsUnknown() {
+		toMarshal["start"] = v.Start
+	}
+
+	return json.Marshal(toMarshal)
+}
+
+func (v *TargetSpecAllocationPoolsValue) UnmarshalJSON(data []byte) error {
+	type JsonTargetSpecAllocationPoolsValue TargetSpecAllocationPoolsValue
+
+	var tmp JsonTargetSpecAllocationPoolsValue
+	if err := json.Unmarshal(data, &tmp); err != nil {
+		return err
+	}
+	v.End = tmp.End
+	v.Start = tmp.Start
+
+	v.state = attr.ValueStateKnown
+
+	return nil
+}
+
+func (v *TargetSpecAllocationPoolsValue) MergeWith(other *TargetSpecAllocationPoolsValue) {
+
+	if (v.End.IsUnknown() || v.End.IsNull()) && !other.End.IsUnknown() {
+		v.End = other.End
+	}
+
+	if (v.Start.IsUnknown() || v.Start.IsNull()) && !other.Start.IsUnknown() {
+		v.Start = other.Start
+	}
+
+	if (v.state == attr.ValueStateUnknown || v.state == attr.ValueStateNull) && other.state != attr.ValueStateUnknown {
+		v.state = other.state
+	}
+}
+
+func (v TargetSpecAllocationPoolsValue) Attributes() map[string]attr.Value {
+	return map[string]attr.Value{
+		"end":   v.End,
+		"start": v.Start,
+	}
+}
+func (v TargetSpecAllocationPoolsValue) ToTerraformValue(ctx context.Context) (tftypes.Value, error) {
+	attrTypes := make(map[string]tftypes.Type, 2)
+
+	var val tftypes.Value
+	var err error
+
+	attrTypes["end"] = basetypes.StringType{}.TerraformType(ctx)
+	attrTypes["start"] = basetypes.StringType{}.TerraformType(ctx)
+
+	objectType := tftypes.Object{AttributeTypes: attrTypes}
+
+	switch v.state {
+	case attr.ValueStateKnown:
+		vals := make(map[string]tftypes.Value, 2)
+
+		val, err = v.End.ToTerraformValue(ctx)
+
+		if err != nil {
+			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
+		}
+
+		vals["end"] = val
+
+		val, err = v.Start.ToTerraformValue(ctx)
+
+		if err != nil {
+			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
+		}
+
+		vals["start"] = val
+
+		if err := tftypes.ValidateValue(objectType, vals); err != nil {
+			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
+		}
+
+		return tftypes.NewValue(objectType, vals), nil
+	case attr.ValueStateNull:
+		return tftypes.NewValue(objectType, nil), nil
+	case attr.ValueStateUnknown:
+		return tftypes.NewValue(objectType, tftypes.UnknownValue), nil
+	default:
+		panic(fmt.Sprintf("unhandled Object state in ToTerraformValue: %s", v.state))
+	}
+}
+
+func (v TargetSpecAllocationPoolsValue) IsNull() bool {
+	return v.state == attr.ValueStateNull
+}
+
+func (v TargetSpecAllocationPoolsValue) IsUnknown() bool {
+	return v.state == attr.ValueStateUnknown
+}
+
+func (v TargetSpecAllocationPoolsValue) String() string {
+	return "TargetSpecAllocationPoolsValue"
+}
+
+func (v TargetSpecAllocationPoolsValue) ToObjectValue(ctx context.Context) (basetypes.ObjectValue, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	objVal, diags := types.ObjectValue(
+		map[string]attr.Type{
+			"end":   ovhtypes.TfStringType{},
+			"start": ovhtypes.TfStringType{},
+		},
+		map[string]attr.Value{
+			"end":   v.End,
+			"start": v.Start,
+		})
+
+	return objVal, diags
+}
+
+func (v TargetSpecAllocationPoolsValue) Equal(o attr.Value) bool {
+	other, ok := o.(TargetSpecAllocationPoolsValue)
+
+	if !ok {
+		return false
+	}
+
+	if v.state != other.state {
+		return false
+	}
+
+	if v.state != attr.ValueStateKnown {
+		return true
+	}
+
+	if !v.End.Equal(other.End) {
+		return false
+	}
+
+	if !v.Start.Equal(other.Start) {
+		return false
+	}
+
+	return true
+}
+
+func (v TargetSpecAllocationPoolsValue) Type(ctx context.Context) attr.Type {
+	return TargetSpecAllocationPoolsType{
+		basetypes.ObjectType{
+			AttrTypes: v.AttributeTypes(ctx),
+		},
+	}
+}
+
+func (v TargetSpecAllocationPoolsValue) AttributeTypes(ctx context.Context) map[string]attr.Type {
+	return map[string]attr.Type{
+		"end":   ovhtypes.TfStringType{},
+		"start": ovhtypes.TfStringType{},
+	}
+}
+
+var _ basetypes.ObjectTypable = TargetSpecLocationType{}
+
+type TargetSpecLocationType struct {
+	basetypes.ObjectType
+}
+
+func (t TargetSpecLocationType) Equal(o attr.Type) bool {
+	other, ok := o.(TargetSpecLocationType)
+
+	if !ok {
+		return false
+	}
+
+	return t.ObjectType.Equal(other.ObjectType)
+}
+
+func (t TargetSpecLocationType) String() string {
+	return "TargetSpecLocationType"
+}
+
+func (t TargetSpecLocationType) ValueFromObject(ctx context.Context, in basetypes.ObjectValue) (basetypes.ObjectValuable, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	attributes := in.Attributes()
+
+	availabilityZoneAttribute, ok := attributes["availability_zone"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`availability_zone is missing from object`)
+
+		return nil, diags
+	}
+
+	availabilityZoneVal, ok := availabilityZoneAttribute.(ovhtypes.TfStringValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`availability_zone expected to be ovhtypes.TfStringValue, was: %T`, availabilityZoneAttribute))
+	}
+
+	regionAttribute, ok := attributes["region"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`region is missing from object`)
+
+		return nil, diags
+	}
+
+	regionVal, ok := regionAttribute.(ovhtypes.TfStringValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`region expected to be ovhtypes.TfStringValue, was: %T`, regionAttribute))
+	}
+
+	if diags.HasError() {
+		return nil, diags
+	}
+
+	return TargetSpecLocationValue{
+		AvailabilityZone: availabilityZoneVal,
+		Region:           regionVal,
+		state:            attr.ValueStateKnown,
+	}, diags
+}
+
+func NewTargetSpecLocationValueNull() TargetSpecLocationValue {
+	return TargetSpecLocationValue{
+		state: attr.ValueStateNull,
+	}
+}
+
+func NewTargetSpecLocationValueUnknown() TargetSpecLocationValue {
+	return TargetSpecLocationValue{
+		state: attr.ValueStateUnknown,
+	}
+}
+
+func NewTargetSpecLocationValue(attributeTypes map[string]attr.Type, attributes map[string]attr.Value) (TargetSpecLocationValue, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	// Reference: https://github.com/hashicorp/terraform-plugin-framework/issues/521
+	ctx := context.Background()
+
+	for name, attributeType := range attributeTypes {
+		attribute, ok := attributes[name]
+
+		if !ok {
+			diags.AddError(
+				"Missing TargetSpecLocationValue Attribute Value",
+				"While creating a TargetSpecLocationValue value, a missing attribute value was detected. "+
+					"A TargetSpecLocationValue must contain values for all attributes, even if null or unknown. "+
+					"This is always an issue with the provider and should be reported to the provider developers.\n\n"+
+					fmt.Sprintf("TargetSpecLocationValue Attribute Name (%s) Expected Type: %s", name, attributeType.String()),
+			)
+
+			continue
+		}
+
+		if !attributeType.Equal(attribute.Type(ctx)) {
+			diags.AddError(
+				"Invalid TargetSpecLocationValue Attribute Type",
+				"While creating a TargetSpecLocationValue value, an invalid attribute value was detected. "+
+					"A TargetSpecLocationValue must use a matching attribute type for the value. "+
+					"This is always an issue with the provider and should be reported to the provider developers.\n\n"+
+					fmt.Sprintf("TargetSpecLocationValue Attribute Name (%s) Expected Type: %s\n", name, attributeType.String())+
+					fmt.Sprintf("TargetSpecLocationValue Attribute Name (%s) Given Type: %s", name, attribute.Type(ctx)),
+			)
+		}
+	}
+
+	for name := range attributes {
+		_, ok := attributeTypes[name]
+
+		if !ok {
+			diags.AddError(
+				"Extra TargetSpecLocationValue Attribute Value",
+				"While creating a TargetSpecLocationValue value, an extra attribute value was detected. "+
+					"A TargetSpecLocationValue must not contain values beyond the expected attribute types. "+
+					"This is always an issue with the provider and should be reported to the provider developers.\n\n"+
+					fmt.Sprintf("Extra TargetSpecLocationValue Attribute Name: %s", name),
+			)
+		}
+	}
+
+	if diags.HasError() {
+		return NewTargetSpecLocationValueUnknown(), diags
+	}
+
+	availabilityZoneAttribute, ok := attributes["availability_zone"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`availability_zone is missing from object`)
+
+		return NewTargetSpecLocationValueUnknown(), diags
+	}
+
+	availabilityZoneVal, ok := availabilityZoneAttribute.(ovhtypes.TfStringValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`availability_zone expected to be ovhtypes.TfStringValue, was: %T`, availabilityZoneAttribute))
+	}
+
+	regionAttribute, ok := attributes["region"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`region is missing from object`)
+
+		return NewTargetSpecLocationValueUnknown(), diags
+	}
+
+	regionVal, ok := regionAttribute.(ovhtypes.TfStringValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`region expected to be ovhtypes.TfStringValue, was: %T`, regionAttribute))
+	}
+
+	if diags.HasError() {
+		return NewTargetSpecLocationValueUnknown(), diags
+	}
+
+	return TargetSpecLocationValue{
+		AvailabilityZone: availabilityZoneVal,
+		Region:           regionVal,
+		state:            attr.ValueStateKnown,
+	}, diags
+}
+
+func NewTargetSpecLocationValueMust(attributeTypes map[string]attr.Type, attributes map[string]attr.Value) TargetSpecLocationValue {
+	object, diags := NewTargetSpecLocationValue(attributeTypes, attributes)
+
+	if diags.HasError() {
+		// This could potentially be added to the diag package.
+		diagsStrings := make([]string, 0, len(diags))
+
+		for _, diagnostic := range diags {
+			diagsStrings = append(diagsStrings, fmt.Sprintf(
+				"%s | %s | %s",
+				diagnostic.Severity(),
+				diagnostic.Summary(),
+				diagnostic.Detail()))
+		}
+
+		panic("NewTargetSpecLocationValueMust received error(s): " + strings.Join(diagsStrings, "\n"))
+	}
+
+	return object
+}
+
+func (t TargetSpecLocationType) ValueFromTerraform(ctx context.Context, in tftypes.Value) (attr.Value, error) {
+	if in.Type() == nil {
+		return NewTargetSpecLocationValueNull(), nil
+	}
+
+	if !in.Type().Equal(t.TerraformType(ctx)) {
+		return nil, fmt.Errorf("expected %s, got %s", t.TerraformType(ctx), in.Type())
+	}
+
+	if !in.IsKnown() {
+		return NewTargetSpecLocationValueUnknown(), nil
+	}
+
+	if in.IsNull() {
+		return NewTargetSpecLocationValueNull(), nil
+	}
+
+	attributes := map[string]attr.Value{}
+
+	val := map[string]tftypes.Value{}
+
+	err := in.As(&val)
+
+	if err != nil {
+		return nil, err
+	}
+
+	for k, v := range val {
+		a, err := t.AttrTypes[k].ValueFromTerraform(ctx, v)
+
+		if err != nil {
+			return nil, err
+		}
+
+		attributes[k] = a
+	}
+
+	return NewTargetSpecLocationValueMust(TargetSpecLocationValue{}.AttributeTypes(ctx), attributes), nil
+}
+
+func (t TargetSpecLocationType) ValueType(ctx context.Context) attr.Value {
+	return TargetSpecLocationValue{}
+}
+
+var _ basetypes.ObjectValuable = TargetSpecLocationValue{}
+
+type TargetSpecLocationValue struct {
+	AvailabilityZone ovhtypes.TfStringValue `tfsdk:"availability_zone" json:"availabilityZone"`
+	Region           ovhtypes.TfStringValue `tfsdk:"region" json:"region"`
+	state            attr.ValueState
+}
+
+func (v TargetSpecLocationValue) ToCreate() *TargetSpecLocationValue {
+	res := &TargetSpecLocationValue{}
+
+	if !v.AvailabilityZone.IsNull() {
+		res.AvailabilityZone = v.AvailabilityZone
+	}
+
+	if !v.Region.IsNull() {
+		res.Region = v.Region
+	}
+
+	res.state = attr.ValueStateKnown
+
+	return res
+}
+
+func (v TargetSpecLocationValue) MarshalJSON() ([]byte, error) {
+	toMarshal := map[string]any{}
+	if !v.AvailabilityZone.IsNull() && !v.AvailabilityZone.IsUnknown() {
+		toMarshal["availabilityZone"] = v.AvailabilityZone
+	}
+	if !v.Region.IsNull() && !v.Region.IsUnknown() {
+		toMarshal["region"] = v.Region
+	}
+
+	return json.Marshal(toMarshal)
+}
+
+func (v *TargetSpecLocationValue) UnmarshalJSON(data []byte) error {
+	type JsonTargetSpecLocationValue TargetSpecLocationValue
+
+	var tmp JsonTargetSpecLocationValue
+	if err := json.Unmarshal(data, &tmp); err != nil {
+		return err
+	}
+	v.AvailabilityZone = tmp.AvailabilityZone
+	v.Region = tmp.Region
+
+	v.state = attr.ValueStateKnown
+
+	return nil
+}
+
+func (v *TargetSpecLocationValue) MergeWith(other *TargetSpecLocationValue) {
+
+	if (v.AvailabilityZone.IsUnknown() || v.AvailabilityZone.IsNull()) && !other.AvailabilityZone.IsUnknown() {
+		v.AvailabilityZone = other.AvailabilityZone
+	}
+
+	if (v.Region.IsUnknown() || v.Region.IsNull()) && !other.Region.IsUnknown() {
+		v.Region = other.Region
+	}
+
+	if (v.state == attr.ValueStateUnknown || v.state == attr.ValueStateNull) && other.state != attr.ValueStateUnknown {
+		v.state = other.state
+	}
+}
+
+func (v TargetSpecLocationValue) Attributes() map[string]attr.Value {
+	return map[string]attr.Value{
+		"availabilityZone": v.AvailabilityZone,
+		"region":           v.Region,
+	}
+}
+func (v TargetSpecLocationValue) ToTerraformValue(ctx context.Context) (tftypes.Value, error) {
+	attrTypes := make(map[string]tftypes.Type, 2)
+
+	var val tftypes.Value
+	var err error
+
+	attrTypes["availability_zone"] = basetypes.StringType{}.TerraformType(ctx)
+	attrTypes["region"] = basetypes.StringType{}.TerraformType(ctx)
+
+	objectType := tftypes.Object{AttributeTypes: attrTypes}
+
+	switch v.state {
+	case attr.ValueStateKnown:
+		vals := make(map[string]tftypes.Value, 2)
+
+		val, err = v.AvailabilityZone.ToTerraformValue(ctx)
+
+		if err != nil {
+			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
+		}
+
+		vals["availability_zone"] = val
+
+		val, err = v.Region.ToTerraformValue(ctx)
+
+		if err != nil {
+			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
+		}
+
+		vals["region"] = val
+
+		if err := tftypes.ValidateValue(objectType, vals); err != nil {
+			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
+		}
+
+		return tftypes.NewValue(objectType, vals), nil
+	case attr.ValueStateNull:
+		return tftypes.NewValue(objectType, nil), nil
+	case attr.ValueStateUnknown:
+		return tftypes.NewValue(objectType, tftypes.UnknownValue), nil
+	default:
+		panic(fmt.Sprintf("unhandled Object state in ToTerraformValue: %s", v.state))
+	}
+}
+
+func (v TargetSpecLocationValue) IsNull() bool {
+	return v.state == attr.ValueStateNull
+}
+
+func (v TargetSpecLocationValue) IsUnknown() bool {
+	return v.state == attr.ValueStateUnknown
+}
+
+func (v TargetSpecLocationValue) String() string {
+	return "TargetSpecLocationValue"
+}
+
+func (v TargetSpecLocationValue) ToObjectValue(ctx context.Context) (basetypes.ObjectValue, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	objVal, diags := types.ObjectValue(
+		map[string]attr.Type{
+			"availability_zone": ovhtypes.TfStringType{},
+			"region":            ovhtypes.TfStringType{},
+		},
+		map[string]attr.Value{
+			"availability_zone": v.AvailabilityZone,
+			"region":            v.Region,
+		})
+
+	return objVal, diags
+}
+
+func (v TargetSpecLocationValue) Equal(o attr.Value) bool {
+	other, ok := o.(TargetSpecLocationValue)
+
+	if !ok {
+		return false
+	}
+
+	if v.state != other.state {
+		return false
+	}
+
+	if v.state != attr.ValueStateKnown {
+		return true
+	}
+
+	if !v.AvailabilityZone.Equal(other.AvailabilityZone) {
+		return false
+	}
+
+	if !v.Region.Equal(other.Region) {
+		return false
+	}
+
+	return true
+}
+
+func (v TargetSpecLocationValue) Type(ctx context.Context) attr.Type {
+	return TargetSpecLocationType{
+		basetypes.ObjectType{
+			AttrTypes: v.AttributeTypes(ctx),
+		},
+	}
+}
+
+func (v TargetSpecLocationValue) AttributeTypes(ctx context.Context) map[string]attr.Type {
+	return map[string]attr.Type{
+		"availability_zone": ovhtypes.TfStringType{},
+		"region":            ovhtypes.TfStringType{},
+	}
+}

--- a/ovh/resource_cloud_network_private_vrack_subnet_test.go
+++ b/ovh/resource_cloud_network_private_vrack_subnet_test.go
@@ -1,0 +1,166 @@
+package ovh
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+)
+
+const testAccResourceCloudNetworkPrivateVrackSubnetNamePrefix = "tf-test-subnet-v2-"
+
+func testAccPreCheckCloudNetworkPrivateVrackSubnet(t *testing.T) {
+	testAccPreCheckCredentials(t)
+	if os.Getenv("OVH_CLOUD_PROJECT_SERVICE_TEST") == "" {
+		t.Skip("OVH_CLOUD_PROJECT_SERVICE_TEST must be set for acceptance tests")
+	}
+	if os.Getenv("OVH_CLOUD_PROJECT_REGION_TEST") == "" {
+		t.Skip("OVH_CLOUD_PROJECT_REGION_TEST must be set for acceptance tests")
+	}
+}
+
+func testAccCloudNetworkPrivateVrackSubnetImportStateIdFunc(resourceName string) resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return "", fmt.Errorf("not found: %s", resourceName)
+		}
+		return fmt.Sprintf("%s/%s/%s",
+			rs.Primary.Attributes["service_name"],
+			rs.Primary.Attributes["network_id"],
+			rs.Primary.Attributes["id"],
+		), nil
+	}
+}
+
+func TestAccCloudNetworkPrivateVrackSubnet_basic(t *testing.T) {
+	serviceName := os.Getenv("OVH_CLOUD_PROJECT_SERVICE_TEST")
+	region := os.Getenv("OVH_CLOUD_PROJECT_REGION_TEST")
+
+	networkName := acctest.RandomWithPrefix(testAccResourceCloudNetworkPrivateVrackNamePrefix)
+	subnetName := acctest.RandomWithPrefix(testAccResourceCloudNetworkPrivateVrackSubnetNamePrefix)
+
+	config := fmt.Sprintf(`
+resource "ovh_cloud_network_private_vrack" "network" {
+  service_name = "%s"
+  name         = "%s"
+  region       = "%s"
+}
+
+resource "ovh_cloud_network_private_vrack_subnet" "test" {
+  service_name = ovh_cloud_network_private_vrack.network.service_name
+  network_id   = ovh_cloud_network_private_vrack.network.id
+  name         = "%s"
+  cidr         = "10.0.0.0/24"
+  region       = "%s"
+  dhcp_enabled = true
+}
+`, serviceName, networkName, region, subnetName, region)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheckCloudNetworkPrivateVrackSubnet(t)
+		},
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("ovh_cloud_network_private_vrack_subnet.test", "service_name", serviceName),
+					resource.TestCheckResourceAttr("ovh_cloud_network_private_vrack_subnet.test", "name", subnetName),
+					resource.TestCheckResourceAttr("ovh_cloud_network_private_vrack_subnet.test", "cidr", "10.0.0.0/24"),
+					resource.TestCheckResourceAttr("ovh_cloud_network_private_vrack_subnet.test", "region", region),
+					resource.TestCheckResourceAttr("ovh_cloud_network_private_vrack_subnet.test", "dhcp_enabled", "true"),
+					resource.TestCheckResourceAttrSet("ovh_cloud_network_private_vrack_subnet.test", "id"),
+					resource.TestCheckResourceAttrSet("ovh_cloud_network_private_vrack_subnet.test", "checksum"),
+					resource.TestCheckResourceAttrSet("ovh_cloud_network_private_vrack_subnet.test", "created_at"),
+					resource.TestCheckResourceAttr("ovh_cloud_network_private_vrack_subnet.test", "resource_status", "READY"),
+					resource.TestCheckResourceAttrSet("ovh_cloud_network_private_vrack_subnet.test", "current_state.name"),
+					resource.TestCheckResourceAttrSet("ovh_cloud_network_private_vrack_subnet.test", "current_state.cidr"),
+					resource.TestCheckResourceAttrSet("ovh_cloud_network_private_vrack_subnet.test", "current_state.location.region"),
+				),
+			},
+			// Test import
+			{
+				ResourceName:      "ovh_cloud_network_private_vrack_subnet.test",
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testAccCloudNetworkPrivateVrackSubnetImportStateIdFunc("ovh_cloud_network_private_vrack_subnet.test"),
+			},
+		},
+	})
+}
+
+func TestAccCloudNetworkPrivateVrackSubnet_update(t *testing.T) {
+	serviceName := os.Getenv("OVH_CLOUD_PROJECT_SERVICE_TEST")
+	region := os.Getenv("OVH_CLOUD_PROJECT_REGION_TEST")
+
+	networkName := acctest.RandomWithPrefix(testAccResourceCloudNetworkPrivateVrackNamePrefix)
+	subnetName := acctest.RandomWithPrefix(testAccResourceCloudNetworkPrivateVrackSubnetNamePrefix)
+	updatedName := acctest.RandomWithPrefix(testAccResourceCloudNetworkPrivateVrackSubnetNamePrefix)
+
+	config := fmt.Sprintf(`
+resource "ovh_cloud_network_private_vrack" "network" {
+  service_name = "%s"
+  name         = "%s"
+  region       = "%s"
+}
+
+resource "ovh_cloud_network_private_vrack_subnet" "test" {
+  service_name = ovh_cloud_network_private_vrack.network.service_name
+  network_id   = ovh_cloud_network_private_vrack.network.id
+  name         = "%s"
+  cidr         = "10.0.0.0/24"
+  region       = "%s"
+  description  = "initial description"
+}
+`, serviceName, networkName, region, subnetName, region)
+
+	updatedConfig := fmt.Sprintf(`
+resource "ovh_cloud_network_private_vrack" "network" {
+  service_name = "%s"
+  name         = "%s"
+  region       = "%s"
+}
+
+resource "ovh_cloud_network_private_vrack_subnet" "test" {
+  service_name = ovh_cloud_network_private_vrack.network.service_name
+  network_id   = ovh_cloud_network_private_vrack.network.id
+  name         = "%s"
+  cidr         = "10.0.0.0/24"
+  region       = "%s"
+  description  = "updated description"
+}
+`, serviceName, networkName, region, updatedName, region)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheckCloudNetworkPrivateVrackSubnet(t)
+		},
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("ovh_cloud_network_private_vrack_subnet.test", "name", subnetName),
+					resource.TestCheckResourceAttr("ovh_cloud_network_private_vrack_subnet.test", "description", "initial description"),
+					resource.TestCheckResourceAttrSet("ovh_cloud_network_private_vrack_subnet.test", "id"),
+					resource.TestCheckResourceAttrSet("ovh_cloud_network_private_vrack_subnet.test", "checksum"),
+				),
+			},
+			{
+				Config: updatedConfig,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("ovh_cloud_network_private_vrack_subnet.test", "name", updatedName),
+					resource.TestCheckResourceAttr("ovh_cloud_network_private_vrack_subnet.test", "description", "updated description"),
+					resource.TestCheckResourceAttrSet("ovh_cloud_network_private_vrack_subnet.test", "id"),
+					resource.TestCheckResourceAttrSet("ovh_cloud_network_private_vrack_subnet.test", "checksum"),
+					resource.TestCheckResourceAttr("ovh_cloud_network_private_vrack_subnet.test", "resource_status", "READY"),
+				),
+			},
+		},
+	})
+}

--- a/ovh/resource_cloud_network_private_vrack_subnet_test.go
+++ b/ovh/resource_cloud_network_private_vrack_subnet_test.go
@@ -94,6 +94,151 @@ resource "ovh_cloud_network_private_vrack_subnet" "test" {
 	})
 }
 
+// TestAccCloudNetworkPrivateVrackSubnet_withAllOptions creates a subnet exercising
+// all optional attributes: gateway_ip, dns_nameservers and allocation_pools.
+func TestAccCloudNetworkPrivateVrackSubnet_withAllOptions(t *testing.T) {
+	serviceName := os.Getenv("OVH_CLOUD_PROJECT_SERVICE_TEST")
+	region := os.Getenv("OVH_CLOUD_PROJECT_REGION_TEST")
+
+	networkName := acctest.RandomWithPrefix(testAccResourceCloudNetworkPrivateVrackNamePrefix)
+	subnetName := acctest.RandomWithPrefix(testAccResourceCloudNetworkPrivateVrackSubnetNamePrefix)
+
+	config := fmt.Sprintf(`
+resource "ovh_cloud_network_private_vrack" "network" {
+  service_name = "%s"
+  name         = "%s"
+  region       = "%s"
+}
+
+resource "ovh_cloud_network_private_vrack_subnet" "test" {
+  service_name    = ovh_cloud_network_private_vrack.network.service_name
+  network_id      = ovh_cloud_network_private_vrack.network.id
+  name            = "%s"
+  cidr            = "10.0.0.0/24"
+  region          = "%s"
+  dhcp_enabled    = true
+  gateway_ip      = "10.0.0.1"
+  dns_nameservers = ["1.1.1.1", "8.8.8.8"]
+
+  allocation_pools = [
+    {
+      start = "10.0.0.10"
+      end   = "10.0.0.100"
+    },
+  ]
+}
+`, serviceName, networkName, region, subnetName, region)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheckCloudNetworkPrivateVrackSubnet(t)
+		},
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("ovh_cloud_network_private_vrack_subnet.test", "name", subnetName),
+					resource.TestCheckResourceAttr("ovh_cloud_network_private_vrack_subnet.test", "cidr", "10.0.0.0/24"),
+					resource.TestCheckResourceAttr("ovh_cloud_network_private_vrack_subnet.test", "dhcp_enabled", "true"),
+					resource.TestCheckResourceAttr("ovh_cloud_network_private_vrack_subnet.test", "gateway_ip", "10.0.0.1"),
+					resource.TestCheckResourceAttr("ovh_cloud_network_private_vrack_subnet.test", "dns_nameservers.#", "2"),
+					resource.TestCheckResourceAttr("ovh_cloud_network_private_vrack_subnet.test", "dns_nameservers.0", "1.1.1.1"),
+					resource.TestCheckResourceAttr("ovh_cloud_network_private_vrack_subnet.test", "dns_nameservers.1", "8.8.8.8"),
+					resource.TestCheckResourceAttr("ovh_cloud_network_private_vrack_subnet.test", "allocation_pools.#", "1"),
+					resource.TestCheckResourceAttr("ovh_cloud_network_private_vrack_subnet.test", "allocation_pools.0.start", "10.0.0.10"),
+					resource.TestCheckResourceAttr("ovh_cloud_network_private_vrack_subnet.test", "allocation_pools.0.end", "10.0.0.100"),
+					resource.TestCheckResourceAttr("ovh_cloud_network_private_vrack_subnet.test", "resource_status", "READY"),
+					resource.TestCheckResourceAttr("ovh_cloud_network_private_vrack_subnet.test", "current_state.gateway_ip", "10.0.0.1"),
+					resource.TestCheckResourceAttr("ovh_cloud_network_private_vrack_subnet.test", "current_state.dhcp_enabled", "true"),
+				),
+			},
+			// Test import
+			{
+				ResourceName:      "ovh_cloud_network_private_vrack_subnet.test",
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testAccCloudNetworkPrivateVrackSubnetImportStateIdFunc("ovh_cloud_network_private_vrack_subnet.test"),
+			},
+		},
+	})
+}
+
+// TestAccCloudNetworkPrivateVrackSubnet_updateMutableFields toggles dhcp_enabled and
+// updates dns_nameservers / gateway_ip in place (these are mutable, no replacement).
+func TestAccCloudNetworkPrivateVrackSubnet_updateMutableFields(t *testing.T) {
+	serviceName := os.Getenv("OVH_CLOUD_PROJECT_SERVICE_TEST")
+	region := os.Getenv("OVH_CLOUD_PROJECT_REGION_TEST")
+
+	networkName := acctest.RandomWithPrefix(testAccResourceCloudNetworkPrivateVrackNamePrefix)
+	subnetName := acctest.RandomWithPrefix(testAccResourceCloudNetworkPrivateVrackSubnetNamePrefix)
+
+	config := fmt.Sprintf(`
+resource "ovh_cloud_network_private_vrack" "network" {
+  service_name = "%s"
+  name         = "%s"
+  region       = "%s"
+}
+
+resource "ovh_cloud_network_private_vrack_subnet" "test" {
+  service_name    = ovh_cloud_network_private_vrack.network.service_name
+  network_id      = ovh_cloud_network_private_vrack.network.id
+  name            = "%s"
+  cidr            = "10.0.0.0/24"
+  region          = "%s"
+  dhcp_enabled    = false
+  dns_nameservers = ["1.1.1.1"]
+}
+`, serviceName, networkName, region, subnetName, region)
+
+	updatedConfig := fmt.Sprintf(`
+resource "ovh_cloud_network_private_vrack" "network" {
+  service_name = "%s"
+  name         = "%s"
+  region       = "%s"
+}
+
+resource "ovh_cloud_network_private_vrack_subnet" "test" {
+  service_name    = ovh_cloud_network_private_vrack.network.service_name
+  network_id      = ovh_cloud_network_private_vrack.network.id
+  name            = "%s"
+  cidr            = "10.0.0.0/24"
+  region          = "%s"
+  dhcp_enabled    = true
+  dns_nameservers = ["8.8.8.8", "8.8.4.4"]
+}
+`, serviceName, networkName, region, subnetName, region)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheckCloudNetworkPrivateVrackSubnet(t)
+		},
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("ovh_cloud_network_private_vrack_subnet.test", "dhcp_enabled", "false"),
+					resource.TestCheckResourceAttr("ovh_cloud_network_private_vrack_subnet.test", "dns_nameservers.#", "1"),
+					resource.TestCheckResourceAttr("ovh_cloud_network_private_vrack_subnet.test", "dns_nameservers.0", "1.1.1.1"),
+					resource.TestCheckResourceAttrSet("ovh_cloud_network_private_vrack_subnet.test", "id"),
+				),
+			},
+			{
+				Config: updatedConfig,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("ovh_cloud_network_private_vrack_subnet.test", "dhcp_enabled", "true"),
+					resource.TestCheckResourceAttr("ovh_cloud_network_private_vrack_subnet.test", "dns_nameservers.#", "2"),
+					resource.TestCheckResourceAttr("ovh_cloud_network_private_vrack_subnet.test", "dns_nameservers.0", "8.8.8.8"),
+					resource.TestCheckResourceAttr("ovh_cloud_network_private_vrack_subnet.test", "dns_nameservers.1", "8.8.4.4"),
+					resource.TestCheckResourceAttr("ovh_cloud_network_private_vrack_subnet.test", "current_state.dhcp_enabled", "true"),
+					resource.TestCheckResourceAttr("ovh_cloud_network_private_vrack_subnet.test", "resource_status", "READY"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccCloudNetworkPrivateVrackSubnet_update(t *testing.T) {
 	serviceName := os.Getenv("OVH_CLOUD_PROJECT_SERVICE_TEST")
 	region := os.Getenv("OVH_CLOUD_PROJECT_REGION_TEST")

--- a/ovh/resource_cloud_network_private_vrack_subnet_test.go
+++ b/ovh/resource_cloud_network_private_vrack_subnet_test.go
@@ -31,7 +31,7 @@ func testAccCloudNetworkPrivateSubnetImportStateIdFunc(resourceName string) reso
 			return "", fmt.Errorf("not found: %s", resourceName)
 		}
 		return fmt.Sprintf("%s/%s/%s",
-			rs.Primary.Attributes["project_id"],
+			rs.Primary.Attributes["service_name"],
 			rs.Primary.Attributes["network_id"],
 			rs.Primary.Attributes["id"],
 		), nil
@@ -54,7 +54,7 @@ resource "ovh_cloud_network_private_vrack" "network" {
 }
 
 resource "ovh_cloud_network_private_vrack_subnet" "test" {
-  project_id = ovh_cloud_network_private_vrack.network.service_name
+  service_name = ovh_cloud_network_private_vrack.network.service_name
   network_id = ovh_cloud_network_private_vrack.network.id
 
   name = "%s"
@@ -74,7 +74,7 @@ resource "ovh_cloud_network_private_vrack_subnet" "test" {
 			{
 				Config: config,
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("ovh_cloud_network_private_vrack_subnet.test", "project_id", serviceName),
+					resource.TestCheckResourceAttr("ovh_cloud_network_private_vrack_subnet.test", "service_name", serviceName),
 					resource.TestCheckResourceAttrSet("ovh_cloud_network_private_vrack_subnet.test", "network_id"),
 					resource.TestCheckResourceAttr("ovh_cloud_network_private_vrack_subnet.test", "name", subnetName),
 					resource.TestCheckResourceAttr("ovh_cloud_network_private_vrack_subnet.test", "cidr", "10.0.0.0/24"),
@@ -118,7 +118,7 @@ resource "ovh_cloud_network_private_vrack" "network" {
 }
 
 resource "ovh_cloud_network_private_vrack_subnet" "test" {
-  project_id = ovh_cloud_network_private_vrack.network.service_name
+  service_name = ovh_cloud_network_private_vrack.network.service_name
   network_id = ovh_cloud_network_private_vrack.network.id
 
   name            = "%s"
@@ -192,7 +192,7 @@ resource "ovh_cloud_network_private_vrack" "network" {
 }
 
 resource "ovh_cloud_network_private_vrack_subnet" "test" {
-  project_id = ovh_cloud_network_private_vrack.network.service_name
+  service_name = ovh_cloud_network_private_vrack.network.service_name
   network_id = ovh_cloud_network_private_vrack.network.id
 
   name            = "%s"
@@ -216,7 +216,7 @@ resource "ovh_cloud_network_private_vrack" "network" {
 }
 
 resource "ovh_cloud_network_private_vrack_subnet" "test" {
-  project_id = ovh_cloud_network_private_vrack.network.service_name
+  service_name = ovh_cloud_network_private_vrack.network.service_name
   network_id = ovh_cloud_network_private_vrack.network.id
 
   name            = "%s"
@@ -281,7 +281,7 @@ resource "ovh_cloud_network_private_vrack" "network" {
 }
 
 resource "ovh_cloud_network_private_vrack_subnet" "test" {
-  project_id = ovh_cloud_network_private_vrack.network.service_name
+  service_name = ovh_cloud_network_private_vrack.network.service_name
   network_id = ovh_cloud_network_private_vrack.network.id
 
   name        = "%s"
@@ -303,7 +303,7 @@ resource "ovh_cloud_network_private_vrack" "network" {
 }
 
 resource "ovh_cloud_network_private_vrack_subnet" "test" {
-  project_id = ovh_cloud_network_private_vrack.network.service_name
+  service_name = ovh_cloud_network_private_vrack.network.service_name
   network_id = ovh_cloud_network_private_vrack.network.id
 
   name        = "%s"

--- a/ovh/resource_cloud_network_private_vrack_subnet_test.go
+++ b/ovh/resource_cloud_network_private_vrack_subnet_test.go
@@ -10,9 +10,9 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 )
 
-const testAccResourceCloudNetworkPrivateVrackSubnetNamePrefix = "tf-test-subnet-v2-"
+const testAccResourceCloudNetworkPrivateSubnetNamePrefix = "tf-test-subnet-"
 
-func testAccPreCheckCloudNetworkPrivateVrackSubnet(t *testing.T) {
+func testAccPreCheckCloudNetworkPrivateSubnet(t *testing.T) {
 	testAccPreCheckCredentials(t)
 	if os.Getenv("OVH_CLOUD_PROJECT_SERVICE_TEST") == "" {
 		t.Skip("OVH_CLOUD_PROJECT_SERVICE_TEST must be set for acceptance tests")
@@ -20,16 +20,18 @@ func testAccPreCheckCloudNetworkPrivateVrackSubnet(t *testing.T) {
 	if os.Getenv("OVH_CLOUD_PROJECT_REGION_TEST") == "" {
 		t.Skip("OVH_CLOUD_PROJECT_REGION_TEST must be set for acceptance tests")
 	}
+	// Creating a regional private network requires a vRack.
+	testAccPreCheckVRack(t)
 }
 
-func testAccCloudNetworkPrivateVrackSubnetImportStateIdFunc(resourceName string) resource.ImportStateIdFunc {
+func testAccCloudNetworkPrivateSubnetImportStateIdFunc(resourceName string) resource.ImportStateIdFunc {
 	return func(s *terraform.State) (string, error) {
 		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
 			return "", fmt.Errorf("not found: %s", resourceName)
 		}
 		return fmt.Sprintf("%s/%s/%s",
-			rs.Primary.Attributes["service_name"],
+			rs.Primary.Attributes["project_id"],
 			rs.Primary.Attributes["network_id"],
 			rs.Primary.Attributes["id"],
 		), nil
@@ -40,40 +42,43 @@ func TestAccCloudNetworkPrivateVrackSubnet_basic(t *testing.T) {
 	serviceName := os.Getenv("OVH_CLOUD_PROJECT_SERVICE_TEST")
 	region := os.Getenv("OVH_CLOUD_PROJECT_REGION_TEST")
 
-	networkName := acctest.RandomWithPrefix(testAccResourceCloudNetworkPrivateVrackNamePrefix)
-	subnetName := acctest.RandomWithPrefix(testAccResourceCloudNetworkPrivateVrackSubnetNamePrefix)
+	subnetName := acctest.RandomWithPrefix(testAccResourceCloudNetworkPrivateSubnetNamePrefix)
 
 	config := fmt.Sprintf(`
 resource "ovh_cloud_network_private_vrack" "network" {
   service_name = "%s"
-  name         = "%s"
-  region       = "%s"
+  name         = "terraform_testacc_private_net"
+  location     = {
+	region = "%s"
+  }
 }
 
 resource "ovh_cloud_network_private_vrack_subnet" "test" {
-  service_name = ovh_cloud_network_private_vrack.network.service_name
-  network_id   = ovh_cloud_network_private_vrack.network.id
-  name         = "%s"
-  cidr         = "10.0.0.0/24"
-  region       = "%s"
-  dhcp_enabled = true
+  project_id = ovh_cloud_network_private_vrack.network.service_name
+  network_id = ovh_cloud_network_private_vrack.network.id
+
+  name = "%s"
+  cidr = "10.0.0.0/24"
+  location = {
+    region = "%s"
+  }
 }
-`, serviceName, networkName, region, subnetName, region)
+`, serviceName, region, subnetName, region)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
-			testAccPreCheckCloudNetworkPrivateVrackSubnet(t)
+			testAccPreCheckCloudNetworkPrivateSubnet(t)
 		},
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
 				Config: config,
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("ovh_cloud_network_private_vrack_subnet.test", "service_name", serviceName),
+					resource.TestCheckResourceAttr("ovh_cloud_network_private_vrack_subnet.test", "project_id", serviceName),
+					resource.TestCheckResourceAttrSet("ovh_cloud_network_private_vrack_subnet.test", "network_id"),
 					resource.TestCheckResourceAttr("ovh_cloud_network_private_vrack_subnet.test", "name", subnetName),
 					resource.TestCheckResourceAttr("ovh_cloud_network_private_vrack_subnet.test", "cidr", "10.0.0.0/24"),
-					resource.TestCheckResourceAttr("ovh_cloud_network_private_vrack_subnet.test", "region", region),
-					resource.TestCheckResourceAttr("ovh_cloud_network_private_vrack_subnet.test", "dhcp_enabled", "true"),
+					resource.TestCheckResourceAttr("ovh_cloud_network_private_vrack_subnet.test", "location.region", region),
 					resource.TestCheckResourceAttrSet("ovh_cloud_network_private_vrack_subnet.test", "id"),
 					resource.TestCheckResourceAttrSet("ovh_cloud_network_private_vrack_subnet.test", "checksum"),
 					resource.TestCheckResourceAttrSet("ovh_cloud_network_private_vrack_subnet.test", "created_at"),
@@ -88,38 +93,42 @@ resource "ovh_cloud_network_private_vrack_subnet" "test" {
 				ResourceName:      "ovh_cloud_network_private_vrack_subnet.test",
 				ImportState:       true,
 				ImportStateVerify: true,
-				ImportStateIdFunc: testAccCloudNetworkPrivateVrackSubnetImportStateIdFunc("ovh_cloud_network_private_vrack_subnet.test"),
+				ImportStateIdFunc: testAccCloudNetworkPrivateSubnetImportStateIdFunc("ovh_cloud_network_private_vrack_subnet.test"),
 			},
 		},
 	})
 }
 
-// TestAccCloudNetworkPrivateVrackSubnet_withAllOptions creates a subnet exercising
-// all optional attributes: gateway_ip, dns_nameservers and allocation_pools.
+// TestAccCloudNetworkPrivateVrackSubnet_withAllOptions creates a subnet exercising all
+// optional attributes: dhcp_enabled, gateway_ip, dns_nameservers and
+// allocation_pools.
 func TestAccCloudNetworkPrivateVrackSubnet_withAllOptions(t *testing.T) {
 	serviceName := os.Getenv("OVH_CLOUD_PROJECT_SERVICE_TEST")
 	region := os.Getenv("OVH_CLOUD_PROJECT_REGION_TEST")
 
-	networkName := acctest.RandomWithPrefix(testAccResourceCloudNetworkPrivateVrackNamePrefix)
-	subnetName := acctest.RandomWithPrefix(testAccResourceCloudNetworkPrivateVrackSubnetNamePrefix)
+	subnetName := acctest.RandomWithPrefix(testAccResourceCloudNetworkPrivateSubnetNamePrefix)
 
 	config := fmt.Sprintf(`
 resource "ovh_cloud_network_private_vrack" "network" {
   service_name = "%s"
-  name         = "%s"
-  region       = "%s"
+  name         = "terraform_testacc_private_net"
+  location     = {
+    region = "%s"
+  }
 }
 
 resource "ovh_cloud_network_private_vrack_subnet" "test" {
-  service_name    = ovh_cloud_network_private_vrack.network.service_name
-  network_id      = ovh_cloud_network_private_vrack.network.id
+  project_id = ovh_cloud_network_private_vrack.network.service_name
+  network_id = ovh_cloud_network_private_vrack.network.id
+
   name            = "%s"
   cidr            = "10.0.0.0/24"
-  region          = "%s"
   dhcp_enabled    = true
   gateway_ip      = "10.0.0.1"
   dns_nameservers = ["1.1.1.1", "8.8.8.8"]
-
+  location = {
+    region = "%s"
+  }
   allocation_pools = [
     {
       start = "10.0.0.10"
@@ -127,11 +136,11 @@ resource "ovh_cloud_network_private_vrack_subnet" "test" {
     },
   ]
 }
-`, serviceName, networkName, region, subnetName, region)
+`, serviceName, region, subnetName, region)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
-			testAccPreCheckCloudNetworkPrivateVrackSubnet(t)
+			testAccPreCheckCloudNetworkPrivateSubnet(t)
 		},
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
@@ -158,66 +167,80 @@ resource "ovh_cloud_network_private_vrack_subnet" "test" {
 				ResourceName:      "ovh_cloud_network_private_vrack_subnet.test",
 				ImportState:       true,
 				ImportStateVerify: true,
-				ImportStateIdFunc: testAccCloudNetworkPrivateVrackSubnetImportStateIdFunc("ovh_cloud_network_private_vrack_subnet.test"),
+				ImportStateIdFunc: testAccCloudNetworkPrivateSubnetImportStateIdFunc("ovh_cloud_network_private_vrack_subnet.test"),
 			},
 		},
 	})
 }
 
 // TestAccCloudNetworkPrivateVrackSubnet_updateMutableFields toggles dhcp_enabled and
-// updates dns_nameservers / gateway_ip in place (these are mutable, no replacement).
+// updates dns_nameservers / description / name in place (all mutable, no replacement).
 func TestAccCloudNetworkPrivateVrackSubnet_updateMutableFields(t *testing.T) {
 	serviceName := os.Getenv("OVH_CLOUD_PROJECT_SERVICE_TEST")
 	region := os.Getenv("OVH_CLOUD_PROJECT_REGION_TEST")
 
-	networkName := acctest.RandomWithPrefix(testAccResourceCloudNetworkPrivateVrackNamePrefix)
-	subnetName := acctest.RandomWithPrefix(testAccResourceCloudNetworkPrivateVrackSubnetNamePrefix)
+	subnetName := acctest.RandomWithPrefix(testAccResourceCloudNetworkPrivateSubnetNamePrefix)
+	updatedName := acctest.RandomWithPrefix(testAccResourceCloudNetworkPrivateSubnetNamePrefix)
 
 	config := fmt.Sprintf(`
 resource "ovh_cloud_network_private_vrack" "network" {
   service_name = "%s"
-  name         = "%s"
-  region       = "%s"
+  name         = "terraform_testacc_private_net"
+  location     = {
+    region = "%s"
+  }
 }
 
 resource "ovh_cloud_network_private_vrack_subnet" "test" {
-  service_name    = ovh_cloud_network_private_vrack.network.service_name
-  network_id      = ovh_cloud_network_private_vrack.network.id
+  project_id = ovh_cloud_network_private_vrack.network.service_name
+  network_id = ovh_cloud_network_private_vrack.network.id
+
   name            = "%s"
   cidr            = "10.0.0.0/24"
-  region          = "%s"
+  description     = "initial description"
   dhcp_enabled    = false
   dns_nameservers = ["1.1.1.1"]
+  location = {
+    region = "%s"
+  }
 }
-`, serviceName, networkName, region, subnetName, region)
+`, serviceName, region, subnetName, region)
 
 	updatedConfig := fmt.Sprintf(`
 resource "ovh_cloud_network_private_vrack" "network" {
   service_name = "%s"
-  name         = "%s"
-  region       = "%s"
+  name         = "terraform_testacc_private_net"
+  location     = {
+	region = "%s"
+  }
 }
 
 resource "ovh_cloud_network_private_vrack_subnet" "test" {
-  service_name    = ovh_cloud_network_private_vrack.network.service_name
-  network_id      = ovh_cloud_network_private_vrack.network.id
+  project_id = ovh_cloud_network_private_vrack.network.service_name
+  network_id = ovh_cloud_network_private_vrack.network.id
+
   name            = "%s"
   cidr            = "10.0.0.0/24"
-  region          = "%s"
+  description     = "updated description"
   dhcp_enabled    = true
   dns_nameservers = ["8.8.8.8", "8.8.4.4"]
+  location = {
+    region = "%s"
+  }
 }
-`, serviceName, networkName, region, subnetName, region)
+`, serviceName, region, updatedName, region)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
-			testAccPreCheckCloudNetworkPrivateVrackSubnet(t)
+			testAccPreCheckCloudNetworkPrivateSubnet(t)
 		},
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
 				Config: config,
 				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("ovh_cloud_network_private_vrack_subnet.test", "name", subnetName),
+					resource.TestCheckResourceAttr("ovh_cloud_network_private_vrack_subnet.test", "description", "initial description"),
 					resource.TestCheckResourceAttr("ovh_cloud_network_private_vrack_subnet.test", "dhcp_enabled", "false"),
 					resource.TestCheckResourceAttr("ovh_cloud_network_private_vrack_subnet.test", "dns_nameservers.#", "1"),
 					resource.TestCheckResourceAttr("ovh_cloud_network_private_vrack_subnet.test", "dns_nameservers.0", "1.1.1.1"),
@@ -227,6 +250,8 @@ resource "ovh_cloud_network_private_vrack_subnet" "test" {
 			{
 				Config: updatedConfig,
 				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("ovh_cloud_network_private_vrack_subnet.test", "name", updatedName),
+					resource.TestCheckResourceAttr("ovh_cloud_network_private_vrack_subnet.test", "description", "updated description"),
 					resource.TestCheckResourceAttr("ovh_cloud_network_private_vrack_subnet.test", "dhcp_enabled", "true"),
 					resource.TestCheckResourceAttr("ovh_cloud_network_private_vrack_subnet.test", "dns_nameservers.#", "2"),
 					resource.TestCheckResourceAttr("ovh_cloud_network_private_vrack_subnet.test", "dns_nameservers.0", "8.8.8.8"),
@@ -243,47 +268,56 @@ func TestAccCloudNetworkPrivateVrackSubnet_update(t *testing.T) {
 	serviceName := os.Getenv("OVH_CLOUD_PROJECT_SERVICE_TEST")
 	region := os.Getenv("OVH_CLOUD_PROJECT_REGION_TEST")
 
-	networkName := acctest.RandomWithPrefix(testAccResourceCloudNetworkPrivateVrackNamePrefix)
-	subnetName := acctest.RandomWithPrefix(testAccResourceCloudNetworkPrivateVrackSubnetNamePrefix)
-	updatedName := acctest.RandomWithPrefix(testAccResourceCloudNetworkPrivateVrackSubnetNamePrefix)
+	subnetName := acctest.RandomWithPrefix(testAccResourceCloudNetworkPrivateSubnetNamePrefix)
+	updatedName := acctest.RandomWithPrefix(testAccResourceCloudNetworkPrivateSubnetNamePrefix)
 
 	config := fmt.Sprintf(`
 resource "ovh_cloud_network_private_vrack" "network" {
   service_name = "%s"
-  name         = "%s"
-  region       = "%s"
+  name         = "terraform_testacc_private_net"
+  location     = {
+    region = "%s"
+  }
 }
 
 resource "ovh_cloud_network_private_vrack_subnet" "test" {
-  service_name = ovh_cloud_network_private_vrack.network.service_name
-  network_id   = ovh_cloud_network_private_vrack.network.id
-  name         = "%s"
-  cidr         = "10.0.0.0/24"
-  region       = "%s"
-  description  = "initial description"
+  project_id = ovh_cloud_network_private_vrack.network.service_name
+  network_id = ovh_cloud_network_private_vrack.network.id
+
+  name        = "%s"
+  cidr        = "10.0.0.0/24"
+  description = "initial description"
+  location = {
+    region = "%s"
+  }
 }
-`, serviceName, networkName, region, subnetName, region)
+`, serviceName, region, subnetName, region)
 
 	updatedConfig := fmt.Sprintf(`
 resource "ovh_cloud_network_private_vrack" "network" {
   service_name = "%s"
-  name         = "%s"
-  region       = "%s"
+  name         = "terraform_testacc_private_net"
+  location     = {
+    region = "%s"
+  }
 }
 
 resource "ovh_cloud_network_private_vrack_subnet" "test" {
-  service_name = ovh_cloud_network_private_vrack.network.service_name
-  network_id   = ovh_cloud_network_private_vrack.network.id
-  name         = "%s"
-  cidr         = "10.0.0.0/24"
-  region       = "%s"
-  description  = "updated description"
+  project_id = ovh_cloud_network_private_vrack.network.service_name
+  network_id = ovh_cloud_network_private_vrack.network.id
+
+  name        = "%s"
+  cidr        = "10.0.0.0/24"
+  description = "updated description"
+  location = {
+    region = "%s"
+  }
 }
-`, serviceName, networkName, region, updatedName, region)
+`, serviceName, region, updatedName, region)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
-			testAccPreCheckCloudNetworkPrivateVrackSubnet(t)
+			testAccPreCheckCloudNetworkPrivateSubnet(t)
 		},
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{

--- a/ovh/resource_cloud_network_private_vrack_test.go
+++ b/ovh/resource_cloud_network_private_vrack_test.go
@@ -1,0 +1,128 @@
+package ovh
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+)
+
+const testAccResourceCloudNetworkPrivateVrackNamePrefix = "tf-test-net-v2-"
+
+func testAccPreCheckCloudNetworkPrivateVrack(t *testing.T) {
+	testAccPreCheckCredentials(t)
+	if os.Getenv("OVH_CLOUD_PROJECT_SERVICE_TEST") == "" {
+		t.Skip("OVH_CLOUD_PROJECT_SERVICE_TEST must be set for acceptance tests")
+	}
+	if os.Getenv("OVH_CLOUD_PROJECT_REGION_TEST") == "" {
+		t.Skip("OVH_CLOUD_PROJECT_REGION_TEST must be set for acceptance tests")
+	}
+}
+
+func testAccCloudNetworkPrivateVrackImportStateIdFunc(resourceName string) resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return "", fmt.Errorf("not found: %s", resourceName)
+		}
+		return fmt.Sprintf("%s/%s", rs.Primary.Attributes["service_name"], rs.Primary.Attributes["id"]), nil
+	}
+}
+
+func TestAccCloudNetworkPrivateVrack_basic(t *testing.T) {
+	serviceName := os.Getenv("OVH_CLOUD_PROJECT_SERVICE_TEST")
+	region := os.Getenv("OVH_CLOUD_PROJECT_REGION_TEST")
+
+	networkName := acctest.RandomWithPrefix(testAccResourceCloudNetworkPrivateVrackNamePrefix)
+
+	config := fmt.Sprintf(`
+resource "ovh_cloud_network_private_vrack" "test" {
+  service_name = "%s"
+  name         = "%s"
+  region       = "%s"
+}
+`, serviceName, networkName, region)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheckCloudNetworkPrivateVrack(t)
+		},
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("ovh_cloud_network_private_vrack.test", "service_name", serviceName),
+					resource.TestCheckResourceAttr("ovh_cloud_network_private_vrack.test", "name", networkName),
+					resource.TestCheckResourceAttr("ovh_cloud_network_private_vrack.test", "region", region),
+					resource.TestCheckResourceAttrSet("ovh_cloud_network_private_vrack.test", "id"),
+					resource.TestCheckResourceAttrSet("ovh_cloud_network_private_vrack.test", "checksum"),
+					resource.TestCheckResourceAttrSet("ovh_cloud_network_private_vrack.test", "created_at"),
+					resource.TestCheckResourceAttr("ovh_cloud_network_private_vrack.test", "resource_status", "READY"),
+					resource.TestCheckResourceAttrSet("ovh_cloud_network_private_vrack.test", "current_state.name"),
+					resource.TestCheckResourceAttrSet("ovh_cloud_network_private_vrack.test", "current_state.location.region"),
+				),
+			},
+			// Test import
+			{
+				ResourceName:      "ovh_cloud_network_private_vrack.test",
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testAccCloudNetworkPrivateVrackImportStateIdFunc("ovh_cloud_network_private_vrack.test"),
+			},
+		},
+	})
+}
+
+func TestAccCloudNetworkPrivateVrack_update(t *testing.T) {
+	serviceName := os.Getenv("OVH_CLOUD_PROJECT_SERVICE_TEST")
+	region := os.Getenv("OVH_CLOUD_PROJECT_REGION_TEST")
+
+	networkName := acctest.RandomWithPrefix(testAccResourceCloudNetworkPrivateVrackNamePrefix)
+	updatedName := acctest.RandomWithPrefix(testAccResourceCloudNetworkPrivateVrackNamePrefix)
+
+	config := fmt.Sprintf(`
+resource "ovh_cloud_network_private_vrack" "test" {
+  service_name = "%s"
+  name         = "%s"
+  region       = "%s"
+}
+`, serviceName, networkName, region)
+
+	updatedConfig := fmt.Sprintf(`
+resource "ovh_cloud_network_private_vrack" "test" {
+  service_name = "%s"
+  name         = "%s"
+  region       = "%s"
+}
+`, serviceName, updatedName, region)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheckCloudNetworkPrivateVrack(t)
+		},
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("ovh_cloud_network_private_vrack.test", "name", networkName),
+					resource.TestCheckResourceAttrSet("ovh_cloud_network_private_vrack.test", "id"),
+					resource.TestCheckResourceAttrSet("ovh_cloud_network_private_vrack.test", "checksum"),
+				),
+			},
+			{
+				Config: updatedConfig,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("ovh_cloud_network_private_vrack.test", "name", updatedName),
+					resource.TestCheckResourceAttrSet("ovh_cloud_network_private_vrack.test", "id"),
+					resource.TestCheckResourceAttrSet("ovh_cloud_network_private_vrack.test", "checksum"),
+					resource.TestCheckResourceAttr("ovh_cloud_network_private_vrack.test", "resource_status", "READY"),
+				),
+			},
+		},
+	})
+}

--- a/ovh/resource_cloud_network_private_vrack_test.go
+++ b/ovh/resource_cloud_network_private_vrack_test.go
@@ -77,6 +77,48 @@ resource "ovh_cloud_network_private_vrack" "test" {
 	})
 }
 
+func TestAccCloudNetworkPrivateVrack_withDescription(t *testing.T) {
+	serviceName := os.Getenv("OVH_CLOUD_PROJECT_SERVICE_TEST")
+	region := os.Getenv("OVH_CLOUD_PROJECT_REGION_TEST")
+
+	networkName := acctest.RandomWithPrefix(testAccResourceCloudNetworkPrivateVrackNamePrefix)
+
+	config := fmt.Sprintf(`
+resource "ovh_cloud_network_private_vrack" "test" {
+  service_name = "%s"
+  name         = "%s"
+  region       = "%s"
+  description  = "network created by acceptance test"
+}
+`, serviceName, networkName, region)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheckCloudNetworkPrivateVrack(t)
+		},
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("ovh_cloud_network_private_vrack.test", "name", networkName),
+					resource.TestCheckResourceAttr("ovh_cloud_network_private_vrack.test", "description", "network created by acceptance test"),
+					resource.TestCheckResourceAttrSet("ovh_cloud_network_private_vrack.test", "id"),
+					resource.TestCheckResourceAttr("ovh_cloud_network_private_vrack.test", "resource_status", "READY"),
+					resource.TestCheckResourceAttr("ovh_cloud_network_private_vrack.test", "current_state.description", "network created by acceptance test"),
+				),
+			},
+			// Test import
+			{
+				ResourceName:      "ovh_cloud_network_private_vrack.test",
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testAccCloudNetworkPrivateVrackImportStateIdFunc("ovh_cloud_network_private_vrack.test"),
+			},
+		},
+	})
+}
+
 func TestAccCloudNetworkPrivateVrack_update(t *testing.T) {
 	serviceName := os.Getenv("OVH_CLOUD_PROJECT_SERVICE_TEST")
 	region := os.Getenv("OVH_CLOUD_PROJECT_REGION_TEST")

--- a/ovh/resource_cloud_network_private_vrack_test.go
+++ b/ovh/resource_cloud_network_private_vrack_test.go
@@ -123,6 +123,50 @@ resource "ovh_cloud_network_private_vrack" "test" {
 	})
 }
 
+func TestAccCloudNetworkPrivateVrack_withVlanId(t *testing.T) {
+	serviceName := os.Getenv("OVH_CLOUD_PROJECT_SERVICE_TEST")
+	region := os.Getenv("OVH_CLOUD_PROJECT_REGION_TEST")
+
+	networkName := acctest.RandomWithPrefix(testAccResourceCloudNetworkPrivateVrackNamePrefix)
+
+	config := fmt.Sprintf(`
+resource "ovh_cloud_network_private_vrack" "test" {
+  service_name = "%s"
+  name         = "%s"
+  location = {
+    region = "%s"
+  }
+  vlan_id = 100
+}
+`, serviceName, networkName, region)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheckCloudNetworkPrivateVrack(t)
+		},
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("ovh_cloud_network_private_vrack.test", "name", networkName),
+					resource.TestCheckResourceAttr("ovh_cloud_network_private_vrack.test", "vlan_id", "100"),
+					resource.TestCheckResourceAttrSet("ovh_cloud_network_private_vrack.test", "id"),
+					resource.TestCheckResourceAttr("ovh_cloud_network_private_vrack.test", "resource_status", "READY"),
+					resource.TestCheckResourceAttr("ovh_cloud_network_private_vrack.test", "current_state.vlan_id", "100"),
+				),
+			},
+			// Test import
+			{
+				ResourceName:      "ovh_cloud_network_private_vrack.test",
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testAccCloudNetworkPrivateVrackImportStateIdFunc("ovh_cloud_network_private_vrack.test"),
+			},
+		},
+	})
+}
+
 func TestAccCloudNetworkPrivateVrack_update(t *testing.T) {
 	serviceName := os.Getenv("OVH_CLOUD_PROJECT_SERVICE_TEST")
 	region := os.Getenv("OVH_CLOUD_PROJECT_REGION_TEST")

--- a/ovh/resource_cloud_network_private_vrack_test.go
+++ b/ovh/resource_cloud_network_private_vrack_test.go
@@ -128,6 +128,7 @@ func TestAccCloudNetworkPrivateVrack_withVlanId(t *testing.T) {
 	region := os.Getenv("OVH_CLOUD_PROJECT_REGION_TEST")
 
 	networkName := acctest.RandomWithPrefix(testAccResourceCloudNetworkPrivateVrackNamePrefix)
+	vlanId := acctest.RandIntRange(0, 4094)
 
 	config := fmt.Sprintf(`
 resource "ovh_cloud_network_private_vrack" "test" {
@@ -136,9 +137,9 @@ resource "ovh_cloud_network_private_vrack" "test" {
   location = {
     region = "%s"
   }
-  vlan_id = 100
+  vlan_id = %d
 }
-`, serviceName, networkName, region)
+`, serviceName, networkName, region, vlanId)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
@@ -150,10 +151,10 @@ resource "ovh_cloud_network_private_vrack" "test" {
 				Config: config,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("ovh_cloud_network_private_vrack.test", "name", networkName),
-					resource.TestCheckResourceAttr("ovh_cloud_network_private_vrack.test", "vlan_id", "100"),
+					resource.TestCheckResourceAttr("ovh_cloud_network_private_vrack.test", "vlan_id", fmt.Sprintf("%d", vlanId)),
 					resource.TestCheckResourceAttrSet("ovh_cloud_network_private_vrack.test", "id"),
 					resource.TestCheckResourceAttr("ovh_cloud_network_private_vrack.test", "resource_status", "READY"),
-					resource.TestCheckResourceAttr("ovh_cloud_network_private_vrack.test", "current_state.vlan_id", "100"),
+					resource.TestCheckResourceAttr("ovh_cloud_network_private_vrack.test", "current_state.vlan_id", fmt.Sprintf("%d", vlanId)),
 				),
 			},
 			// Test import

--- a/ovh/resource_cloud_network_private_vrack_test.go
+++ b/ovh/resource_cloud_network_private_vrack_test.go
@@ -42,7 +42,9 @@ func TestAccCloudNetworkPrivateVrack_basic(t *testing.T) {
 resource "ovh_cloud_network_private_vrack" "test" {
   service_name = "%s"
   name         = "%s"
-  region       = "%s"
+  location = {
+    region = "%s"
+  }
 }
 `, serviceName, networkName, region)
 
@@ -57,7 +59,7 @@ resource "ovh_cloud_network_private_vrack" "test" {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("ovh_cloud_network_private_vrack.test", "service_name", serviceName),
 					resource.TestCheckResourceAttr("ovh_cloud_network_private_vrack.test", "name", networkName),
-					resource.TestCheckResourceAttr("ovh_cloud_network_private_vrack.test", "region", region),
+					resource.TestCheckResourceAttr("ovh_cloud_network_private_vrack.test", "location.region", region),
 					resource.TestCheckResourceAttrSet("ovh_cloud_network_private_vrack.test", "id"),
 					resource.TestCheckResourceAttrSet("ovh_cloud_network_private_vrack.test", "checksum"),
 					resource.TestCheckResourceAttrSet("ovh_cloud_network_private_vrack.test", "created_at"),
@@ -87,7 +89,9 @@ func TestAccCloudNetworkPrivateVrack_withDescription(t *testing.T) {
 resource "ovh_cloud_network_private_vrack" "test" {
   service_name = "%s"
   name         = "%s"
-  region       = "%s"
+  location = {
+    region = "%s"
+  }
   description  = "network created by acceptance test"
 }
 `, serviceName, networkName, region)
@@ -130,7 +134,9 @@ func TestAccCloudNetworkPrivateVrack_update(t *testing.T) {
 resource "ovh_cloud_network_private_vrack" "test" {
   service_name = "%s"
   name         = "%s"
-  region       = "%s"
+  location = {
+    region = "%s"
+  }
 }
 `, serviceName, networkName, region)
 
@@ -138,7 +144,9 @@ resource "ovh_cloud_network_private_vrack" "test" {
 resource "ovh_cloud_network_private_vrack" "test" {
   service_name = "%s"
   name         = "%s"
-  region       = "%s"
+  location = {
+    region = "%s"
+  }
 }
 `, serviceName, updatedName, region)
 

--- a/ovh/resource_cloud_storage_block_volume.go
+++ b/ovh/resource_cloud_storage_block_volume.go
@@ -98,8 +98,12 @@ func (r *cloudStorageBlockVolumeResource) Schema(ctx context.Context, req resour
 			"volume_type": schema.StringAttribute{
 				CustomType:          ovhtypes.TfStringType{},
 				Optional:            true,
+				Computed:            true,
 				Description:         "Volume type (CLASSIC, HIGH_SPEED, HIGH_SPEED_GEN2). Can be changed after creation (triggers online retype).",
 				MarkdownDescription: "Volume type (`CLASSIC`, `HIGH_SPEED`, `HIGH_SPEED_GEN2`). Can be changed after creation (triggers online retype).",
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
 			},
 			"encryption": schema.SingleNestedAttribute{
 				Optional:            true,

--- a/ovh/resource_cloud_storage_block_volume_test.go
+++ b/ovh/resource_cloud_storage_block_volume_test.go
@@ -284,6 +284,71 @@ resource "ovh_cloud_storage_block_volume" "volume_from_image" {
 	})
 }
 
+// TestAccCloudStorageBlockVolume_recoverDefaults verifies that a volume created
+// WITHOUT an `encryption` block does not produce a perpetual diff.
+func TestAccCloudStorageBlockVolume_recoverDefaults(t *testing.T) {
+	serviceName := os.Getenv("OVH_CLOUD_PROJECT_SERVICE_TEST")
+	region := os.Getenv("OVH_CLOUD_PROJECT_REGION_TEST")
+
+	volumeName := acctest.RandomWithPrefix(testAccResourceCloudStorageBlockVolumeNamePrefix)
+
+	// Config omits `encryption` block entirely so that the
+	// recover step is responsible for populating both.
+	config := fmt.Sprintf(`
+resource "ovh_cloud_storage_block_volume" "volume" {
+  service_name = "%s"
+  name         = "%s"
+  size         = 10
+  region       = "%s"
+  volume_type  = "CLASSIC"
+}
+`, serviceName, volumeName, region)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheckCloud(t)
+			testAccCheckCloudProjectExists(t)
+		},
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("ovh_cloud_storage_block_volume.volume", "service_name", serviceName),
+					resource.TestCheckResourceAttr("ovh_cloud_storage_block_volume.volume", "name", volumeName),
+					resource.TestCheckResourceAttr("ovh_cloud_storage_block_volume.volume", "size", "10"),
+					resource.TestCheckResourceAttr("ovh_cloud_storage_block_volume.volume", "region", region),
+					// volume_type was omitted; recover must have populated it.
+					resource.TestCheckResourceAttrSet("ovh_cloud_storage_block_volume.volume", "volume_type"),
+					resource.TestCheckResourceAttrSet("ovh_cloud_storage_block_volume.volume", "current_state.volume_type"),
+					// encryption block was omitted; recover must have populated enabled.
+					resource.TestCheckResourceAttrSet("ovh_cloud_storage_block_volume.volume", "encryption.enabled"),
+					resource.TestCheckResourceAttrSet("ovh_cloud_storage_block_volume.volume", "id"),
+					resource.TestCheckResourceAttrSet("ovh_cloud_storage_block_volume.volume", "checksum"),
+					resource.TestCheckResourceAttrSet("ovh_cloud_storage_block_volume.volume", "resource_status"),
+				),
+			},
+			{
+				// Re-applying the SAME config must yield an empty plan. This is the
+				// core assertion: the recover-populated volume_type and encryption
+				// must not cause an "inconsistent result" or a perpetual diff.
+				Config: config,
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
+			},
+			{
+				ResourceName:      "ovh_cloud_storage_block_volume.volume",
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testAccCloudStorageBlockVolumeImportStateIdFunc("ovh_cloud_storage_block_volume.volume"),
+			},
+		},
+	})
+}
+
 // TestAccCloudStorageBlockVolume_noServiceName validates that when service_name
 // is omitted from the resource configuration, the provider falls back to the
 // OVH_CLOUD_PROJECT_SERVICE environment variable at plan time (via the

--- a/ovh/types_cloud_gateway.go
+++ b/ovh/types_cloud_gateway.go
@@ -1,0 +1,356 @@
+package ovh
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
+	ovhtypes "github.com/ovh/terraform-provider-ovh/v2/ovh/types"
+)
+
+// CloudGatewayModel represents the Terraform model for the gateway resource
+type CloudGatewayModel struct {
+	// Required — immutable
+	ServiceName      ovhtypes.TfStringValue `tfsdk:"service_name"`
+	Region           ovhtypes.TfStringValue `tfsdk:"region"`
+	AvailabilityZone ovhtypes.TfStringValue `tfsdk:"availability_zone"`
+
+	// Required — mutable
+	Name ovhtypes.TfStringValue `tfsdk:"name"`
+
+	// Optional — mutable
+	Description     ovhtypes.TfStringValue                             `tfsdk:"description"`
+	ExternalGateway types.Object                                       `tfsdk:"external_gateway"`
+	SubnetIds       ovhtypes.TfListNestedValue[ovhtypes.TfStringValue] `tfsdk:"subnet_ids"`
+
+	// Computed
+	Id             ovhtypes.TfStringValue `tfsdk:"id"`
+	Checksum       ovhtypes.TfStringValue `tfsdk:"checksum"`
+	CreatedAt      ovhtypes.TfStringValue `tfsdk:"created_at"`
+	UpdatedAt      ovhtypes.TfStringValue `tfsdk:"updated_at"`
+	ResourceStatus ovhtypes.TfStringValue `tfsdk:"resource_status"`
+	CurrentState   types.Object           `tfsdk:"current_state"`
+}
+
+// API Response types
+
+type CloudGatewayAPIExternalGateway struct {
+	Enabled bool   `json:"enabled"`
+	Model   string `json:"model,omitempty"`
+}
+
+type CloudGatewayAPIResponse struct {
+	Id             string                       `json:"id"`
+	Checksum       string                       `json:"checksum"`
+	CreatedAt      string                       `json:"createdAt"`
+	UpdatedAt      string                       `json:"updatedAt"`
+	ResourceStatus string                       `json:"resourceStatus"`
+	CurrentState   *CloudGatewayAPICurrentState `json:"currentState,omitempty"`
+	TargetSpec     *CloudGatewayAPITargetSpec   `json:"targetSpec,omitempty"`
+}
+
+type CloudGatewayAPICurrentState struct {
+	Name            string                          `json:"name,omitempty"`
+	Description     string                          `json:"description,omitempty"`
+	Status          string                          `json:"status,omitempty"`
+	ExternalGateway *CloudGatewayAPIExternalGateway `json:"externalGateway,omitempty"`
+	ExternalIP      string                          `json:"externalIp,omitempty"`
+	Subnets         []CloudGatewayAPISubnet         `json:"subnets,omitempty"`
+	Location        *CloudGatewayAPILocation        `json:"location,omitempty"`
+}
+
+type CloudGatewayAPITargetSpec struct {
+	Name            string                          `json:"name"`
+	Description     string                          `json:"description,omitempty"`
+	ExternalGateway *CloudGatewayAPIExternalGateway `json:"externalGateway,omitempty"`
+	Subnets         []CloudGatewayAPISubnet         `json:"subnets,omitempty"`
+	Location        *CloudGatewayAPILocation        `json:"location,omitempty"`
+}
+
+type CloudGatewayAPISubnet struct {
+	Id string `json:"id"`
+}
+
+type CloudGatewayAPILocation struct {
+	Region           string `json:"region"`
+	AvailabilityZone string `json:"availabilityZone,omitempty"`
+}
+
+// Create payload
+type CloudGatewayCreatePayload struct {
+	TargetSpec *CloudGatewayAPITargetSpec `json:"targetSpec"`
+}
+
+// Update payload — uses a separate struct without Location (immutable)
+type CloudGatewayUpdateTargetSpec struct {
+	Name            string                          `json:"name"`
+	Description     string                          `json:"description,omitempty"`
+	ExternalGateway *CloudGatewayAPIExternalGateway `json:"externalGateway,omitempty"`
+	Subnets         []CloudGatewayAPISubnet         `json:"subnets,omitempty"`
+}
+
+type CloudGatewayUpdatePayload struct {
+	Checksum   string                        `json:"checksum"`
+	TargetSpec *CloudGatewayUpdateTargetSpec `json:"targetSpec"`
+}
+
+// ExternalGatewayAttrTypes returns the attribute types for the external_gateway object
+func ExternalGatewayAttrTypes() map[string]attr.Type {
+	return map[string]attr.Type{
+		"enabled": types.BoolType,
+		"model":   ovhtypes.TfStringType{},
+	}
+}
+
+// ToCreate converts the Terraform model to the API create payload
+func (m *CloudGatewayModel) ToCreate() *CloudGatewayCreatePayload {
+	targetSpec := &CloudGatewayAPITargetSpec{
+		Name: m.Name.ValueString(),
+		Location: &CloudGatewayAPILocation{
+			Region: m.Region.ValueString(),
+		},
+	}
+
+	// Handle optional description
+	if !m.Description.IsNull() && !m.Description.IsUnknown() {
+		targetSpec.Description = m.Description.ValueString()
+	}
+
+	// Handle optional availability zone
+	if !m.AvailabilityZone.IsNull() && !m.AvailabilityZone.IsUnknown() {
+		targetSpec.Location.AvailabilityZone = m.AvailabilityZone.ValueString()
+	}
+
+	// Handle external_gateway
+	if !m.ExternalGateway.IsNull() && !m.ExternalGateway.IsUnknown() {
+		egAttrs := m.ExternalGateway.Attributes()
+		eg := &CloudGatewayAPIExternalGateway{}
+		if enabledVal, ok := egAttrs["enabled"].(types.Bool); ok {
+			eg.Enabled = enabledVal.ValueBool()
+		}
+		if modelVal, ok := egAttrs["model"].(ovhtypes.TfStringValue); ok && !modelVal.IsNull() && !modelVal.IsUnknown() {
+			eg.Model = modelVal.ValueString()
+		}
+		targetSpec.ExternalGateway = eg
+	}
+
+	// Handle optional subnet_ids
+	if !m.SubnetIds.IsNull() && !m.SubnetIds.IsUnknown() {
+		subnets := make([]CloudGatewayAPISubnet, 0)
+		for _, elem := range m.SubnetIds.Elements() {
+			if strVal, ok := elem.(ovhtypes.TfStringValue); ok {
+				subnets = append(subnets, CloudGatewayAPISubnet{Id: strVal.ValueString()})
+			}
+		}
+		targetSpec.Subnets = subnets
+	}
+
+	return &CloudGatewayCreatePayload{TargetSpec: targetSpec}
+}
+
+// ToUpdate converts the Terraform model to the API update payload
+// Note: location is immutable and not included in update payload
+func (m *CloudGatewayModel) ToUpdate(checksum string) *CloudGatewayUpdatePayload {
+	targetSpec := &CloudGatewayUpdateTargetSpec{
+		Name: m.Name.ValueString(),
+	}
+
+	// Handle optional description
+	if !m.Description.IsNull() && !m.Description.IsUnknown() {
+		targetSpec.Description = m.Description.ValueString()
+	}
+
+	// Handle external_gateway
+	if !m.ExternalGateway.IsNull() && !m.ExternalGateway.IsUnknown() {
+		egAttrs := m.ExternalGateway.Attributes()
+		eg := &CloudGatewayAPIExternalGateway{}
+		if enabledVal, ok := egAttrs["enabled"].(types.Bool); ok {
+			eg.Enabled = enabledVal.ValueBool()
+		}
+		if modelVal, ok := egAttrs["model"].(ovhtypes.TfStringValue); ok && !modelVal.IsNull() && !modelVal.IsUnknown() {
+			eg.Model = modelVal.ValueString()
+		}
+		targetSpec.ExternalGateway = eg
+	}
+
+	// Handle optional subnet_ids
+	if !m.SubnetIds.IsNull() && !m.SubnetIds.IsUnknown() {
+		subnets := make([]CloudGatewayAPISubnet, 0)
+		for _, elem := range m.SubnetIds.Elements() {
+			if strVal, ok := elem.(ovhtypes.TfStringValue); ok {
+				subnets = append(subnets, CloudGatewayAPISubnet{Id: strVal.ValueString()})
+			}
+		}
+		targetSpec.Subnets = subnets
+	}
+
+	return &CloudGatewayUpdatePayload{
+		Checksum:   checksum,
+		TargetSpec: targetSpec,
+	}
+}
+
+// gatewaySubnetAttrTypes returns the attr types for a single subnet object
+func gatewaySubnetAttrTypes() map[string]attr.Type {
+	return map[string]attr.Type{
+		"id": ovhtypes.TfStringType{},
+	}
+}
+
+// GatewayCurrentStateAttrTypes returns the attribute types for the current_state object
+func GatewayCurrentStateAttrTypes() map[string]attr.Type {
+	return map[string]attr.Type{
+		"name":        ovhtypes.TfStringType{},
+		"description": ovhtypes.TfStringType{},
+		"status":      ovhtypes.TfStringType{},
+		"external_gateway": types.ObjectType{
+			AttrTypes: ExternalGatewayAttrTypes(),
+		},
+		"external_ip": ovhtypes.TfStringType{},
+		"subnets": types.ListType{
+			ElemType: types.ObjectType{
+				AttrTypes: gatewaySubnetAttrTypes(),
+			},
+		},
+		"region":            ovhtypes.TfStringType{},
+		"availability_zone": ovhtypes.TfStringType{},
+	}
+}
+
+// buildGatewayCurrentStateObject constructs the current_state object from API response
+func buildGatewayCurrentStateObject(ctx context.Context, state *CloudGatewayAPICurrentState) basetypes.ObjectValue {
+	// Build subnets list
+	subnetObjType := types.ObjectType{AttrTypes: gatewaySubnetAttrTypes()}
+
+	var subnetsVal basetypes.ListValue
+	if state.Subnets != nil {
+		subnetObjs := make([]attr.Value, len(state.Subnets))
+		for i, subnet := range state.Subnets {
+			subnetObj, _ := types.ObjectValue(
+				gatewaySubnetAttrTypes(),
+				map[string]attr.Value{
+					"id": ovhtypes.TfStringValue{StringValue: types.StringValue(subnet.Id)},
+				},
+			)
+			subnetObjs[i] = subnetObj
+		}
+		subnetsVal, _ = types.ListValue(subnetObjType, subnetObjs)
+	} else {
+		subnetsVal = types.ListNull(subnetObjType)
+	}
+
+	// Build region and availability_zone from location
+	regionVal := ovhtypes.TfStringValue{StringValue: types.StringValue("")}
+	azVal := ovhtypes.TfStringValue{StringValue: types.StringValue("")}
+	if state.Location != nil {
+		regionVal = ovhtypes.TfStringValue{StringValue: types.StringValue(state.Location.Region)}
+		if state.Location.AvailabilityZone != "" {
+			azVal = ovhtypes.TfStringValue{StringValue: types.StringValue(state.Location.AvailabilityZone)}
+		}
+	}
+
+	// Build external_gateway object
+	var externalGatewayVal basetypes.ObjectValue
+	if state.ExternalGateway != nil {
+		modelVal := ovhtypes.TfStringValue{StringValue: types.StringNull()}
+		if state.ExternalGateway.Model != "" {
+			modelVal = ovhtypes.TfStringValue{StringValue: types.StringValue(state.ExternalGateway.Model)}
+		}
+		externalGatewayVal, _ = types.ObjectValue(
+			ExternalGatewayAttrTypes(),
+			map[string]attr.Value{
+				"enabled": types.BoolValue(state.ExternalGateway.Enabled),
+				"model":   modelVal,
+			},
+		)
+	} else {
+		externalGatewayVal, _ = types.ObjectValue(
+			ExternalGatewayAttrTypes(),
+			map[string]attr.Value{
+				"enabled": types.BoolValue(false),
+				"model":   ovhtypes.TfStringValue{StringValue: types.StringNull()},
+			},
+		)
+	}
+
+	currentStateObj, _ := types.ObjectValue(
+		GatewayCurrentStateAttrTypes(),
+		map[string]attr.Value{
+			"name":              ovhtypes.TfStringValue{StringValue: types.StringValue(state.Name)},
+			"description":       ovhtypes.TfStringValue{StringValue: types.StringValue(state.Description)},
+			"status":            ovhtypes.TfStringValue{StringValue: types.StringValue(state.Status)},
+			"external_gateway":  externalGatewayVal,
+			"external_ip":       ovhtypes.TfStringValue{StringValue: types.StringValue(state.ExternalIP)},
+			"subnets":           subnetsVal,
+			"region":            regionVal,
+			"availability_zone": azVal,
+		},
+	)
+
+	return currentStateObj
+}
+
+// MergeWith merges API response data into the Terraform model
+func (m *CloudGatewayModel) MergeWith(ctx context.Context, response *CloudGatewayAPIResponse) {
+	m.Id = ovhtypes.TfStringValue{StringValue: types.StringValue(response.Id)}
+	m.Checksum = ovhtypes.TfStringValue{StringValue: types.StringValue(response.Checksum)}
+	m.CreatedAt = ovhtypes.TfStringValue{StringValue: types.StringValue(response.CreatedAt)}
+	m.UpdatedAt = ovhtypes.TfStringValue{StringValue: types.StringValue(response.UpdatedAt)}
+	m.ResourceStatus = ovhtypes.TfStringValue{StringValue: types.StringValue(response.ResourceStatus)}
+
+	// Build current_state from API currentState
+	if response.CurrentState != nil {
+		m.CurrentState = buildGatewayCurrentStateObject(ctx, response.CurrentState)
+	} else {
+		m.CurrentState = types.ObjectNull(GatewayCurrentStateAttrTypes())
+	}
+
+	// Set flattened root-level fields from targetSpec
+	if response.TargetSpec != nil {
+		m.Name = ovhtypes.TfStringValue{StringValue: types.StringValue(response.TargetSpec.Name)}
+		// Keep description null if user didn't set it and API returns empty
+		if response.TargetSpec.Description != "" || (!m.Description.IsNull() && !m.Description.IsUnknown()) {
+			m.Description = ovhtypes.TfStringValue{StringValue: types.StringValue(response.TargetSpec.Description)}
+		}
+
+		// Set external_gateway from targetSpec
+		if response.TargetSpec.ExternalGateway != nil {
+			modelVal := ovhtypes.TfStringValue{StringValue: types.StringNull()}
+			if response.TargetSpec.ExternalGateway.Model != "" {
+				modelVal = ovhtypes.TfStringValue{StringValue: types.StringValue(response.TargetSpec.ExternalGateway.Model)}
+			}
+			m.ExternalGateway, _ = types.ObjectValue(
+				ExternalGatewayAttrTypes(),
+				map[string]attr.Value{
+					"enabled": types.BoolValue(response.TargetSpec.ExternalGateway.Enabled),
+					"model":   modelVal,
+				},
+			)
+		} else {
+			m.ExternalGateway = types.ObjectNull(ExternalGatewayAttrTypes())
+		}
+
+		if response.TargetSpec.Location != nil {
+			m.Region = ovhtypes.TfStringValue{StringValue: types.StringValue(response.TargetSpec.Location.Region)}
+			if response.TargetSpec.Location.AvailabilityZone != "" {
+				m.AvailabilityZone = ovhtypes.TfStringValue{StringValue: types.StringValue(response.TargetSpec.Location.AvailabilityZone)}
+			}
+		}
+
+		// Set subnet_ids from targetSpec
+		if response.TargetSpec.Subnets != nil {
+			subnetVals := make([]attr.Value, len(response.TargetSpec.Subnets))
+			for i, subnet := range response.TargetSpec.Subnets {
+				subnetVals[i] = ovhtypes.TfStringValue{StringValue: types.StringValue(subnet.Id)}
+			}
+			m.SubnetIds = ovhtypes.TfListNestedValue[ovhtypes.TfStringValue]{
+				ListValue: basetypes.NewListValueMust(ovhtypes.TfStringType{}, subnetVals),
+			}
+		} else {
+			m.SubnetIds = ovhtypes.TfListNestedValue[ovhtypes.TfStringValue]{
+				ListValue: basetypes.NewListNull(ovhtypes.TfStringType{}),
+			}
+		}
+	}
+}

--- a/ovh/types_cloud_network_private_vrack.go
+++ b/ovh/types_cloud_network_private_vrack.go
@@ -18,6 +18,7 @@ type CloudNetworkPrivateVrackModel struct {
 
 	// Optional
 	Description ovhtypes.TfStringValue `tfsdk:"description"`
+	VlanId      ovhtypes.TfInt64Value  `tfsdk:"vlan_id"`
 
 	// Computed
 	Id             ovhtypes.TfStringValue `tfsdk:"id"`
@@ -43,6 +44,7 @@ type CloudNetworkAPICurrentState struct {
 	Name        string                   `json:"name,omitempty"`
 	Description string                   `json:"description,omitempty"`
 	Location    *CloudNetworkAPILocation `json:"location,omitempty"`
+	VlanId      *int64                   `json:"vlanId,omitempty"`
 }
 
 type CloudNetworkAPILocation struct {
@@ -53,6 +55,7 @@ type CloudNetworkAPITargetSpec struct {
 	Name        string                   `json:"name"`
 	Description string                   `json:"description,omitempty"`
 	Location    *CloudNetworkAPILocation `json:"location,omitempty"`
+	VlanId      *int64                   `json:"vlanId,omitempty"`
 }
 
 type CloudNetworkAPIPutTargetSpec struct {
@@ -113,6 +116,11 @@ func (m *CloudNetworkPrivateVrackModel) ToCreate() *CloudNetworkCreatePayload {
 		targetSpec.Description = m.Description.ValueString()
 	}
 
+	if !m.VlanId.IsNull() && !m.VlanId.IsUnknown() {
+		v := m.VlanId.ValueInt64()
+		targetSpec.VlanId = &v
+	}
+
 	return &CloudNetworkCreatePayload{
 		TargetSpec: targetSpec,
 	}
@@ -133,6 +141,7 @@ func NetworkCurrentStateAttrTypes() map[string]attr.Type {
 	return map[string]attr.Type{
 		"name":        ovhtypes.TfStringType{},
 		"description": ovhtypes.TfStringType{},
+		"vlan_id":     ovhtypes.TfInt64Type{},
 		"location": types.ObjectType{
 			AttrTypes: map[string]attr.Type{
 				"region": ovhtypes.TfStringType{},
@@ -163,6 +172,13 @@ func (m *CloudNetworkPrivateVrackModel) MergeWith(ctx context.Context, response 
 		// Keep description null if user didn't set it and API returns empty
 		if response.TargetSpec.Description != "" || (!m.Description.IsNull() && !m.Description.IsUnknown()) {
 			m.Description = ovhtypes.TfStringValue{StringValue: types.StringValue(response.TargetSpec.Description)}
+		}
+
+		// VLAN ID is computed: always set from the API response
+		if response.TargetSpec.VlanId != nil {
+			m.VlanId = ovhtypes.TfInt64Value{Int64Value: types.Int64Value(*response.TargetSpec.VlanId)}
+		} else {
+			m.VlanId = ovhtypes.TfInt64Value{Int64Value: types.Int64Null()}
 		}
 
 		if response.TargetSpec.Location != nil {
@@ -196,11 +212,19 @@ func buildNetworkCurrentStateObject(state *CloudNetworkAPICurrentState) basetype
 		})
 	}
 
+	var vlanIdVal ovhtypes.TfInt64Value
+	if state.VlanId != nil {
+		vlanIdVal = ovhtypes.TfInt64Value{Int64Value: types.Int64Value(*state.VlanId)}
+	} else {
+		vlanIdVal = ovhtypes.TfInt64Value{Int64Value: types.Int64Null()}
+	}
+
 	currentStateObj, _ := types.ObjectValue(
 		NetworkCurrentStateAttrTypes(),
 		map[string]attr.Value{
 			"name":        ovhtypes.TfStringValue{StringValue: types.StringValue(state.Name)},
 			"description": ovhtypes.TfStringValue{StringValue: types.StringValue(state.Description)},
+			"vlan_id":     vlanIdVal,
 			"location":    locationObj,
 		},
 	)

--- a/ovh/types_cloud_network_private_vrack.go
+++ b/ovh/types_cloud_network_private_vrack.go
@@ -14,7 +14,7 @@ type CloudNetworkPrivateVrackModel struct {
 	// Required
 	ServiceName ovhtypes.TfStringValue `tfsdk:"service_name"`
 	Name        ovhtypes.TfStringValue `tfsdk:"name"`
-	Region      ovhtypes.TfStringValue `tfsdk:"region"`
+	Location    types.Object           `tfsdk:"location"`
 
 	// Optional
 	Description ovhtypes.TfStringValue `tfsdk:"description"`
@@ -70,12 +70,42 @@ type CloudNetworkUpdatePayload struct {
 	TargetSpec *CloudNetworkAPIPutTargetSpec `json:"targetSpec"`
 }
 
+// vrackLocationAttrTypes returns the attribute types for the root-level
+// location object exposed by the network resource and data sources.
+func vrackLocationAttrTypes() map[string]attr.Type {
+	return map[string]attr.Type{
+		"region": ovhtypes.TfStringType{},
+	}
+}
+
+// vrackLocationRegion extracts the region value out of a root-level location
+// object. It returns an empty string when the object is null/unknown or does
+// not contain a region attribute.
+func vrackLocationRegion(location types.Object) string {
+	if location.IsNull() || location.IsUnknown() {
+		return ""
+	}
+
+	attrs := location.Attributes()
+	regionAttr, ok := attrs["region"]
+	if !ok {
+		return ""
+	}
+
+	region, ok := regionAttr.(ovhtypes.TfStringValue)
+	if !ok {
+		return ""
+	}
+
+	return region.ValueString()
+}
+
 // ToCreate converts the Terraform model to the API create payload
 func (m *CloudNetworkPrivateVrackModel) ToCreate() *CloudNetworkCreatePayload {
 	targetSpec := &CloudNetworkAPITargetSpec{
 		Name: m.Name.ValueString(),
 		Location: &CloudNetworkAPILocation{
-			Region: m.Region.ValueString(),
+			Region: vrackLocationRegion(m.Location),
 		},
 	}
 
@@ -136,7 +166,14 @@ func (m *CloudNetworkPrivateVrackModel) MergeWith(ctx context.Context, response 
 		}
 
 		if response.TargetSpec.Location != nil {
-			m.Region = ovhtypes.TfStringValue{StringValue: types.StringValue(response.TargetSpec.Location.Region)}
+			m.Location, _ = types.ObjectValue(
+				vrackLocationAttrTypes(),
+				map[string]attr.Value{
+					"region": ovhtypes.TfStringValue{StringValue: types.StringValue(response.TargetSpec.Location.Region)},
+				},
+			)
+		} else {
+			m.Location = types.ObjectNull(vrackLocationAttrTypes())
 		}
 	}
 }

--- a/ovh/types_cloud_network_private_vrack.go
+++ b/ovh/types_cloud_network_private_vrack.go
@@ -1,0 +1,172 @@
+package ovh
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
+	ovhtypes "github.com/ovh/terraform-provider-ovh/v2/ovh/types"
+)
+
+// CloudNetworkPrivateVrackModel represents the Terraform model for the network resource
+type CloudNetworkPrivateVrackModel struct {
+	// Required
+	ServiceName ovhtypes.TfStringValue `tfsdk:"service_name"`
+	Name        ovhtypes.TfStringValue `tfsdk:"name"`
+	Region      ovhtypes.TfStringValue `tfsdk:"region"`
+
+	// Optional
+	Description ovhtypes.TfStringValue `tfsdk:"description"`
+
+	// Computed
+	Id             ovhtypes.TfStringValue `tfsdk:"id"`
+	Checksum       ovhtypes.TfStringValue `tfsdk:"checksum"`
+	CreatedAt      ovhtypes.TfStringValue `tfsdk:"created_at"`
+	UpdatedAt      ovhtypes.TfStringValue `tfsdk:"updated_at"`
+	ResourceStatus ovhtypes.TfStringValue `tfsdk:"resource_status"`
+	CurrentState   types.Object           `tfsdk:"current_state"`
+}
+
+// API Response types
+type CloudNetworkAPIResponse struct {
+	Id             string                       `json:"id"`
+	Checksum       string                       `json:"checksum"`
+	CreatedAt      string                       `json:"createdAt"`
+	UpdatedAt      string                       `json:"updatedAt"`
+	ResourceStatus string                       `json:"resourceStatus"`
+	CurrentState   *CloudNetworkAPICurrentState `json:"currentState,omitempty"`
+	TargetSpec     *CloudNetworkAPITargetSpec   `json:"targetSpec,omitempty"`
+}
+
+type CloudNetworkAPICurrentState struct {
+	Name        string                   `json:"name,omitempty"`
+	Description string                   `json:"description,omitempty"`
+	Location    *CloudNetworkAPILocation `json:"location,omitempty"`
+}
+
+type CloudNetworkAPILocation struct {
+	Region string `json:"region"`
+}
+
+type CloudNetworkAPITargetSpec struct {
+	Name        string                   `json:"name"`
+	Description string                   `json:"description,omitempty"`
+	Location    *CloudNetworkAPILocation `json:"location,omitempty"`
+}
+
+type CloudNetworkAPIPutTargetSpec struct {
+	Name string `json:"name"`
+}
+
+// Create payload
+type CloudNetworkCreatePayload struct {
+	TargetSpec *CloudNetworkAPITargetSpec `json:"targetSpec"`
+}
+
+// Update payload
+type CloudNetworkUpdatePayload struct {
+	Checksum   string                        `json:"checksum"`
+	TargetSpec *CloudNetworkAPIPutTargetSpec `json:"targetSpec"`
+}
+
+// ToCreate converts the Terraform model to the API create payload
+func (m *CloudNetworkPrivateVrackModel) ToCreate() *CloudNetworkCreatePayload {
+	targetSpec := &CloudNetworkAPITargetSpec{
+		Name: m.Name.ValueString(),
+		Location: &CloudNetworkAPILocation{
+			Region: m.Region.ValueString(),
+		},
+	}
+
+	if !m.Description.IsNull() && !m.Description.IsUnknown() {
+		targetSpec.Description = m.Description.ValueString()
+	}
+
+	return &CloudNetworkCreatePayload{
+		TargetSpec: targetSpec,
+	}
+}
+
+// ToUpdate converts the Terraform model to the API update payload
+func (m *CloudNetworkPrivateVrackModel) ToUpdate(checksum string) *CloudNetworkUpdatePayload {
+	return &CloudNetworkUpdatePayload{
+		Checksum: checksum,
+		TargetSpec: &CloudNetworkAPIPutTargetSpec{
+			Name: m.Name.ValueString(),
+		},
+	}
+}
+
+// NetworkCurrentStateAttrTypes returns the attribute types for the current_state object
+func NetworkCurrentStateAttrTypes() map[string]attr.Type {
+	return map[string]attr.Type{
+		"name":        ovhtypes.TfStringType{},
+		"description": ovhtypes.TfStringType{},
+		"location": types.ObjectType{
+			AttrTypes: map[string]attr.Type{
+				"region": ovhtypes.TfStringType{},
+			},
+		},
+	}
+}
+
+// MergeWith merges API response data into the Terraform model
+func (m *CloudNetworkPrivateVrackModel) MergeWith(ctx context.Context, response *CloudNetworkAPIResponse) {
+	m.Id = ovhtypes.TfStringValue{StringValue: types.StringValue(response.Id)}
+	m.Checksum = ovhtypes.TfStringValue{StringValue: types.StringValue(response.Checksum)}
+	m.CreatedAt = ovhtypes.TfStringValue{StringValue: types.StringValue(response.CreatedAt)}
+	m.UpdatedAt = ovhtypes.TfStringValue{StringValue: types.StringValue(response.UpdatedAt)}
+	m.ResourceStatus = ovhtypes.TfStringValue{StringValue: types.StringValue(response.ResourceStatus)}
+
+	if response.CurrentState != nil {
+		m.CurrentState = buildNetworkCurrentStateObject(response.CurrentState)
+	} else {
+		m.CurrentState = types.ObjectNull(NetworkCurrentStateAttrTypes())
+	}
+
+	// Set flattened root-level fields from targetSpec
+	if response.TargetSpec != nil {
+		// Required field, always set from targetSpec
+		m.Name = ovhtypes.TfStringValue{StringValue: types.StringValue(response.TargetSpec.Name)}
+
+		// Keep description null if user didn't set it and API returns empty
+		if response.TargetSpec.Description != "" || (!m.Description.IsNull() && !m.Description.IsUnknown()) {
+			m.Description = ovhtypes.TfStringValue{StringValue: types.StringValue(response.TargetSpec.Description)}
+		}
+
+		if response.TargetSpec.Location != nil {
+			m.Region = ovhtypes.TfStringValue{StringValue: types.StringValue(response.TargetSpec.Location.Region)}
+		}
+	}
+}
+
+func buildNetworkCurrentStateObject(state *CloudNetworkAPICurrentState) basetypes.ObjectValue {
+	// Build location object
+	var locationObj basetypes.ObjectValue
+	if state.Location != nil {
+		locationObj, _ = types.ObjectValue(
+			map[string]attr.Type{
+				"region": ovhtypes.TfStringType{},
+			},
+			map[string]attr.Value{
+				"region": ovhtypes.TfStringValue{StringValue: types.StringValue(state.Location.Region)},
+			},
+		)
+	} else {
+		locationObj = types.ObjectNull(map[string]attr.Type{
+			"region": ovhtypes.TfStringType{},
+		})
+	}
+
+	currentStateObj, _ := types.ObjectValue(
+		NetworkCurrentStateAttrTypes(),
+		map[string]attr.Value{
+			"name":        ovhtypes.TfStringValue{StringValue: types.StringValue(state.Name)},
+			"description": ovhtypes.TfStringValue{StringValue: types.StringValue(state.Description)},
+			"location":    locationObj,
+		},
+	)
+
+	return currentStateObj
+}

--- a/ovh/types_cloud_network_private_vrack_subnet.go
+++ b/ovh/types_cloud_network_private_vrack_subnet.go
@@ -1,0 +1,415 @@
+package ovh
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
+	ovhtypes "github.com/ovh/terraform-provider-ovh/v2/ovh/types"
+)
+
+// CloudSubnetModel represents the Terraform model for the subnet resource
+type CloudSubnetModel struct {
+	// Required
+	ServiceName ovhtypes.TfStringValue `tfsdk:"service_name"`
+	NetworkId   ovhtypes.TfStringValue `tfsdk:"network_id"`
+	Name        ovhtypes.TfStringValue `tfsdk:"name"`
+	CIDR        ovhtypes.TfStringValue `tfsdk:"cidr"`
+	Region      ovhtypes.TfStringValue `tfsdk:"region"`
+
+	// Optional
+	Description     ovhtypes.TfStringValue `tfsdk:"description"`
+	DHCPEnabled     types.Bool             `tfsdk:"dhcp_enabled"`
+	DNSNameservers  types.List             `tfsdk:"dns_nameservers"`
+	GatewayIP       ovhtypes.TfStringValue `tfsdk:"gateway_ip"`
+	AllocationPools types.List             `tfsdk:"allocation_pools"`
+
+	// Computed
+	Id             ovhtypes.TfStringValue `tfsdk:"id"`
+	Checksum       ovhtypes.TfStringValue `tfsdk:"checksum"`
+	CreatedAt      ovhtypes.TfStringValue `tfsdk:"created_at"`
+	UpdatedAt      ovhtypes.TfStringValue `tfsdk:"updated_at"`
+	ResourceStatus ovhtypes.TfStringValue `tfsdk:"resource_status"`
+	CurrentState   types.Object           `tfsdk:"current_state"`
+}
+
+// API Response types
+type CloudSubnetAPIResponse struct {
+	Id             string                      `json:"id"`
+	Checksum       string                      `json:"checksum"`
+	CreatedAt      string                      `json:"createdAt"`
+	UpdatedAt      string                      `json:"updatedAt"`
+	ResourceStatus string                      `json:"resourceStatus"`
+	CurrentState   *CloudSubnetAPICurrentState `json:"currentState,omitempty"`
+	TargetSpec     *CloudSubnetAPITargetSpec   `json:"targetSpec,omitempty"`
+}
+
+type CloudSubnetAPICurrentState struct {
+	Name           string                    `json:"name,omitempty"`
+	CIDR           string                    `json:"cidr,omitempty"`
+	Description    string                    `json:"description,omitempty"`
+	DHCPEnabled    *bool                     `json:"dhcpEnabled,omitempty"`
+	DNSNameservers []string                  `json:"dnsNameservers,omitempty"`
+	GatewayIP      string                    `json:"gatewayIp,omitempty"`
+	HostRoutes     []CloudSubnetAPIHostRoute `json:"hostRoutes,omitempty"`
+	Location       *CloudSubnetAPILocation   `json:"location,omitempty"`
+}
+
+type CloudSubnetAPILocation struct {
+	Region string `json:"region"`
+}
+
+type CloudSubnetAPIHostRoute struct {
+	Destination string `json:"destination"`
+	NextHop     string `json:"nextHop"`
+}
+
+type CloudSubnetAPIAllocationPool struct {
+	Start string `json:"start"`
+	End   string `json:"end"`
+}
+
+type CloudSubnetAPITargetSpec struct {
+	Name            string                         `json:"name"`
+	CIDR            string                         `json:"cidr,omitempty"`
+	Description     string                         `json:"description,omitempty"`
+	DHCPEnabled     *bool                          `json:"dhcpEnabled,omitempty"`
+	DNSNameservers  []string                       `json:"dnsNameservers,omitempty"`
+	GatewayIP       string                         `json:"gatewayIp,omitempty"`
+	AllocationPools []CloudSubnetAPIAllocationPool `json:"allocationPools,omitempty"`
+	Location        *CloudSubnetAPILocation        `json:"location,omitempty"`
+}
+
+type CloudSubnetAPIPutTargetSpec struct {
+	Name            string                         `json:"name"`
+	Description     string                         `json:"description,omitempty"`
+	DHCPEnabled     *bool                          `json:"dhcpEnabled,omitempty"`
+	DNSNameservers  []string                       `json:"dnsNameservers,omitempty"`
+	GatewayIP       string                         `json:"gatewayIp,omitempty"`
+	AllocationPools []CloudSubnetAPIAllocationPool `json:"allocationPools,omitempty"`
+}
+
+// Create payload
+type CloudSubnetCreatePayload struct {
+	TargetSpec *CloudSubnetAPITargetSpec `json:"targetSpec"`
+}
+
+// Update payload
+type CloudSubnetUpdatePayload struct {
+	Checksum   string                       `json:"checksum"`
+	TargetSpec *CloudSubnetAPIPutTargetSpec `json:"targetSpec"`
+}
+
+// ToCreate converts the Terraform model to the API create payload
+func (m *CloudSubnetModel) ToCreate() *CloudSubnetCreatePayload {
+	targetSpec := &CloudSubnetAPITargetSpec{
+		Name: m.Name.ValueString(),
+		CIDR: m.CIDR.ValueString(),
+		Location: &CloudSubnetAPILocation{
+			Region: m.Region.ValueString(),
+		},
+	}
+
+	if !m.Description.IsNull() && !m.Description.IsUnknown() {
+		targetSpec.Description = m.Description.ValueString()
+	}
+
+	if !m.DHCPEnabled.IsNull() && !m.DHCPEnabled.IsUnknown() {
+		val := m.DHCPEnabled.ValueBool()
+		targetSpec.DHCPEnabled = &val
+	}
+
+	if !m.DNSNameservers.IsNull() && !m.DNSNameservers.IsUnknown() {
+		dns := make([]string, 0, len(m.DNSNameservers.Elements()))
+		for _, elem := range m.DNSNameservers.Elements() {
+			if strVal, ok := elem.(types.String); ok {
+				dns = append(dns, strVal.ValueString())
+			}
+		}
+		targetSpec.DNSNameservers = dns
+	}
+
+	if !m.GatewayIP.IsNull() && !m.GatewayIP.IsUnknown() {
+		targetSpec.GatewayIP = m.GatewayIP.ValueString()
+	}
+
+	if !m.AllocationPools.IsNull() && !m.AllocationPools.IsUnknown() {
+		pools := make([]CloudSubnetAPIAllocationPool, 0, len(m.AllocationPools.Elements()))
+		for _, elem := range m.AllocationPools.Elements() {
+			obj, ok := elem.(basetypes.ObjectValue)
+			if !ok {
+				continue
+			}
+			attrs := obj.Attributes()
+			pool := CloudSubnetAPIAllocationPool{}
+			if v, ok := attrs["start"].(ovhtypes.TfStringValue); ok && !v.IsNull() && !v.IsUnknown() {
+				pool.Start = v.ValueString()
+			}
+			if v, ok := attrs["end"].(ovhtypes.TfStringValue); ok && !v.IsNull() && !v.IsUnknown() {
+				pool.End = v.ValueString()
+			}
+			pools = append(pools, pool)
+		}
+		targetSpec.AllocationPools = pools
+	}
+
+	return &CloudSubnetCreatePayload{
+		TargetSpec: targetSpec,
+	}
+}
+
+// ToUpdate converts the Terraform model to the API update payload
+func (m *CloudSubnetModel) ToUpdate(checksum string) *CloudSubnetUpdatePayload {
+	targetSpec := &CloudSubnetAPIPutTargetSpec{
+		Name: m.Name.ValueString(),
+	}
+
+	if !m.Description.IsNull() && !m.Description.IsUnknown() {
+		targetSpec.Description = m.Description.ValueString()
+	}
+
+	if !m.DHCPEnabled.IsNull() && !m.DHCPEnabled.IsUnknown() {
+		val := m.DHCPEnabled.ValueBool()
+		targetSpec.DHCPEnabled = &val
+	}
+
+	if !m.DNSNameservers.IsNull() && !m.DNSNameservers.IsUnknown() {
+		dns := make([]string, 0, len(m.DNSNameservers.Elements()))
+		for _, elem := range m.DNSNameservers.Elements() {
+			if strVal, ok := elem.(types.String); ok {
+				dns = append(dns, strVal.ValueString())
+			}
+		}
+		targetSpec.DNSNameservers = dns
+	}
+
+	if !m.GatewayIP.IsNull() && !m.GatewayIP.IsUnknown() {
+		targetSpec.GatewayIP = m.GatewayIP.ValueString()
+	}
+
+	if !m.AllocationPools.IsNull() && !m.AllocationPools.IsUnknown() {
+		pools := make([]CloudSubnetAPIAllocationPool, 0, len(m.AllocationPools.Elements()))
+		for _, elem := range m.AllocationPools.Elements() {
+			obj, ok := elem.(basetypes.ObjectValue)
+			if !ok {
+				continue
+			}
+			attrs := obj.Attributes()
+			pool := CloudSubnetAPIAllocationPool{}
+			if v, ok := attrs["start"].(ovhtypes.TfStringValue); ok && !v.IsNull() && !v.IsUnknown() {
+				pool.Start = v.ValueString()
+			}
+			if v, ok := attrs["end"].(ovhtypes.TfStringValue); ok && !v.IsNull() && !v.IsUnknown() {
+				pool.End = v.ValueString()
+			}
+			pools = append(pools, pool)
+		}
+		targetSpec.AllocationPools = pools
+	}
+
+	return &CloudSubnetUpdatePayload{
+		Checksum:   checksum,
+		TargetSpec: targetSpec,
+	}
+}
+
+// SubnetCurrentStateAttrTypes returns the attribute types for the current_state object
+func SubnetCurrentStateAttrTypes() map[string]attr.Type {
+	return map[string]attr.Type{
+		"name":         ovhtypes.TfStringType{},
+		"cidr":         ovhtypes.TfStringType{},
+		"description":  ovhtypes.TfStringType{},
+		"dhcp_enabled": types.BoolType,
+		"dns_nameservers": types.ListType{
+			ElemType: types.StringType,
+		},
+		"gateway_ip": ovhtypes.TfStringType{},
+		"host_routes": types.ListType{
+			ElemType: types.ObjectType{
+				AttrTypes: map[string]attr.Type{
+					"destination": ovhtypes.TfStringType{},
+					"next_hop":    ovhtypes.TfStringType{},
+				},
+			},
+		},
+		"location": types.ObjectType{
+			AttrTypes: map[string]attr.Type{
+				"region": ovhtypes.TfStringType{},
+			},
+		},
+	}
+}
+
+// MergeWith merges API response data into the Terraform model
+func (m *CloudSubnetModel) MergeWith(ctx context.Context, response *CloudSubnetAPIResponse) {
+	m.Id = ovhtypes.TfStringValue{StringValue: types.StringValue(response.Id)}
+	m.Checksum = ovhtypes.TfStringValue{StringValue: types.StringValue(response.Checksum)}
+	m.CreatedAt = ovhtypes.TfStringValue{StringValue: types.StringValue(response.CreatedAt)}
+	m.UpdatedAt = ovhtypes.TfStringValue{StringValue: types.StringValue(response.UpdatedAt)}
+	m.ResourceStatus = ovhtypes.TfStringValue{StringValue: types.StringValue(response.ResourceStatus)}
+
+	if response.CurrentState != nil {
+		m.CurrentState = buildSubnetCurrentStateObject(response.CurrentState)
+	} else {
+		m.CurrentState = types.ObjectNull(SubnetCurrentStateAttrTypes())
+	}
+
+	// Set flattened root-level fields from targetSpec ONLY. The optional root
+	// attributes mirror caller intent (what the API echoes back in targetSpec)
+	// and must stay null when the caller omitted them. The realized backend
+	// values (Neutron-resolved gateway, dhcp, pools, ...) are exposed solely
+	// via the computed current_state object built above and must NEVER be
+	// surfaced as these root attributes.
+	//
+	// These optional attributes are Optional-not-Computed with no plan
+	// modifiers, so the framework never leaves them "unknown": an omitted
+	// field is simply null. The rule is therefore: if targetSpec carries the
+	// field, set it; otherwise set it to null.
+	//
+	// network_id is a path parameter (not part of targetSpec) and is left
+	// sourced from state/input.
+	if response.TargetSpec != nil {
+		// Required fields, always set from targetSpec
+		m.Name = ovhtypes.TfStringValue{StringValue: types.StringValue(response.TargetSpec.Name)}
+		m.CIDR = ovhtypes.TfStringValue{StringValue: types.StringValue(response.TargetSpec.CIDR)}
+
+		if response.TargetSpec.Location != nil {
+			m.Region = ovhtypes.TfStringValue{StringValue: types.StringValue(response.TargetSpec.Location.Region)}
+		}
+
+		if response.TargetSpec.Description != "" {
+			m.Description = ovhtypes.TfStringValue{StringValue: types.StringValue(response.TargetSpec.Description)}
+		} else {
+			m.Description = ovhtypes.TfStringValue{StringValue: types.StringNull()}
+		}
+
+		if response.TargetSpec.DHCPEnabled != nil {
+			m.DHCPEnabled = types.BoolValue(*response.TargetSpec.DHCPEnabled)
+		} else {
+			m.DHCPEnabled = types.BoolNull()
+		}
+
+		if response.TargetSpec.GatewayIP != "" {
+			m.GatewayIP = ovhtypes.TfStringValue{StringValue: types.StringValue(response.TargetSpec.GatewayIP)}
+		} else {
+			m.GatewayIP = ovhtypes.TfStringValue{StringValue: types.StringNull()}
+		}
+
+		if response.TargetSpec.DNSNameservers != nil {
+			dnsVals := make([]attr.Value, len(response.TargetSpec.DNSNameservers))
+			for i, dns := range response.TargetSpec.DNSNameservers {
+				dnsVals[i] = types.StringValue(dns)
+			}
+			m.DNSNameservers = types.ListValueMust(types.StringType, dnsVals)
+		} else {
+			m.DNSNameservers = types.ListNull(types.StringType)
+		}
+
+		allocationPoolObjType := types.ObjectType{AttrTypes: subnetAllocationPoolAttrTypes()}
+		if response.TargetSpec.AllocationPools != nil {
+			poolObjs := make([]attr.Value, len(response.TargetSpec.AllocationPools))
+			for i, pool := range response.TargetSpec.AllocationPools {
+				poolObj, _ := types.ObjectValue(
+					subnetAllocationPoolAttrTypes(),
+					map[string]attr.Value{
+						"start": ovhtypes.TfStringValue{StringValue: types.StringValue(pool.Start)},
+						"end":   ovhtypes.TfStringValue{StringValue: types.StringValue(pool.End)},
+					},
+				)
+				poolObjs[i] = poolObj
+			}
+			m.AllocationPools = types.ListValueMust(allocationPoolObjType, poolObjs)
+		} else {
+			m.AllocationPools = types.ListNull(allocationPoolObjType)
+		}
+	}
+}
+
+// subnetAllocationPoolAttrTypes returns the attr types for a single
+// allocation_pool object as declared in the resource schema.
+func subnetAllocationPoolAttrTypes() map[string]attr.Type {
+	return map[string]attr.Type{
+		"start": ovhtypes.TfStringType{},
+		"end":   ovhtypes.TfStringType{},
+	}
+}
+
+func buildSubnetCurrentStateObject(state *CloudSubnetAPICurrentState) basetypes.ObjectValue {
+	// Build location object
+	var locationObj basetypes.ObjectValue
+	if state.Location != nil {
+		locationObj, _ = types.ObjectValue(
+			map[string]attr.Type{
+				"region": ovhtypes.TfStringType{},
+			},
+			map[string]attr.Value{
+				"region": ovhtypes.TfStringValue{StringValue: types.StringValue(state.Location.Region)},
+			},
+		)
+	} else {
+		locationObj = types.ObjectNull(map[string]attr.Type{
+			"region": ovhtypes.TfStringType{},
+		})
+	}
+
+	// Build dhcp_enabled value
+	var dhcpVal attr.Value
+	if state.DHCPEnabled != nil {
+		dhcpVal = types.BoolValue(*state.DHCPEnabled)
+	} else {
+		dhcpVal = types.BoolNull()
+	}
+
+	// Build dns_nameservers list
+	var dnsVal basetypes.ListValue
+	if state.DNSNameservers != nil {
+		dnsVals := make([]attr.Value, len(state.DNSNameservers))
+		for i, dns := range state.DNSNameservers {
+			dnsVals[i] = types.StringValue(dns)
+		}
+		dnsVal, _ = types.ListValue(types.StringType, dnsVals)
+	} else {
+		dnsVal = types.ListNull(types.StringType)
+	}
+
+	// Build host_routes list
+	hostRouteAttrTypes := map[string]attr.Type{
+		"destination": ovhtypes.TfStringType{},
+		"next_hop":    ovhtypes.TfStringType{},
+	}
+
+	var hostRoutesVal basetypes.ListValue
+	if state.HostRoutes != nil {
+		routeObjs := make([]attr.Value, len(state.HostRoutes))
+		for i, route := range state.HostRoutes {
+			routeObj, _ := types.ObjectValue(
+				hostRouteAttrTypes,
+				map[string]attr.Value{
+					"destination": ovhtypes.TfStringValue{StringValue: types.StringValue(route.Destination)},
+					"next_hop":    ovhtypes.TfStringValue{StringValue: types.StringValue(route.NextHop)},
+				},
+			)
+			routeObjs[i] = routeObj
+		}
+		hostRoutesVal, _ = types.ListValue(types.ObjectType{AttrTypes: hostRouteAttrTypes}, routeObjs)
+	} else {
+		hostRoutesVal = types.ListNull(types.ObjectType{AttrTypes: hostRouteAttrTypes})
+	}
+
+	currentStateObj, _ := types.ObjectValue(
+		SubnetCurrentStateAttrTypes(),
+		map[string]attr.Value{
+			"name":            ovhtypes.TfStringValue{StringValue: types.StringValue(state.Name)},
+			"cidr":            ovhtypes.TfStringValue{StringValue: types.StringValue(state.CIDR)},
+			"description":     ovhtypes.TfStringValue{StringValue: types.StringValue(state.Description)},
+			"dhcp_enabled":    dhcpVal,
+			"dns_nameservers": dnsVal,
+			"gateway_ip":      ovhtypes.TfStringValue{StringValue: types.StringValue(state.GatewayIP)},
+			"host_routes":     hostRoutesVal,
+			"location":        locationObj,
+		},
+	)
+
+	return currentStateObj
+}

--- a/ovh/types_cloud_network_private_vrack_subnet.go
+++ b/ovh/types_cloud_network_private_vrack_subnet.go
@@ -16,7 +16,7 @@ type CloudSubnetModel struct {
 	NetworkId   ovhtypes.TfStringValue `tfsdk:"network_id"`
 	Name        ovhtypes.TfStringValue `tfsdk:"name"`
 	CIDR        ovhtypes.TfStringValue `tfsdk:"cidr"`
-	Region      ovhtypes.TfStringValue `tfsdk:"region"`
+	Location    types.Object           `tfsdk:"location"`
 
 	// Optional
 	Description     ovhtypes.TfStringValue `tfsdk:"description"`
@@ -46,14 +46,15 @@ type CloudSubnetAPIResponse struct {
 }
 
 type CloudSubnetAPICurrentState struct {
-	Name           string                    `json:"name,omitempty"`
-	CIDR           string                    `json:"cidr,omitempty"`
-	Description    string                    `json:"description,omitempty"`
-	DHCPEnabled    *bool                     `json:"dhcpEnabled,omitempty"`
-	DNSNameservers []string                  `json:"dnsNameservers,omitempty"`
-	GatewayIP      string                    `json:"gatewayIp,omitempty"`
-	HostRoutes     []CloudSubnetAPIHostRoute `json:"hostRoutes,omitempty"`
-	Location       *CloudSubnetAPILocation   `json:"location,omitempty"`
+	Name            string                         `json:"name,omitempty"`
+	CIDR            string                         `json:"cidr,omitempty"`
+	Description     string                         `json:"description,omitempty"`
+	DHCPEnabled     *bool                          `json:"dhcpEnabled,omitempty"`
+	DNSNameservers  []string                       `json:"dnsNameservers,omitempty"`
+	GatewayIP       string                         `json:"gatewayIp,omitempty"`
+	AllocationPools []CloudSubnetAPIAllocationPool `json:"allocationPools,omitempty"`
+	HostRoutes      []CloudSubnetAPIHostRoute      `json:"hostRoutes,omitempty"`
+	Location        *CloudSubnetAPILocation        `json:"location,omitempty"`
 }
 
 type CloudSubnetAPILocation struct {
@@ -101,13 +102,25 @@ type CloudSubnetUpdatePayload struct {
 	TargetSpec *CloudSubnetAPIPutTargetSpec `json:"targetSpec"`
 }
 
+// subnetModelRegion extracts the region string from the data-source model's
+// location object (or "" when unset).
+func (m *CloudSubnetModel) subnetModelRegion() string {
+	if m.Location.IsNull() || m.Location.IsUnknown() {
+		return ""
+	}
+	if v, ok := m.Location.Attributes()["region"].(ovhtypes.TfStringValue); ok {
+		return v.ValueString()
+	}
+	return ""
+}
+
 // ToCreate converts the Terraform model to the API create payload
 func (m *CloudSubnetModel) ToCreate() *CloudSubnetCreatePayload {
 	targetSpec := &CloudSubnetAPITargetSpec{
 		Name: m.Name.ValueString(),
 		CIDR: m.CIDR.ValueString(),
 		Location: &CloudSubnetAPILocation{
-			Region: m.Region.ValueString(),
+			Region: m.subnetModelRegion(),
 		},
 	}
 
@@ -225,6 +238,9 @@ func SubnetCurrentStateAttrTypes() map[string]attr.Type {
 			ElemType: types.StringType,
 		},
 		"gateway_ip": ovhtypes.TfStringType{},
+		"allocation_pools": types.ListType{
+			ElemType: types.ObjectType{AttrTypes: subnetAllocationPoolAttrTypes()},
+		},
 		"host_routes": types.ListType{
 			ElemType: types.ObjectType{
 				AttrTypes: map[string]attr.Type{
@@ -255,27 +271,37 @@ func (m *CloudSubnetModel) MergeWith(ctx context.Context, response *CloudSubnetA
 		m.CurrentState = types.ObjectNull(SubnetCurrentStateAttrTypes())
 	}
 
-	// Set flattened root-level fields from targetSpec ONLY. The optional root
-	// attributes mirror caller intent (what the API echoes back in targetSpec)
-	// and must stay null when the caller omitted them. The realized backend
-	// values (Neutron-resolved gateway, dhcp, pools, ...) are exposed solely
-	// via the computed current_state object built above and must NEVER be
-	// surfaced as these root attributes.
+	// Set flattened root-level fields from targetSpec. The Neutron-defaulted
+	// attributes dhcp_enabled and gateway_ip are Optional+Computed: when the
+	// caller omits them, the backend resolves defaults and writes them into
+	// targetSpec at creation, so the API echoes them back here and they are
+	// stored in state. Their UseStateForUnknown plan modifiers keep the
+	// API-returned value stable across subsequent plans/applies (no spurious
+	// diff, no inconsistent-result error). The rule is therefore: if targetSpec
+	// carries the field, set it; otherwise set it to null.
 	//
-	// These optional attributes are Optional-not-Computed with no plan
-	// modifiers, so the framework never leaves them "unknown": an omitted
-	// field is simply null. The rule is therefore: if targetSpec carries the
-	// field, set it; otherwise set it to null.
+	// allocation_pools is Optional-only (config-driven): it is read from config
+	// in ToCreate/ToUpdate but is intentionally NOT overwritten from the API
+	// response (see the allocation_pools note below) to avoid reintroducing a
+	// server-vs-config diff.
 	//
 	// network_id is a path parameter (not part of targetSpec) and is left
 	// sourced from state/input.
+	m.Location = types.ObjectNull(subnetDataLocationAttrTypes())
 	if response.TargetSpec != nil {
 		// Required fields, always set from targetSpec
 		m.Name = ovhtypes.TfStringValue{StringValue: types.StringValue(response.TargetSpec.Name)}
 		m.CIDR = ovhtypes.TfStringValue{StringValue: types.StringValue(response.TargetSpec.CIDR)}
 
 		if response.TargetSpec.Location != nil {
-			m.Region = ovhtypes.TfStringValue{StringValue: types.StringValue(response.TargetSpec.Location.Region)}
+			m.Location, _ = types.ObjectValue(
+				subnetDataLocationAttrTypes(),
+				map[string]attr.Value{
+					"region": ovhtypes.TfStringValue{StringValue: types.StringValue(response.TargetSpec.Location.Region)},
+				},
+			)
+		} else {
+			m.Location = types.ObjectNull(subnetDataLocationAttrTypes())
 		}
 
 		if response.TargetSpec.Description != "" {
@@ -306,23 +332,11 @@ func (m *CloudSubnetModel) MergeWith(ctx context.Context, response *CloudSubnetA
 			m.DNSNameservers = types.ListNull(types.StringType)
 		}
 
-		allocationPoolObjType := types.ObjectType{AttrTypes: subnetAllocationPoolAttrTypes()}
-		if response.TargetSpec.AllocationPools != nil {
-			poolObjs := make([]attr.Value, len(response.TargetSpec.AllocationPools))
-			for i, pool := range response.TargetSpec.AllocationPools {
-				poolObj, _ := types.ObjectValue(
-					subnetAllocationPoolAttrTypes(),
-					map[string]attr.Value{
-						"start": ovhtypes.TfStringValue{StringValue: types.StringValue(pool.Start)},
-						"end":   ovhtypes.TfStringValue{StringValue: types.StringValue(pool.End)},
-					},
-				)
-				poolObjs[i] = poolObj
-			}
-			m.AllocationPools = types.ListValueMust(allocationPoolObjType, poolObjs)
-		} else {
-			m.AllocationPools = types.ListNull(allocationPoolObjType)
-		}
+		// allocation_pools is Optional-only (not Computed) and therefore purely
+		// config-driven: the model already carries the value the user configured
+		// (or null when unset). We intentionally do NOT overwrite m.AllocationPools
+		// from the API response here — doing so would reintroduce a server-vs-config
+		// diff. ToCreate/ToUpdate still read m.AllocationPools to build the payload.
 	}
 }
 
@@ -332,6 +346,14 @@ func subnetAllocationPoolAttrTypes() map[string]attr.Type {
 	return map[string]attr.Type{
 		"start": ovhtypes.TfStringType{},
 		"end":   ovhtypes.TfStringType{},
+	}
+}
+
+// subnetDataLocationAttrTypes returns the attr types for the root-level
+// location object exposed by the subnet data sources.
+func subnetDataLocationAttrTypes() map[string]attr.Type {
+	return map[string]attr.Type{
+		"region": ovhtypes.TfStringType{},
 	}
 }
 
@@ -373,6 +395,23 @@ func buildSubnetCurrentStateObject(state *CloudSubnetAPICurrentState) basetypes.
 		dnsVal = types.ListNull(types.StringType)
 	}
 
+	// Build allocation_pools list
+	allocationPoolElemType := types.ObjectType{AttrTypes: subnetAllocationPoolAttrTypes()}
+	var allocationPoolsVal basetypes.ListValue
+	if state.AllocationPools != nil {
+		poolObjs := make([]attr.Value, len(state.AllocationPools))
+		for i, pool := range state.AllocationPools {
+			poolObj, _ := types.ObjectValue(subnetAllocationPoolAttrTypes(), map[string]attr.Value{
+				"start": ovhtypes.TfStringValue{StringValue: types.StringValue(pool.Start)},
+				"end":   ovhtypes.TfStringValue{StringValue: types.StringValue(pool.End)},
+			})
+			poolObjs[i] = poolObj
+		}
+		allocationPoolsVal, _ = types.ListValue(allocationPoolElemType, poolObjs)
+	} else {
+		allocationPoolsVal = types.ListNull(allocationPoolElemType)
+	}
+
 	// Build host_routes list
 	hostRouteAttrTypes := map[string]attr.Type{
 		"destination": ovhtypes.TfStringType{},
@@ -400,14 +439,15 @@ func buildSubnetCurrentStateObject(state *CloudSubnetAPICurrentState) basetypes.
 	currentStateObj, _ := types.ObjectValue(
 		SubnetCurrentStateAttrTypes(),
 		map[string]attr.Value{
-			"name":            ovhtypes.TfStringValue{StringValue: types.StringValue(state.Name)},
-			"cidr":            ovhtypes.TfStringValue{StringValue: types.StringValue(state.CIDR)},
-			"description":     ovhtypes.TfStringValue{StringValue: types.StringValue(state.Description)},
-			"dhcp_enabled":    dhcpVal,
-			"dns_nameservers": dnsVal,
-			"gateway_ip":      ovhtypes.TfStringValue{StringValue: types.StringValue(state.GatewayIP)},
-			"host_routes":     hostRoutesVal,
-			"location":        locationObj,
+			"name":             ovhtypes.TfStringValue{StringValue: types.StringValue(state.Name)},
+			"cidr":             ovhtypes.TfStringValue{StringValue: types.StringValue(state.CIDR)},
+			"description":      ovhtypes.TfStringValue{StringValue: types.StringValue(state.Description)},
+			"dhcp_enabled":     dhcpVal,
+			"dns_nameservers":  dnsVal,
+			"gateway_ip":       ovhtypes.TfStringValue{StringValue: types.StringValue(state.GatewayIP)},
+			"allocation_pools": allocationPoolsVal,
+			"host_routes":      hostRoutesVal,
+			"location":         locationObj,
 		},
 	)
 


### PR DESCRIPTION
# Description

This PR adds the new public cloud networking resources and datasources:

Resources:
- ovh_cloud_gateway
- ovh_cloud_network_private_vrack
- ovh_cloud_network_private_vrack_subnet

Datasources:
- ovh_cloud_gateway
- ovh_cloud_gateways
- ovh_cloud_network_private_vrack
- ovh_cloud_network_private_vracks
- ovh_cloud_network_private_vrack_subnet
- ovh_cloud_network_private_vrack_subnets

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

```
make testacc TESTARGS="-run 'CloudGateway'"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -run 'CloudGateway' -timeout 600m -p 10
?   	github.com/ovh/terraform-provider-ovh/v2	[no test files]
=== RUN   TestAccDataSourceCloudGateway_basic
--- PASS: TestAccDataSourceCloudGateway_basic (34.03s)
=== RUN   TestAccDataSourceCloudGateways_basic
--- PASS: TestAccDataSourceCloudGateways_basic (35.32s)
=== RUN   TestAccCloudGateway_basic
--- PASS: TestAccCloudGateway_basic (33.58s)
=== RUN   TestAccCloudGateway_update
--- PASS: TestAccCloudGateway_update (39.91s)
=== RUN   TestAccCloudGateway_disabledExternalGateway
--- PASS: TestAccCloudGateway_disabledExternalGateway (28.26s)
=== RUN   TestAccCloudGateway_updateExternalGatewayModel
--- PASS: TestAccCloudGateway_updateExternalGatewayModel (39.53s)
=== RUN   TestAccCloudGateway_withSubnets
--- PASS: TestAccCloudGateway_withSubnets (82.23s)
PASS
ok
```

```
make testacc TESTARGS="-run 'CloudNetworkPrivateVrack'"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -run 'CloudNetworkPrivateVrack' -timeout 600m -p 10
?   	github.com/ovh/terraform-provider-ovh/v2	[no test files]
=== RUN   TestAccDataSourceCloudNetworkPrivateVrackSubnet_basic
--- PASS: TestAccDataSourceCloudNetworkPrivateVrackSubnet_basic (37.97s)
=== RUN   TestAccDataSourceCloudNetworkPrivateVrackSubnets_basic
--- PASS: TestAccDataSourceCloudNetworkPrivateVrackSubnets_basic (35.45s)
=== RUN   TestAccDataSourceCloudNetworkPrivateVrack_basic
--- PASS: TestAccDataSourceCloudNetworkPrivateVrack_basic (23.82s)
=== RUN   TestAccDataSourceCloudNetworkPrivateVracks_basic
--- PASS: TestAccDataSourceCloudNetworkPrivateVracks_basic (27.22s)
=== RUN   TestAccCloudNetworkPrivateVrackSubnet_basic
--- PASS: TestAccCloudNetworkPrivateVrackSubnet_basic (35.75s)
=== RUN   TestAccCloudNetworkPrivateVrackSubnet_withAllOptions
--- PASS: TestAccCloudNetworkPrivateVrackSubnet_withAllOptions (35.94s)
=== RUN   TestAccCloudNetworkPrivateVrackSubnet_updateMutableFields
--- PASS: TestAccCloudNetworkPrivateVrackSubnet_updateMutableFields (40.13s)
=== RUN   TestAccCloudNetworkPrivateVrackSubnet_update
--- PASS: TestAccCloudNetworkPrivateVrackSubnet_update (39.45s)
=== RUN   TestAccCloudNetworkPrivateVrack_basic
--- PASS: TestAccCloudNetworkPrivateVrack_basic (23.42s)
=== RUN   TestAccCloudNetworkPrivateVrack_withDescription
--- PASS: TestAccCloudNetworkPrivateVrack_withDescription (23.79s)
=== RUN   TestAccCloudNetworkPrivateVrack_update
--- PASS: TestAccCloudNetworkPrivateVrack_update (34.85s)
PASS
ok
```

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or issues
- [x] I have added acceptance tests that prove my fix is effective or that my feature works
- [x] New and existing acceptance tests pass locally with my changes
- [x] I ran successfully `go mod vendor` if I added or modify `go.mod` file
