### PR TITLE
Dev/aamstutz/add security groups

### DIFF
--- a/docs/data-sources/cloud_security_group.md
+++ b/docs/data-sources/cloud_security_group.md
@@ -1,0 +1,63 @@
+---
+subcategory : "Cloud Project"
+---
+
+# ovh_cloud_security_group (Data Source)
+
+Use this data source to retrieve information about a security group in a public cloud project.
+
+## Example Usage
+
+```terraform
+data "ovh_cloud_security_group" "sg" {
+  service_name = "<public cloud project ID>"
+  id           = "<security group ID>"
+}
+
+output "security_group_name" {
+  value = data.ovh_cloud_security_group.sg.name
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `service_name` - (Required) Service name of the resource representing the id of the cloud project.
+* `id` - (Required) Security group ID.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `region` - Region of the security group.
+* `name` - Name of the security group.
+* `description` - Description of the security group.
+* `rule` - List of security group rules. Each rule exports:
+  * `direction` - Direction of the rule (`INGRESS` or `EGRESS`).
+  * `ethernet_type` - Ethernet type (`IPV4` or `IPV6`).
+  * `protocol` - Protocol (`TCP`, `UDP`, `ICMP`, etc.).
+  * `port_range_min` - Minimum port number.
+  * `port_range_max` - Maximum port number.
+  * `remote_group_id` - Remote security group ID.
+  * `remote_ip_prefix` - Remote IP prefix (CIDR notation).
+  * `description` - Description of the rule.
+* `checksum` - Computed hash representing the current target specification value.
+* `created_at` - Creation date of the security group.
+* `updated_at` - Last update date of the security group.
+* `resource_status` - Security group readiness in the system (`CREATING`, `DELETING`, `ERROR`, `OUT_OF_SYNC`, `READY`, `UPDATING`).
+* `current_state` - Current state of the security group:
+  * `name` - Name of the security group.
+  * `description` - Description of the security group.
+  * `region` - Region of the security group.
+  * `rules` - User-specified security group rules with their IDs:
+    * `id` - Rule ID.
+    * `direction` - Direction of the rule.
+    * `ethernet_type` - Ethernet type.
+    * `protocol` - Protocol.
+    * `port_range_min` - Minimum port number.
+    * `port_range_max` - Maximum port number.
+    * `remote_group_id` - Remote security group ID.
+    * `remote_ip_prefix` - Remote IP prefix.
+    * `description` - Description of the rule.
+  * `default_rules` - Default egress rules auto-created by OpenStack (same schema as `rules`).

--- a/docs/data-sources/cloud_security_groups.md
+++ b/docs/data-sources/cloud_security_groups.md
@@ -1,0 +1,63 @@
+---
+subcategory : "Cloud Project"
+---
+
+# ovh_cloud_security_groups (Data Source)
+
+Use this data source to list the security groups of a public cloud project.
+
+## Example Usage
+
+```terraform
+data "ovh_cloud_security_groups" "security_groups" {
+  service_name = "<public cloud project ID>"
+}
+
+output "security_group_names" {
+  value = [for sg in data.ovh_cloud_security_groups.security_groups.security_groups : sg.name]
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `service_name` - (Required) Service name of the resource representing the id of the cloud project.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `security_groups` - List of security groups. Each element exports:
+  * `id` - Security group ID.
+  * `name` - Name of the security group.
+  * `description` - Description of the security group.
+  * `region` - Region of the security group.
+  * `rule` - List of security group rules:
+    * `direction` - Direction of the rule (`INGRESS` or `EGRESS`).
+    * `ethernet_type` - Ethernet type (`IPV4` or `IPV6`).
+    * `protocol` - Protocol (`TCP`, `UDP`, `ICMP`, etc.).
+    * `port_range_min` - Minimum port number.
+    * `port_range_max` - Maximum port number.
+    * `remote_group_id` - Remote security group ID.
+    * `remote_ip_prefix` - Remote IP prefix (CIDR notation).
+    * `description` - Description of the rule.
+  * `checksum` - Computed hash representing the current target specification value.
+  * `created_at` - Creation date of the security group.
+  * `updated_at` - Last update date of the security group.
+  * `resource_status` - Security group readiness in the system (`CREATING`, `DELETING`, `ERROR`, `OUT_OF_SYNC`, `READY`, `UPDATING`).
+  * `current_state` - Current state of the security group:
+    * `name` - Name of the security group.
+    * `description` - Description of the security group.
+    * `region` - Region of the security group.
+    * `rules` - User-specified security group rules with their IDs:
+      * `id` - Rule ID.
+      * `direction` - Direction of the rule.
+      * `ethernet_type` - Ethernet type.
+      * `protocol` - Protocol.
+      * `port_range_min` - Minimum port number.
+      * `port_range_max` - Maximum port number.
+      * `remote_group_id` - Remote security group ID.
+      * `remote_ip_prefix` - Remote IP prefix.
+      * `description` - Description of the rule.
+    * `default_rules` - Default egress rules auto-created by OpenStack (same schema as `rules`).

--- a/docs/resources/cloud_security_group.md
+++ b/docs/resources/cloud_security_group.md
@@ -10,7 +10,7 @@ Creates a security group in a public cloud project.
 
 ```terraform
 resource "ovh_cloud_security_group" "sg" {
-  service_name = "xxxxxxxxxx"
+  service_name = "<public cloud project ID>"
   region       = "GRA1"
   name         = "my-security-group"
   description  = "Allow SSH and HTTPS"
@@ -33,7 +33,7 @@ resource "ovh_cloud_security_group" "sg" {
       port_range_max   = 443
       remote_ip_prefix = "0.0.0.0/0"
       description      = "HTTPS"
-    },
+    }
   ]
 }
 ```

--- a/docs/resources/cloud_security_group.md
+++ b/docs/resources/cloud_security_group.md
@@ -1,0 +1,103 @@
+---
+subcategory : "Cloud Project"
+---
+
+# ovh_cloud_security_group
+
+Creates a security group in a public cloud project.
+
+## Example Usage
+
+```terraform
+resource "ovh_cloud_security_group" "sg" {
+  service_name = "xxxxxxxxxx"
+  region       = "GRA1"
+  name         = "my-security-group"
+  description  = "Allow SSH and HTTPS"
+
+  rule = [
+    {
+      direction        = "INGRESS"
+      ethernet_type    = "IPV4"
+      protocol         = "TCP"
+      port_range_min   = 22
+      port_range_max   = 22
+      remote_ip_prefix = "0.0.0.0/0"
+      description      = "SSH"
+    },
+    {
+      direction        = "INGRESS"
+      ethernet_type    = "IPV4"
+      protocol         = "TCP"
+      port_range_min   = 443
+      port_range_max   = 443
+      remote_ip_prefix = "0.0.0.0/0"
+      description      = "HTTPS"
+    },
+  ]
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `service_name` - (Required) Service name of the resource representing the id of the cloud project. **Changing this value recreates the resource.**
+* `region` - (Required) Region where the security group will be created. **Changing this value recreates the resource.**
+* `name` - (Required) Name of the security group.
+* `description` - (Optional) Description of the security group.
+* `rule` - (Optional) List of security group rules. Each rule supports:
+  * `direction` - (Required) Direction of the rule (`INGRESS` or `EGRESS`).
+  * `ethernet_type` - (Required) Ether type (`IPV4` or `IPV6`).
+  * `protocol` - (Optional) Protocol (`TCP`, `UDP`, `ICMP`, etc.).
+  * `port_range_min` - (Optional) Minimum port number.
+  * `port_range_max` - (Optional) Maximum port number.
+  * `remote_group_id` - (Optional) Remote security group ID.
+  * `remote_ip_prefix` - (Optional) Remote IP prefix (CIDR notation).
+  * `description` - (Optional) Description of the rule.
+
+~> **NOTE:** When a security group is created, OpenStack automatically adds a
+default egress rule (allowing all outbound traffic). This default rule is **not**
+part of the managed `rule` set: it is never sent in your configuration and never
+appears under `rule`, so it will not show up as drift on subsequent plans. It is
+surfaced for information only under `current_state.default_rules`.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `id` - Security group ID.
+* `checksum` - Computed hash representing the current target specification value.
+* `created_at` - Creation date of the security group.
+* `updated_at` - Last update date of the security group.
+* `resource_status` - Security group readiness in the system (`CREATING`, `DELETING`, `ERROR`, `OUT_OF_SYNC`, `READY`, `UPDATING`).
+* `current_state` - Current state of the security group:
+  * `name` - Name of the security group.
+  * `description` - Description of the security group.
+  * `region` - Region of the security group.
+  * `rules` - User-specified security group rules with their IDs:
+    * `id` - Rule ID.
+    * `direction` - Direction of the rule.
+    * `ethernet_type` - Ether type.
+    * `protocol` - Protocol.
+    * `port_range_min` - Minimum port number.
+    * `port_range_max` - Maximum port number.
+    * `remote_group_id` - Remote security group ID.
+    * `remote_ip_prefix` - Remote IP prefix.
+    * `description` - Description of the rule.
+  * `default_rules` - Default egress rules auto-created by OpenStack (same schema as `rules`). These are not part of the managed `rule` set and are exposed for information only.
+
+## Import
+
+A cloud security group can be imported using the `service_name` and `security_group_id`, separated by `/`:
+
+```terraform
+import {
+  to = ovh_cloud_security_group.sg
+  id = "<service_name>/<security_group_id>"
+}
+```
+
+```bash
+$ terraform import ovh_cloud_security_group.sg service_name/security_group_id
+```

--- a/ovh/data_cloud_security_group.go
+++ b/ovh/data_cloud_security_group.go
@@ -1,0 +1,256 @@
+package ovh
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	ovhtypes "github.com/ovh/terraform-provider-ovh/v2/ovh/types"
+)
+
+var _ datasource.DataSourceWithConfigure = (*cloudSecurityGroupDataSource)(nil)
+
+func NewCloudSecurityGroupDataSource() datasource.DataSource {
+	return &cloudSecurityGroupDataSource{}
+}
+
+type cloudSecurityGroupDataSource struct {
+	config *Config
+}
+
+func (d *cloudSecurityGroupDataSource) Metadata(ctx context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_cloud_security_group"
+}
+
+func (d *cloudSecurityGroupDataSource) Configure(_ context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+
+	config, ok := req.ProviderData.(*Config)
+	if !ok {
+		resp.Diagnostics.AddError(
+			"Unexpected Data Source Configure Type",
+			fmt.Sprintf("Expected *Config, got: %T. Please report this issue to the provider developers.", req.ProviderData),
+		)
+		return
+	}
+
+	d.config = config
+}
+
+// securityGroupDataSourceRuleSchemaAttributes returns the schema attributes for
+// a computed rule (used in both the root rule list and the current_state rule lists).
+func securityGroupDataSourceRuleSchemaAttributes() map[string]schema.Attribute {
+	return map[string]schema.Attribute{
+		"id": schema.StringAttribute{
+			CustomType:  ovhtypes.TfStringType{},
+			Computed:    true,
+			Description: "Rule ID",
+		},
+		"direction": schema.StringAttribute{
+			CustomType:  ovhtypes.TfStringType{},
+			Computed:    true,
+			Description: "Direction of the rule",
+		},
+		"ethernet_type": schema.StringAttribute{
+			CustomType:  ovhtypes.TfStringType{},
+			Computed:    true,
+			Description: "Ethernet type",
+		},
+		"protocol": schema.StringAttribute{
+			CustomType:  ovhtypes.TfStringType{},
+			Computed:    true,
+			Description: "Protocol",
+		},
+		"port_range_min": schema.Int64Attribute{
+			Computed:    true,
+			Description: "Minimum port number",
+		},
+		"port_range_max": schema.Int64Attribute{
+			Computed:    true,
+			Description: "Maximum port number",
+		},
+		"remote_group_id": schema.StringAttribute{
+			CustomType:  ovhtypes.TfStringType{},
+			Computed:    true,
+			Description: "Remote security group ID",
+		},
+		"remote_ip_prefix": schema.StringAttribute{
+			CustomType:  ovhtypes.TfStringType{},
+			Computed:    true,
+			Description: "Remote IP prefix",
+		},
+		"description": schema.StringAttribute{
+			CustomType:  ovhtypes.TfStringType{},
+			Computed:    true,
+			Description: "Description of the rule",
+		},
+	}
+}
+
+// securityGroupDataSourceCurrentStateSchema returns the schema for the computed
+// current_state nested object, reused by the singular and plural data sources.
+func securityGroupDataSourceCurrentStateSchema() schema.SingleNestedAttribute {
+	return schema.SingleNestedAttribute{
+		Computed:    true,
+		Description: "Current state of the security group",
+		Attributes: map[string]schema.Attribute{
+			"name": schema.StringAttribute{
+				CustomType:  ovhtypes.TfStringType{},
+				Computed:    true,
+				Description: "Name of the security group",
+			},
+			"description": schema.StringAttribute{
+				CustomType:  ovhtypes.TfStringType{},
+				Computed:    true,
+				Description: "Description of the security group",
+			},
+			"region": schema.StringAttribute{
+				CustomType:  ovhtypes.TfStringType{},
+				Computed:    true,
+				Description: "Region of the security group",
+			},
+			"rules": schema.ListNestedAttribute{
+				Computed:    true,
+				Description: "User-specified security group rules with their IDs",
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: securityGroupDataSourceRuleSchemaAttributes(),
+				},
+			},
+			"default_rules": schema.ListNestedAttribute{
+				Computed:    true,
+				Description: "Default egress rules auto-created by OpenStack",
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: securityGroupDataSourceRuleSchemaAttributes(),
+				},
+			},
+		},
+	}
+}
+
+func (d *cloudSecurityGroupDataSource) Schema(ctx context.Context, req datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Description: "Use this data source to retrieve information about a security group in a public cloud project.",
+		Attributes: map[string]schema.Attribute{
+			"service_name": schema.StringAttribute{
+				CustomType:  ovhtypes.TfStringType{},
+				Required:    true,
+				Description: "Service name of the resource representing the id of the cloud project",
+			},
+			"id": schema.StringAttribute{
+				CustomType:  ovhtypes.TfStringType{},
+				Required:    true,
+				Description: "Security group ID",
+			},
+			"region": schema.StringAttribute{
+				CustomType:  ovhtypes.TfStringType{},
+				Computed:    true,
+				Description: "Region of the security group",
+			},
+			"name": schema.StringAttribute{
+				CustomType:  ovhtypes.TfStringType{},
+				Computed:    true,
+				Description: "Name of the security group",
+			},
+			"description": schema.StringAttribute{
+				CustomType:  ovhtypes.TfStringType{},
+				Computed:    true,
+				Description: "Description of the security group",
+			},
+			"rule": schema.ListNestedAttribute{
+				Computed:    true,
+				Description: "List of security group rules",
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]schema.Attribute{
+						"direction": schema.StringAttribute{
+							CustomType:  ovhtypes.TfStringType{},
+							Computed:    true,
+							Description: "Direction of the rule",
+						},
+						"ethernet_type": schema.StringAttribute{
+							CustomType:  ovhtypes.TfStringType{},
+							Computed:    true,
+							Description: "Ethernet type",
+						},
+						"protocol": schema.StringAttribute{
+							CustomType:  ovhtypes.TfStringType{},
+							Computed:    true,
+							Description: "Protocol",
+						},
+						"port_range_min": schema.Int64Attribute{
+							Computed:    true,
+							Description: "Minimum port number",
+						},
+						"port_range_max": schema.Int64Attribute{
+							Computed:    true,
+							Description: "Maximum port number",
+						},
+						"remote_group_id": schema.StringAttribute{
+							CustomType:  ovhtypes.TfStringType{},
+							Computed:    true,
+							Description: "Remote security group ID",
+						},
+						"remote_ip_prefix": schema.StringAttribute{
+							CustomType:  ovhtypes.TfStringType{},
+							Computed:    true,
+							Description: "Remote IP prefix",
+						},
+						"description": schema.StringAttribute{
+							CustomType:  ovhtypes.TfStringType{},
+							Computed:    true,
+							Description: "Description of the rule",
+						},
+					},
+				},
+			},
+			"checksum": schema.StringAttribute{
+				CustomType:  ovhtypes.TfStringType{},
+				Computed:    true,
+				Description: "Computed hash representing the current target specification value",
+			},
+			"created_at": schema.StringAttribute{
+				CustomType:  ovhtypes.TfStringType{},
+				Computed:    true,
+				Description: "Creation date of the security group",
+			},
+			"updated_at": schema.StringAttribute{
+				CustomType:  ovhtypes.TfStringType{},
+				Computed:    true,
+				Description: "Last update date of the security group",
+			},
+			"resource_status": schema.StringAttribute{
+				CustomType:  ovhtypes.TfStringType{},
+				Computed:    true,
+				Description: "Security group readiness in the system (CREATING, DELETING, ERROR, OUT_OF_SYNC, READY, UPDATING)",
+			},
+			"current_state": securityGroupDataSourceCurrentStateSchema(),
+		},
+	}
+}
+
+func (d *cloudSecurityGroupDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+	var data CloudSecurityGroupModel
+
+	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	endpoint := "/v2/publicCloud/project/" + url.PathEscape(data.ServiceName.ValueString()) + "/securityGroup/" + url.PathEscape(data.Id.ValueString())
+
+	var responseData CloudSecurityGroupAPIResponse
+	if err := d.config.OVHClient.Get(endpoint, &responseData); err != nil {
+		resp.Diagnostics.AddError(
+			fmt.Sprintf("Error calling Get %s", endpoint),
+			err.Error(),
+		)
+		return
+	}
+
+	data.MergeWith(ctx, &responseData)
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}

--- a/ovh/data_cloud_security_group_test.go
+++ b/ovh/data_cloud_security_group_test.go
@@ -1,0 +1,69 @@
+package ovh
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+func TestAccDataSourceCloudSecurityGroup_basic(t *testing.T) {
+	serviceName := os.Getenv("OVH_CLOUD_PROJECT_SERVICE_TEST")
+	region := os.Getenv("OVH_CLOUD_PROJECT_REGION_TEST")
+
+	name := acctest.RandomWithPrefix(testAccResourceCloudSecurityGroupNamePrefix)
+
+	config := fmt.Sprintf(`
+resource "ovh_cloud_security_group" "test" {
+  service_name = "%s"
+  region       = "%s"
+  name         = "%s"
+  description  = "Test security group"
+
+  rule = [
+    {
+      direction        = "INGRESS"
+      ethernet_type    = "IPV4"
+      protocol         = "TCP"
+      port_range_min   = 22
+      port_range_max   = 22
+      remote_ip_prefix = "0.0.0.0/0"
+      description      = "SSH"
+    },
+  ]
+}
+
+data "ovh_cloud_security_group" "test" {
+  service_name = ovh_cloud_security_group.test.service_name
+  id           = ovh_cloud_security_group.test.id
+}
+`, serviceName, region, name)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheckCloudSecurityGroup(t)
+		},
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("data.ovh_cloud_security_group.test", "service_name", serviceName),
+					resource.TestCheckResourceAttr("data.ovh_cloud_security_group.test", "name", name),
+					resource.TestCheckResourceAttr("data.ovh_cloud_security_group.test", "region", region),
+					resource.TestCheckResourceAttrPair(
+						"data.ovh_cloud_security_group.test", "id",
+						"ovh_cloud_security_group.test", "id",
+					),
+					resource.TestCheckResourceAttrSet("data.ovh_cloud_security_group.test", "checksum"),
+					resource.TestCheckResourceAttrSet("data.ovh_cloud_security_group.test", "created_at"),
+					resource.TestCheckResourceAttr("data.ovh_cloud_security_group.test", "resource_status", "READY"),
+					resource.TestCheckResourceAttr("data.ovh_cloud_security_group.test", "rule.#", "1"),
+					resource.TestCheckResourceAttrSet("data.ovh_cloud_security_group.test", "current_state.name"),
+				),
+			},
+		},
+	})
+}

--- a/ovh/data_cloud_security_groups.go
+++ b/ovh/data_cloud_security_groups.go
@@ -1,0 +1,259 @@
+package ovh
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
+	ovhtypes "github.com/ovh/terraform-provider-ovh/v2/ovh/types"
+)
+
+var _ datasource.DataSourceWithConfigure = (*cloudSecurityGroupsDataSource)(nil)
+
+func NewCloudSecurityGroupsDataSource() datasource.DataSource {
+	return &cloudSecurityGroupsDataSource{}
+}
+
+type cloudSecurityGroupsDataSource struct {
+	config *Config
+}
+
+// CloudSecurityGroupsModel is the model for the plural security groups data source.
+type CloudSecurityGroupsModel struct {
+	ServiceName    ovhtypes.TfStringValue `tfsdk:"service_name"`
+	SecurityGroups types.List             `tfsdk:"security_groups"`
+}
+
+func (d *cloudSecurityGroupsDataSource) Metadata(ctx context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_cloud_security_groups"
+}
+
+func (d *cloudSecurityGroupsDataSource) Configure(_ context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+
+	config, ok := req.ProviderData.(*Config)
+	if !ok {
+		resp.Diagnostics.AddError(
+			"Unexpected Data Source Configure Type",
+			fmt.Sprintf("Expected *Config, got: %T. Please report this issue to the provider developers.", req.ProviderData),
+		)
+		return
+	}
+
+	d.config = config
+}
+
+// SecurityGroupListItemAttrTypes returns the attribute types for a single
+// security group element of the plural data source list.
+func SecurityGroupListItemAttrTypes() map[string]attr.Type {
+	ruleObjType := types.ObjectType{AttrTypes: SecurityGroupRuleAttrTypes()}
+	return map[string]attr.Type{
+		"id":          ovhtypes.TfStringType{},
+		"name":        ovhtypes.TfStringType{},
+		"description": ovhtypes.TfStringType{},
+		"region":      ovhtypes.TfStringType{},
+		"rule": types.ListType{
+			ElemType: ruleObjType,
+		},
+		"checksum":        ovhtypes.TfStringType{},
+		"created_at":      ovhtypes.TfStringType{},
+		"updated_at":      ovhtypes.TfStringType{},
+		"resource_status": ovhtypes.TfStringType{},
+		"current_state": types.ObjectType{
+			AttrTypes: SecurityGroupCurrentStateAttrTypes(),
+		},
+	}
+}
+
+func (d *cloudSecurityGroupsDataSource) Schema(ctx context.Context, req datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Description: "Use this data source to list the security groups of a public cloud project.",
+		Attributes: map[string]schema.Attribute{
+			"service_name": schema.StringAttribute{
+				CustomType:  ovhtypes.TfStringType{},
+				Required:    true,
+				Description: "Service name of the resource representing the id of the cloud project",
+			},
+			"security_groups": schema.ListNestedAttribute{
+				Computed:    true,
+				Description: "List of security groups",
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]schema.Attribute{
+						"id": schema.StringAttribute{
+							CustomType:  ovhtypes.TfStringType{},
+							Computed:    true,
+							Description: "Security group ID",
+						},
+						"name": schema.StringAttribute{
+							CustomType:  ovhtypes.TfStringType{},
+							Computed:    true,
+							Description: "Name of the security group",
+						},
+						"description": schema.StringAttribute{
+							CustomType:  ovhtypes.TfStringType{},
+							Computed:    true,
+							Description: "Description of the security group",
+						},
+						"region": schema.StringAttribute{
+							CustomType:  ovhtypes.TfStringType{},
+							Computed:    true,
+							Description: "Region of the security group",
+						},
+						"rule": schema.ListNestedAttribute{
+							Computed:    true,
+							Description: "List of security group rules",
+							NestedObject: schema.NestedAttributeObject{
+								Attributes: map[string]schema.Attribute{
+									"direction": schema.StringAttribute{
+										CustomType:  ovhtypes.TfStringType{},
+										Computed:    true,
+										Description: "Direction of the rule",
+									},
+									"ethernet_type": schema.StringAttribute{
+										CustomType:  ovhtypes.TfStringType{},
+										Computed:    true,
+										Description: "Ethernet type",
+									},
+									"protocol": schema.StringAttribute{
+										CustomType:  ovhtypes.TfStringType{},
+										Computed:    true,
+										Description: "Protocol",
+									},
+									"port_range_min": schema.Int64Attribute{
+										Computed:    true,
+										Description: "Minimum port number",
+									},
+									"port_range_max": schema.Int64Attribute{
+										Computed:    true,
+										Description: "Maximum port number",
+									},
+									"remote_group_id": schema.StringAttribute{
+										CustomType:  ovhtypes.TfStringType{},
+										Computed:    true,
+										Description: "Remote security group ID",
+									},
+									"remote_ip_prefix": schema.StringAttribute{
+										CustomType:  ovhtypes.TfStringType{},
+										Computed:    true,
+										Description: "Remote IP prefix",
+									},
+									"description": schema.StringAttribute{
+										CustomType:  ovhtypes.TfStringType{},
+										Computed:    true,
+										Description: "Description of the rule",
+									},
+								},
+							},
+						},
+						"checksum": schema.StringAttribute{
+							CustomType:  ovhtypes.TfStringType{},
+							Computed:    true,
+							Description: "Computed hash representing the current target specification value",
+						},
+						"created_at": schema.StringAttribute{
+							CustomType:  ovhtypes.TfStringType{},
+							Computed:    true,
+							Description: "Creation date of the security group",
+						},
+						"updated_at": schema.StringAttribute{
+							CustomType:  ovhtypes.TfStringType{},
+							Computed:    true,
+							Description: "Last update date of the security group",
+						},
+						"resource_status": schema.StringAttribute{
+							CustomType:  ovhtypes.TfStringType{},
+							Computed:    true,
+							Description: "Security group readiness in the system (CREATING, DELETING, ERROR, OUT_OF_SYNC, READY, UPDATING)",
+						},
+						"current_state": securityGroupDataSourceCurrentStateSchema(),
+					},
+				},
+			},
+		},
+	}
+}
+
+func (d *cloudSecurityGroupsDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+	var data CloudSecurityGroupsModel
+
+	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	endpoint := "/v2/publicCloud/project/" + url.PathEscape(data.ServiceName.ValueString()) + "/securityGroup"
+
+	var responseData []CloudSecurityGroupAPIResponse
+	if err := d.config.OVHClient.Get(endpoint, &responseData); err != nil {
+		resp.Diagnostics.AddError(
+			fmt.Sprintf("Error calling Get %s", endpoint),
+			err.Error(),
+		)
+		return
+	}
+
+	itemObjType := types.ObjectType{AttrTypes: SecurityGroupListItemAttrTypes()}
+	items := make([]attr.Value, 0, len(responseData))
+	for i := range responseData {
+		items = append(items, buildSecurityGroupListItemObject(ctx, &responseData[i]))
+	}
+
+	data.SecurityGroups = types.ListValueMust(itemObjType, items)
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+// buildSecurityGroupListItemObject builds a single security group list element
+// from an API response, reusing the resource helpers for nested objects.
+func buildSecurityGroupListItemObject(ctx context.Context, response *CloudSecurityGroupAPIResponse) basetypes.ObjectValue {
+	nameVal := ovhtypes.TfStringValue{StringValue: types.StringNull()}
+	descVal := ovhtypes.TfStringValue{StringValue: types.StringNull()}
+	regionVal := ovhtypes.TfStringValue{StringValue: types.StringNull()}
+	ruleVal := types.ListNull(types.ObjectType{AttrTypes: SecurityGroupRuleAttrTypes()})
+
+	if response.TargetSpec != nil {
+		nameVal = ovhtypes.TfStringValue{StringValue: types.StringValue(response.TargetSpec.Name)}
+
+		if response.TargetSpec.Description != "" {
+			descVal = ovhtypes.TfStringValue{StringValue: types.StringValue(response.TargetSpec.Description)}
+		}
+
+		if response.TargetSpec.Location != nil {
+			regionVal = ovhtypes.TfStringValue{StringValue: types.StringValue(response.TargetSpec.Location.Region)}
+		}
+
+		ruleVal = buildSecurityGroupTargetRulesList(response.TargetSpec.Rules)
+	}
+
+	var currentStateVal attr.Value
+	if response.CurrentState != nil {
+		currentStateVal = buildSecurityGroupCurrentStateObject(ctx, response.CurrentState)
+	} else {
+		currentStateVal = types.ObjectNull(SecurityGroupCurrentStateAttrTypes())
+	}
+
+	obj, _ := types.ObjectValue(
+		SecurityGroupListItemAttrTypes(),
+		map[string]attr.Value{
+			"id":              ovhtypes.TfStringValue{StringValue: types.StringValue(response.Id)},
+			"name":            nameVal,
+			"description":     descVal,
+			"region":          regionVal,
+			"rule":            ruleVal,
+			"checksum":        ovhtypes.TfStringValue{StringValue: types.StringValue(response.Checksum)},
+			"created_at":      ovhtypes.TfStringValue{StringValue: types.StringValue(response.CreatedAt)},
+			"updated_at":      ovhtypes.TfStringValue{StringValue: types.StringValue(response.UpdatedAt)},
+			"resource_status": ovhtypes.TfStringValue{StringValue: types.StringValue(response.ResourceStatus)},
+			"current_state":   currentStateVal,
+		},
+	)
+
+	return obj
+}

--- a/ovh/data_cloud_security_groups_test.go
+++ b/ovh/data_cloud_security_groups_test.go
@@ -1,0 +1,58 @@
+package ovh
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+func TestAccDataSourceCloudSecurityGroups_basic(t *testing.T) {
+	serviceName := os.Getenv("OVH_CLOUD_PROJECT_SERVICE_TEST")
+	region := os.Getenv("OVH_CLOUD_PROJECT_REGION_TEST")
+
+	name := acctest.RandomWithPrefix(testAccResourceCloudSecurityGroupNamePrefix)
+
+	config := fmt.Sprintf(`
+resource "ovh_cloud_security_group" "test" {
+  service_name = "%s"
+  region       = "%s"
+  name         = "%s"
+  description  = "Test security group"
+
+  rule = [
+    {
+      direction        = "INGRESS"
+      ethernet_type    = "IPV4"
+      protocol         = "TCP"
+      port_range_min   = 22
+      port_range_max   = 22
+      remote_ip_prefix = "0.0.0.0/0"
+      description      = "SSH"
+    },
+  ]
+}
+
+data "ovh_cloud_security_groups" "test" {
+  service_name = ovh_cloud_security_group.test.service_name
+}
+`, serviceName, region, name)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheckCloudSecurityGroup(t)
+		},
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("data.ovh_cloud_security_groups.test", "service_name", serviceName),
+					resource.TestCheckResourceAttrSet("data.ovh_cloud_security_groups.test", "security_groups.#"),
+				),
+			},
+		},
+	})
+}

--- a/ovh/provider_new.go
+++ b/ovh/provider_new.go
@@ -227,6 +227,8 @@ func (p *OvhProvider) Configure(ctx context.Context, req provider.ConfigureReque
 // DataSources defines the data sources implemented in the provider.
 func (p *OvhProvider) DataSources(_ context.Context) []func() datasource.DataSource {
 	return []func() datasource.DataSource{
+		NewCloudSecurityGroupDataSource,
+		NewCloudSecurityGroupsDataSource,
 		NewCloudProjectDatabaseIPRestrictionsDataSource,
 		NewCloudProjectFlavorDataSource,
 		NewCloudProjectFlavorsDataSource,
@@ -307,6 +309,7 @@ func (p *OvhProvider) DataSources(_ context.Context) []func() datasource.DataSou
 // Resources defines the resources implemented in the provider.
 func (p *OvhProvider) Resources(_ context.Context) []func() resource.Resource {
 	return []func() resource.Resource{
+		NewCloudSecurityGroupResource,
 		NewCloudProjectAlertingResource,
 		NewCloudProjectFileStorageShareResource,
 		NewCloudProjectFileStorageShareNetworkResource,

--- a/ovh/resource_cloud_security_group.go
+++ b/ovh/resource_cloud_security_group.go
@@ -1,0 +1,487 @@
+package ovh
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
+	"github.com/ovh/go-ovh/ovh"
+	ovhtypes "github.com/ovh/terraform-provider-ovh/v2/ovh/types"
+)
+
+var (
+	_ resource.Resource                = (*cloudSecurityGroupResource)(nil)
+	_ resource.ResourceWithConfigure   = (*cloudSecurityGroupResource)(nil)
+	_ resource.ResourceWithImportState = (*cloudSecurityGroupResource)(nil)
+)
+
+func NewCloudSecurityGroupResource() resource.Resource {
+	return &cloudSecurityGroupResource{}
+}
+
+type cloudSecurityGroupResource struct {
+	config *Config
+}
+
+func (r *cloudSecurityGroupResource) Metadata(ctx context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_cloud_security_group"
+}
+
+func (r *cloudSecurityGroupResource) Configure(ctx context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+
+	config, ok := req.ProviderData.(*Config)
+	if !ok {
+		resp.Diagnostics.AddError(
+			"Unexpected Resource Configure Type",
+			fmt.Sprintf("Expected *Config, got: %T. Please report this issue to the provider developers.", req.ProviderData),
+		)
+		return
+	}
+
+	r.config = config
+}
+
+var securityGroupMutableAttrs = MutableAttrs{
+	Strings: []string{"name", "description"},
+	Lists:   []string{"rule"},
+}
+
+// securityGroupStateRuleSchemaAttributes returns the schema attributes for a computed rule in current_state.
+func securityGroupStateRuleSchemaAttributes() map[string]schema.Attribute {
+	return map[string]schema.Attribute{
+		"id": schema.StringAttribute{
+			CustomType: ovhtypes.TfStringType{}, Computed: true,
+			Description: "Rule ID", MarkdownDescription: "Rule ID",
+		},
+		"direction": schema.StringAttribute{
+			CustomType: ovhtypes.TfStringType{}, Computed: true,
+			Description: "Direction of the rule", MarkdownDescription: "Direction of the rule",
+		},
+		"ethernet_type": schema.StringAttribute{
+			CustomType: ovhtypes.TfStringType{}, Computed: true,
+			Description: "Ethernet type", MarkdownDescription: "Ethernet type",
+		},
+		"protocol": schema.StringAttribute{
+			CustomType: ovhtypes.TfStringType{}, Computed: true,
+			Description: "Protocol", MarkdownDescription: "Protocol",
+		},
+		"port_range_min": schema.Int64Attribute{
+			Computed: true, Description: "Minimum port number", MarkdownDescription: "Minimum port number",
+		},
+		"port_range_max": schema.Int64Attribute{
+			Computed: true, Description: "Maximum port number", MarkdownDescription: "Maximum port number",
+		},
+		"remote_group_id": schema.StringAttribute{
+			CustomType: ovhtypes.TfStringType{}, Computed: true,
+			Description: "Remote security group ID", MarkdownDescription: "Remote security group ID",
+		},
+		"remote_ip_prefix": schema.StringAttribute{
+			CustomType: ovhtypes.TfStringType{}, Computed: true,
+			Description: "Remote IP prefix", MarkdownDescription: "Remote IP prefix",
+		},
+		"description": schema.StringAttribute{
+			CustomType: ovhtypes.TfStringType{}, Computed: true,
+			Description: "Description of the rule", MarkdownDescription: "Description of the rule",
+		},
+	}
+}
+
+func (r *cloudSecurityGroupResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Description: "Creates a security group in a public cloud project.",
+		Attributes: map[string]schema.Attribute{
+			// Required — immutable
+			"service_name": schema.StringAttribute{
+				CustomType:          ovhtypes.TfStringType{},
+				Required:            true,
+				Description:         "Service name of the resource representing the id of the cloud project",
+				MarkdownDescription: "Service name of the resource representing the id of the cloud project",
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+			},
+			"region": schema.StringAttribute{
+				CustomType:          ovhtypes.TfStringType{},
+				Required:            true,
+				Description:         "Region where the security group will be created",
+				MarkdownDescription: "Region where the security group will be created",
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+			},
+
+			// Required — mutable
+			"name": schema.StringAttribute{
+				CustomType:          ovhtypes.TfStringType{},
+				Required:            true,
+				Description:         "Name of the security group",
+				MarkdownDescription: "Name of the security group",
+			},
+
+			// Optional — mutable
+			"description": schema.StringAttribute{
+				CustomType:          ovhtypes.TfStringType{},
+				Optional:            true,
+				Description:         "Description of the security group",
+				MarkdownDescription: "Description of the security group",
+			},
+			"rule": schema.ListNestedAttribute{
+				Optional:    true,
+				Description: "List of security group rules",
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]schema.Attribute{
+						"direction": schema.StringAttribute{
+							CustomType:          ovhtypes.TfStringType{},
+							Required:            true,
+							Description:         "Direction of the rule (INGRESS or EGRESS)",
+							MarkdownDescription: "Direction of the rule (`INGRESS` or `EGRESS`)",
+						},
+						"ethernet_type": schema.StringAttribute{
+							CustomType:          ovhtypes.TfStringType{},
+							Required:            true,
+							Description:         "Ethernet type (IPV4 or IPV6)",
+							MarkdownDescription: "Ethernet type (`IPV4` or `IPV6`)",
+						},
+						"protocol": schema.StringAttribute{
+							CustomType:          ovhtypes.TfStringType{},
+							Optional:            true,
+							Description:         "Protocol (TCP, UDP, ICMP, etc.)",
+							MarkdownDescription: "Protocol (`TCP`, `UDP`, `ICMP`, etc.)",
+						},
+						"port_range_min": schema.Int64Attribute{
+							Optional:            true,
+							Description:         "Minimum port number",
+							MarkdownDescription: "Minimum port number",
+						},
+						"port_range_max": schema.Int64Attribute{
+							Optional:            true,
+							Description:         "Maximum port number",
+							MarkdownDescription: "Maximum port number",
+						},
+						"remote_group_id": schema.StringAttribute{
+							CustomType:          ovhtypes.TfStringType{},
+							Optional:            true,
+							Description:         "Remote security group ID",
+							MarkdownDescription: "Remote security group ID",
+						},
+						"remote_ip_prefix": schema.StringAttribute{
+							CustomType:          ovhtypes.TfStringType{},
+							Optional:            true,
+							Description:         "Remote IP prefix (CIDR notation)",
+							MarkdownDescription: "Remote IP prefix (CIDR notation)",
+						},
+						"description": schema.StringAttribute{
+							CustomType:          ovhtypes.TfStringType{},
+							Optional:            true,
+							Description:         "Description of the rule",
+							MarkdownDescription: "Description of the rule",
+						},
+					},
+				},
+			},
+
+			// Computed
+			"id": schema.StringAttribute{
+				CustomType:          ovhtypes.TfStringType{},
+				Computed:            true,
+				Description:         "Security group ID",
+				MarkdownDescription: "Security group ID",
+			},
+			"checksum": schema.StringAttribute{
+				CustomType:          ovhtypes.TfStringType{},
+				Computed:            true,
+				Description:         "Computed hash representing the current target specification value",
+				MarkdownDescription: "Computed hash representing the current target specification value",
+				PlanModifiers: []planmodifier.String{
+					UnknownDuringUpdateStringModifier(securityGroupMutableAttrs),
+				},
+			},
+			"created_at": schema.StringAttribute{
+				CustomType:          ovhtypes.TfStringType{},
+				Computed:            true,
+				Description:         "Creation date of the security group",
+				MarkdownDescription: "Creation date of the security group",
+			},
+			"updated_at": schema.StringAttribute{
+				CustomType:          ovhtypes.TfStringType{},
+				Computed:            true,
+				Description:         "Last update date of the security group",
+				MarkdownDescription: "Last update date of the security group",
+				PlanModifiers: []planmodifier.String{
+					UnknownDuringUpdateStringModifier(securityGroupMutableAttrs),
+				},
+			},
+			"resource_status": schema.StringAttribute{
+				CustomType:          ovhtypes.TfStringType{},
+				Computed:            true,
+				Description:         "Security group readiness in the system (CREATING, DELETING, ERROR, OUT_OF_SYNC, READY, UPDATING)",
+				MarkdownDescription: "Security group readiness in the system (`CREATING`, `DELETING`, `ERROR`, `OUT_OF_SYNC`, `READY`, `UPDATING`)",
+				PlanModifiers: []planmodifier.String{
+					OutOfSyncPlanModifier(),
+				},
+			},
+			"current_state": schema.SingleNestedAttribute{
+				Computed:    true,
+				Description: "Current state of the security group",
+				PlanModifiers: []planmodifier.Object{
+					UnknownDuringUpdateObjectModifier(securityGroupMutableAttrs),
+				},
+				Attributes: map[string]schema.Attribute{
+					"name": schema.StringAttribute{
+						CustomType:          ovhtypes.TfStringType{},
+						Computed:            true,
+						Description:         "Name of the security group",
+						MarkdownDescription: "Name of the security group",
+					},
+					"description": schema.StringAttribute{
+						CustomType:          ovhtypes.TfStringType{},
+						Computed:            true,
+						Description:         "Description of the security group",
+						MarkdownDescription: "Description of the security group",
+					},
+					"region": schema.StringAttribute{
+						CustomType:          ovhtypes.TfStringType{},
+						Computed:            true,
+						Description:         "Region of the security group",
+						MarkdownDescription: "Region of the security group",
+					},
+					"rules": schema.ListNestedAttribute{
+						Computed:    true,
+						Description: "User-specified security group rules with their IDs",
+						NestedObject: schema.NestedAttributeObject{
+							Attributes: securityGroupStateRuleSchemaAttributes(),
+						},
+					},
+					"default_rules": schema.ListNestedAttribute{
+						Computed:    true,
+						Description: "Default egress rules auto-created by OpenStack",
+						NestedObject: schema.NestedAttributeObject{
+							Attributes: securityGroupStateRuleSchemaAttributes(),
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func (r *cloudSecurityGroupResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	splits := strings.Split(req.ID, "/")
+	if len(splits) != 2 {
+		resp.Diagnostics.AddError("Given ID is malformed", "ID must be formatted like the following: <service_name>/<security_group_id>")
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("service_name"), splits[0])...)
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("id"), splits[1])...)
+}
+
+func (r *cloudSecurityGroupResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	var data CloudSecurityGroupModel
+
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	createPayload := data.ToCreate()
+
+	endpoint := "/v2/publicCloud/project/" + url.PathEscape(data.ServiceName.ValueString()) + "/securityGroup"
+
+	var responseData CloudSecurityGroupAPIResponse
+	if err := r.config.OVHClient.Post(endpoint, createPayload, &responseData); err != nil {
+		resp.Diagnostics.AddError(
+			fmt.Sprintf("Error calling Post %s", endpoint),
+			err.Error(),
+		)
+		return
+	}
+
+	// Save state immediately so the resource ID is tracked even if the workflow fails
+	data.MergeWith(ctx, &responseData)
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+
+	// Wait for security group to be READY
+	_, err := r.waitForSecurityGroupReady(ctx, data.ServiceName.ValueString(), responseData.Id)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Error waiting for security group to be ready",
+			err.Error(),
+		)
+		return
+	}
+
+	// Read final state
+	endpoint = "/v2/publicCloud/project/" + url.PathEscape(data.ServiceName.ValueString()) + "/securityGroup/" + url.PathEscape(responseData.Id)
+	if err := r.config.OVHClient.Get(endpoint, &responseData); err != nil {
+		resp.Diagnostics.AddError(
+			fmt.Sprintf("Error calling Get %s", endpoint),
+			err.Error(),
+		)
+		return
+	}
+
+	data.MergeWith(ctx, &responseData)
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+func (r *cloudSecurityGroupResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	var data CloudSecurityGroupModel
+
+	resp.Diagnostics.Append(req.State.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	endpoint := "/v2/publicCloud/project/" + url.PathEscape(data.ServiceName.ValueString()) + "/securityGroup/" + url.PathEscape(data.Id.ValueString())
+
+	var responseData CloudSecurityGroupAPIResponse
+	if err := r.config.OVHClient.Get(endpoint, &responseData); err != nil {
+		if errOvh, ok := err.(*ovh.APIError); ok && errOvh.Code == 404 {
+			resp.State.RemoveResource(ctx)
+			return
+		}
+		resp.Diagnostics.AddError(
+			fmt.Sprintf("Error calling Get %s", endpoint),
+			err.Error(),
+		)
+		return
+	}
+
+	data.MergeWith(ctx, &responseData)
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+func (r *cloudSecurityGroupResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	var data, planData CloudSecurityGroupModel
+
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &planData)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	resp.Diagnostics.Append(req.State.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	updatePayload := planData.ToUpdate(data.Checksum.ValueString())
+
+	endpoint := "/v2/publicCloud/project/" + url.PathEscape(data.ServiceName.ValueString()) + "/securityGroup/" + url.PathEscape(data.Id.ValueString())
+
+	var responseData CloudSecurityGroupAPIResponse
+	if err := r.config.OVHClient.Put(endpoint, updatePayload, &responseData); err != nil {
+		resp.Diagnostics.AddError(
+			fmt.Sprintf("Error calling Put %s", endpoint),
+			err.Error(),
+		)
+		return
+	}
+
+	// Wait for security group to be READY
+	_, err := r.waitForSecurityGroupReady(ctx, data.ServiceName.ValueString(), data.Id.ValueString())
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Error waiting for security group to be ready after update",
+			err.Error(),
+		)
+		return
+	}
+
+	// Read final state
+	if err := r.config.OVHClient.Get(endpoint, &responseData); err != nil {
+		resp.Diagnostics.AddError(
+			fmt.Sprintf("Error calling Get %s", endpoint),
+			err.Error(),
+		)
+		return
+	}
+
+	planData.MergeWith(ctx, &responseData)
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &planData)...)
+}
+
+func (r *cloudSecurityGroupResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	var data CloudSecurityGroupModel
+
+	resp.Diagnostics.Append(req.State.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	endpoint := "/v2/publicCloud/project/" + url.PathEscape(data.ServiceName.ValueString()) + "/securityGroup/" + url.PathEscape(data.Id.ValueString())
+
+	if err := r.config.OVHClient.Delete(endpoint, nil); err != nil {
+		if errOvh, ok := err.(*ovh.APIError); ok && errOvh.Code == 404 {
+			return
+		}
+		resp.Diagnostics.AddError(
+			fmt.Sprintf("Error calling Delete %s", endpoint),
+			err.Error(),
+		)
+		return
+	}
+
+	// Wait for deletion to complete
+	stateConf := &retry.StateChangeConf{
+		Pending: []string{"DELETING"},
+		Target:  []string{"DELETED"},
+		Refresh: func() (interface{}, string, error) {
+			res := &CloudSecurityGroupAPIResponse{}
+			endpoint := "/v2/publicCloud/project/" + url.PathEscape(data.ServiceName.ValueString()) + "/securityGroup/" + url.PathEscape(data.Id.ValueString())
+			err := r.config.OVHClient.GetWithContext(ctx, endpoint, res)
+			if err != nil {
+				if errOvh, ok := err.(*ovh.APIError); ok && errOvh.Code == 404 {
+					return res, "DELETED", nil
+				}
+				return res, "", err
+			}
+			return res, res.ResourceStatus, nil
+		},
+		Timeout:    20 * time.Minute,
+		Delay:      10 * time.Second,
+		MinTimeout: 5 * time.Second,
+	}
+
+	if _, err := stateConf.WaitForStateContext(ctx); err != nil {
+		resp.Diagnostics.AddError(
+			"Error waiting for security group to be deleted",
+			err.Error(),
+		)
+	}
+}
+
+func (r *cloudSecurityGroupResource) waitForSecurityGroupReady(ctx context.Context, serviceName, securityGroupId string) (interface{}, error) {
+	stateConf := &retry.StateChangeConf{
+		Pending: []string{"CREATING", "UPDATING", "PENDING", "OUT_OF_SYNC"},
+		Target:  []string{"READY"},
+		Refresh: func() (interface{}, string, error) {
+			res := &CloudSecurityGroupAPIResponse{}
+			endpoint := "/v2/publicCloud/project/" + url.PathEscape(serviceName) + "/securityGroup/" + url.PathEscape(securityGroupId)
+			err := r.config.OVHClient.GetWithContext(ctx, endpoint, res)
+			if err != nil {
+				return res, "", err
+			}
+			return res, res.ResourceStatus, nil
+		},
+		Timeout:    20 * time.Minute,
+		Delay:      10 * time.Second,
+		MinTimeout: 5 * time.Second,
+	}
+
+	return stateConf.WaitForStateContext(ctx)
+}

--- a/ovh/resource_cloud_security_group_test.go
+++ b/ovh/resource_cloud_security_group_test.go
@@ -53,7 +53,7 @@ resource "ovh_cloud_security_group" "test" {
       port_range_max   = 22
       remote_ip_prefix = "0.0.0.0/0"
       description      = "SSH"
-    },
+    }
   ]
 }
 `, serviceName, region, name)
@@ -82,6 +82,11 @@ resource "ovh_cloud_security_group" "test" {
 					resource.TestCheckResourceAttrSet("ovh_cloud_security_group.test", "checksum"),
 					resource.TestCheckResourceAttrSet("ovh_cloud_security_group.test", "created_at"),
 					resource.TestCheckResourceAttr("ovh_cloud_security_group.test", "resource_status", "READY"),
+					// current_state must reflect the created rule, with an OpenStack-assigned rule ID
+					resource.TestCheckResourceAttr("ovh_cloud_security_group.test", "current_state.name", name),
+					resource.TestCheckResourceAttr("ovh_cloud_security_group.test", "current_state.region", region),
+					resource.TestCheckResourceAttr("ovh_cloud_security_group.test", "current_state.rules.#", "1"),
+					resource.TestCheckResourceAttrSet("ovh_cloud_security_group.test", "current_state.rules.0.id"),
 				),
 			},
 			// Test import
@@ -102,6 +107,7 @@ func TestAccCloudSecurityGroup_update(t *testing.T) {
 	name := testAccResourceCloudSecurityGroupNamePrefix + "before-update"
 	updatedName := testAccResourceCloudSecurityGroupNamePrefix + "after-update"
 
+	// Step 1: a single rule with a description set.
 	config := fmt.Sprintf(`
 resource "ovh_cloud_security_group" "test" {
   service_name = "%s"
@@ -118,11 +124,12 @@ resource "ovh_cloud_security_group" "test" {
       port_range_max   = 22
       remote_ip_prefix = "0.0.0.0/0"
       description      = "SSH"
-    },
+    }
   ]
 }
 `, serviceName, region, name)
 
+	// Step 2: rename, change description, add a second rule (1 -> 2).
 	updatedConfig := fmt.Sprintf(`
 resource "ovh_cloud_security_group" "test" {
   service_name = "%s"
@@ -148,7 +155,28 @@ resource "ovh_cloud_security_group" "test" {
       port_range_max   = 443
       remote_ip_prefix = "0.0.0.0/0"
       description      = "HTTPS"
-    },
+    }
+  ]
+}
+`, serviceName, region, updatedName)
+
+	// Step 3: remove a rule (2 -> 1) and clear the optional description.
+	shrunkConfig := fmt.Sprintf(`
+resource "ovh_cloud_security_group" "test" {
+  service_name = "%s"
+  region       = "%s"
+  name         = "%s"
+
+  rule = [
+    {
+      direction        = "INGRESS"
+      ethernet_type    = "IPV4"
+      protocol         = "TCP"
+      port_range_min   = 443
+      port_range_max   = 443
+      remote_ip_prefix = "0.0.0.0/0"
+      description      = "HTTPS"
+    }
   ]
 }
 `, serviceName, region, updatedName)
@@ -178,6 +206,240 @@ resource "ovh_cloud_security_group" "test" {
 					resource.TestCheckResourceAttrSet("ovh_cloud_security_group.test", "id"),
 					resource.TestCheckResourceAttrSet("ovh_cloud_security_group.test", "checksum"),
 					resource.TestCheckResourceAttr("ovh_cloud_security_group.test", "resource_status", "READY"),
+					resource.TestCheckResourceAttr("ovh_cloud_security_group.test", "current_state.rules.#", "2"),
+				),
+			},
+			{
+				// Removing a rule and clearing the description must converge cleanly.
+				Config: shrunkConfig,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("ovh_cloud_security_group.test", "name", updatedName),
+					// An omitted optional attribute is null (absent from state), not "".
+					resource.TestCheckNoResourceAttr("ovh_cloud_security_group.test", "description"),
+					resource.TestCheckResourceAttr("ovh_cloud_security_group.test", "rule.#", "1"),
+					resource.TestCheckResourceAttr("ovh_cloud_security_group.test", "rule.0.port_range_min", "443"),
+					resource.TestCheckResourceAttr("ovh_cloud_security_group.test", "resource_status", "READY"),
+					resource.TestCheckResourceAttr("ovh_cloud_security_group.test", "current_state.rules.#", "1"),
+				),
+			},
+		},
+	})
+}
+
+// TestAccCloudSecurityGroup_noRules creates a security group without any user
+// rule. OpenStack still auto-creates default egress rules, which must surface in
+// current_state.default_rules.
+func TestAccCloudSecurityGroup_noRules(t *testing.T) {
+	serviceName := os.Getenv("OVH_CLOUD_PROJECT_SERVICE_TEST")
+	region := os.Getenv("OVH_CLOUD_PROJECT_REGION_TEST")
+
+	name := testAccResourceCloudSecurityGroupNamePrefix + "no-rules"
+
+	config := fmt.Sprintf(`
+resource "ovh_cloud_security_group" "test" {
+  service_name = "%s"
+  region       = "%s"
+  name         = "%s"
+  description  = "No user rules"
+}
+`, serviceName, region, name)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheckCloudSecurityGroup(t)
+		},
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("ovh_cloud_security_group.test", "name", name),
+					resource.TestCheckResourceAttr("ovh_cloud_security_group.test", "rule.#", "0"),
+					resource.TestCheckResourceAttr("ovh_cloud_security_group.test", "resource_status", "READY"),
+					resource.TestCheckResourceAttr("ovh_cloud_security_group.test", "current_state.name", name),
+					resource.TestCheckNoResourceAttr("ovh_cloud_security_group.test", "current_state.rules"),
+					// OpenStack always provisions at least one default egress rule.
+					resource.TestCheckResourceAttrSet("ovh_cloud_security_group.test", "current_state.default_rules.0.id"),
+					resource.TestCheckResourceAttr("ovh_cloud_security_group.test", "current_state.default_rules.0.direction", "EGRESS"),
+				),
+			},
+			{
+				ResourceName:      "ovh_cloud_security_group.test",
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testAccCloudSecurityGroupImportStateIdFunc("ovh_cloud_security_group.test"),
+			},
+		},
+	})
+}
+
+// TestAccCloudSecurityGroup_comprehensive exercises the rule fields untested by
+// the basic test: EGRESS direction, IPV6 ethernet type, ICMP (no ports) and UDP
+// protocols. Rule assertions are index-independent because the API does not
+// guarantee rule ordering.
+func TestAccCloudSecurityGroup_comprehensive(t *testing.T) {
+	serviceName := os.Getenv("OVH_CLOUD_PROJECT_SERVICE_TEST")
+	region := os.Getenv("OVH_CLOUD_PROJECT_REGION_TEST")
+
+	name := testAccResourceCloudSecurityGroupNamePrefix + "comprehensive"
+
+	config := fmt.Sprintf(`
+resource "ovh_cloud_security_group" "test" {
+  service_name = "%s"
+  region       = "%s"
+  name         = "%s"
+  description  = "Comprehensive rule coverage"
+
+  rule = [
+    {
+      direction        = "EGRESS"
+      ethernet_type    = "IPV4"
+      protocol         = "TCP"
+      port_range_min   = 80
+      port_range_max   = 80
+      remote_ip_prefix = "0.0.0.0/0"
+      description      = "Egress HTTP"
+    },
+    {
+      direction        = "INGRESS"
+      ethernet_type    = "IPV6"
+      protocol         = "TCP"
+      port_range_min   = 22
+      port_range_max   = 22
+      remote_ip_prefix = "::/0"
+      description      = "IPv6 SSH"
+    },
+    {
+      direction        = "INGRESS"
+      ethernet_type    = "IPV4"
+      protocol         = "ICMP"
+      remote_ip_prefix = "0.0.0.0/0"
+      description      = "Ping"
+    },
+    {
+      direction        = "INGRESS"
+      ethernet_type    = "IPV4"
+      protocol         = "UDP"
+      port_range_min   = 53
+      port_range_max   = 53
+      remote_ip_prefix = "0.0.0.0/0"
+      description      = "DNS"
+    }
+  ]
+}
+`, serviceName, region, name)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheckCloudSecurityGroup(t)
+		},
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("ovh_cloud_security_group.test", "name", name),
+					resource.TestCheckResourceAttr("ovh_cloud_security_group.test", "rule.#", "4"),
+					resource.TestCheckResourceAttr("ovh_cloud_security_group.test", "resource_status", "READY"),
+					resource.TestCheckResourceAttr("ovh_cloud_security_group.test", "current_state.rules.#", "4"),
+					// EGRESS / IPV4 / TCP
+					resource.TestCheckTypeSetElemNestedAttrs("ovh_cloud_security_group.test", "rule.*", map[string]string{
+						"direction":      "EGRESS",
+						"ethernet_type":  "IPV4",
+						"protocol":       "TCP",
+						"port_range_min": "80",
+					}),
+					// INGRESS / IPV6
+					resource.TestCheckTypeSetElemNestedAttrs("ovh_cloud_security_group.test", "rule.*", map[string]string{
+						"direction":        "INGRESS",
+						"ethernet_type":    "IPV6",
+						"remote_ip_prefix": "::/0",
+					}),
+					// ICMP without port range
+					resource.TestCheckTypeSetElemNestedAttrs("ovh_cloud_security_group.test", "rule.*", map[string]string{
+						"protocol":    "ICMP",
+						"description": "Ping",
+					}),
+					// UDP
+					resource.TestCheckTypeSetElemNestedAttrs("ovh_cloud_security_group.test", "rule.*", map[string]string{
+						"protocol":       "UDP",
+						"port_range_min": "53",
+					}),
+				),
+			},
+			{
+				ResourceName:      "ovh_cloud_security_group.test",
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testAccCloudSecurityGroupImportStateIdFunc("ovh_cloud_security_group.test"),
+			},
+		},
+	})
+}
+
+// TestAccCloudSecurityGroup_remoteGroup covers a rule that references another
+// security group through remote_group_id instead of a remote_ip_prefix.
+func TestAccCloudSecurityGroup_remoteGroup(t *testing.T) {
+	serviceName := os.Getenv("OVH_CLOUD_PROJECT_SERVICE_TEST")
+	region := os.Getenv("OVH_CLOUD_PROJECT_REGION_TEST")
+
+	sourceName := testAccResourceCloudSecurityGroupNamePrefix + "remote-source"
+	targetName := testAccResourceCloudSecurityGroupNamePrefix + "remote-target"
+
+	config := fmt.Sprintf(`
+resource "ovh_cloud_security_group" "source" {
+  service_name = "%s"
+  region       = "%s"
+  name         = "%s"
+
+  rule = [
+    {
+      direction        = "INGRESS"
+      ethernet_type    = "IPV4"
+      protocol         = "TCP"
+      port_range_min   = 22
+      port_range_max   = 22
+      remote_ip_prefix = "0.0.0.0/0"
+      description      = "SSH"
+    }
+  ]
+}
+
+resource "ovh_cloud_security_group" "target" {
+  service_name = "%s"
+  region       = "%s"
+  name         = "%s"
+
+  rule = [
+    {
+      direction       = "INGRESS"
+      ethernet_type   = "IPV4"
+      protocol        = "TCP"
+      port_range_min  = 3306
+      port_range_max  = 3306
+      remote_group_id = ovh_cloud_security_group.source.id
+      description     = "MySQL from source SG"
+    }
+  ]
+}
+`, serviceName, region, sourceName, serviceName, region, targetName)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheckCloudSecurityGroup(t)
+		},
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("ovh_cloud_security_group.target", "rule.#", "1"),
+					resource.TestCheckResourceAttr("ovh_cloud_security_group.target", "resource_status", "READY"),
+					resource.TestCheckResourceAttrSet("ovh_cloud_security_group.target", "rule.0.remote_group_id"),
+					resource.TestCheckResourceAttrPair(
+						"ovh_cloud_security_group.target", "rule.0.remote_group_id",
+						"ovh_cloud_security_group.source", "id",
+					),
 				),
 			},
 		},

--- a/ovh/resource_cloud_security_group_test.go
+++ b/ovh/resource_cloud_security_group_test.go
@@ -1,0 +1,185 @@
+package ovh
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+)
+
+const testAccResourceCloudSecurityGroupNamePrefix = "tf-test-sg-v2-"
+
+func testAccPreCheckCloudSecurityGroup(t *testing.T) {
+	testAccPreCheckCredentials(t)
+	if os.Getenv("OVH_CLOUD_PROJECT_SERVICE_TEST") == "" {
+		t.Skip("OVH_CLOUD_PROJECT_SERVICE_TEST must be set for acceptance tests")
+	}
+	if os.Getenv("OVH_CLOUD_PROJECT_REGION_TEST") == "" {
+		t.Skip("OVH_CLOUD_PROJECT_REGION_TEST must be set for acceptance tests")
+	}
+}
+
+func testAccCloudSecurityGroupImportStateIdFunc(resourceName string) resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return "", fmt.Errorf("not found: %s", resourceName)
+		}
+		return fmt.Sprintf("%s/%s", rs.Primary.Attributes["service_name"], rs.Primary.Attributes["id"]), nil
+	}
+}
+
+func TestAccCloudSecurityGroup_basic(t *testing.T) {
+	serviceName := os.Getenv("OVH_CLOUD_PROJECT_SERVICE_TEST")
+	region := os.Getenv("OVH_CLOUD_PROJECT_REGION_TEST")
+
+	name := testAccResourceCloudSecurityGroupNamePrefix + "basic"
+
+	config := fmt.Sprintf(`
+resource "ovh_cloud_security_group" "test" {
+  service_name = "%s"
+  region       = "%s"
+  name         = "%s"
+  description  = "Test security group"
+
+  rule = [
+    {
+      direction        = "INGRESS"
+      ethernet_type    = "IPV4"
+      protocol         = "TCP"
+      port_range_min   = 22
+      port_range_max   = 22
+      remote_ip_prefix = "0.0.0.0/0"
+      description      = "SSH"
+    },
+  ]
+}
+`, serviceName, region, name)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheckCloudSecurityGroup(t)
+		},
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("ovh_cloud_security_group.test", "service_name", serviceName),
+					resource.TestCheckResourceAttr("ovh_cloud_security_group.test", "region", region),
+					resource.TestCheckResourceAttr("ovh_cloud_security_group.test", "name", name),
+					resource.TestCheckResourceAttr("ovh_cloud_security_group.test", "description", "Test security group"),
+					resource.TestCheckResourceAttr("ovh_cloud_security_group.test", "rule.#", "1"),
+					resource.TestCheckResourceAttr("ovh_cloud_security_group.test", "rule.0.direction", "INGRESS"),
+					resource.TestCheckResourceAttr("ovh_cloud_security_group.test", "rule.0.ethernet_type", "IPV4"),
+					resource.TestCheckResourceAttr("ovh_cloud_security_group.test", "rule.0.protocol", "TCP"),
+					resource.TestCheckResourceAttr("ovh_cloud_security_group.test", "rule.0.port_range_min", "22"),
+					resource.TestCheckResourceAttr("ovh_cloud_security_group.test", "rule.0.port_range_max", "22"),
+					resource.TestCheckResourceAttr("ovh_cloud_security_group.test", "rule.0.remote_ip_prefix", "0.0.0.0/0"),
+					resource.TestCheckResourceAttrSet("ovh_cloud_security_group.test", "id"),
+					resource.TestCheckResourceAttrSet("ovh_cloud_security_group.test", "checksum"),
+					resource.TestCheckResourceAttrSet("ovh_cloud_security_group.test", "created_at"),
+					resource.TestCheckResourceAttr("ovh_cloud_security_group.test", "resource_status", "READY"),
+				),
+			},
+			// Test import
+			{
+				ResourceName:      "ovh_cloud_security_group.test",
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testAccCloudSecurityGroupImportStateIdFunc("ovh_cloud_security_group.test"),
+			},
+		},
+	})
+}
+
+func TestAccCloudSecurityGroup_update(t *testing.T) {
+	serviceName := os.Getenv("OVH_CLOUD_PROJECT_SERVICE_TEST")
+	region := os.Getenv("OVH_CLOUD_PROJECT_REGION_TEST")
+
+	name := testAccResourceCloudSecurityGroupNamePrefix + "before-update"
+	updatedName := testAccResourceCloudSecurityGroupNamePrefix + "after-update"
+
+	config := fmt.Sprintf(`
+resource "ovh_cloud_security_group" "test" {
+  service_name = "%s"
+  region       = "%s"
+  name         = "%s"
+  description  = "Before update"
+
+  rule = [
+    {
+      direction        = "INGRESS"
+      ethernet_type    = "IPV4"
+      protocol         = "TCP"
+      port_range_min   = 22
+      port_range_max   = 22
+      remote_ip_prefix = "0.0.0.0/0"
+      description      = "SSH"
+    },
+  ]
+}
+`, serviceName, region, name)
+
+	updatedConfig := fmt.Sprintf(`
+resource "ovh_cloud_security_group" "test" {
+  service_name = "%s"
+  region       = "%s"
+  name         = "%s"
+  description  = "After update"
+
+  rule = [
+    {
+      direction        = "INGRESS"
+      ethernet_type    = "IPV4"
+      protocol         = "TCP"
+      port_range_min   = 22
+      port_range_max   = 22
+      remote_ip_prefix = "0.0.0.0/0"
+      description      = "SSH"
+    },
+    {
+      direction        = "INGRESS"
+      ethernet_type    = "IPV4"
+      protocol         = "TCP"
+      port_range_min   = 443
+      port_range_max   = 443
+      remote_ip_prefix = "0.0.0.0/0"
+      description      = "HTTPS"
+    },
+  ]
+}
+`, serviceName, region, updatedName)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheckCloudSecurityGroup(t)
+		},
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("ovh_cloud_security_group.test", "name", name),
+					resource.TestCheckResourceAttr("ovh_cloud_security_group.test", "description", "Before update"),
+					resource.TestCheckResourceAttr("ovh_cloud_security_group.test", "rule.#", "1"),
+					resource.TestCheckResourceAttrSet("ovh_cloud_security_group.test", "id"),
+					resource.TestCheckResourceAttrSet("ovh_cloud_security_group.test", "checksum"),
+				),
+			},
+			{
+				Config: updatedConfig,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("ovh_cloud_security_group.test", "name", updatedName),
+					resource.TestCheckResourceAttr("ovh_cloud_security_group.test", "description", "After update"),
+					resource.TestCheckResourceAttr("ovh_cloud_security_group.test", "rule.#", "2"),
+					resource.TestCheckResourceAttrSet("ovh_cloud_security_group.test", "id"),
+					resource.TestCheckResourceAttrSet("ovh_cloud_security_group.test", "checksum"),
+					resource.TestCheckResourceAttr("ovh_cloud_security_group.test", "resource_status", "READY"),
+				),
+			},
+		},
+	})
+}

--- a/ovh/types_cloud_security_group.go
+++ b/ovh/types_cloud_security_group.go
@@ -1,0 +1,408 @@
+package ovh
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
+	ovhtypes "github.com/ovh/terraform-provider-ovh/v2/ovh/types"
+)
+
+// CloudSecurityGroupModel represents the Terraform model for the security group resource
+type CloudSecurityGroupModel struct {
+	// Required — immutable
+	ServiceName ovhtypes.TfStringValue `tfsdk:"service_name"`
+	Region      ovhtypes.TfStringValue `tfsdk:"region"`
+
+	// Required — mutable
+	Name ovhtypes.TfStringValue `tfsdk:"name"`
+
+	// Optional — mutable
+	Description ovhtypes.TfStringValue `tfsdk:"description"`
+	Rule        types.List             `tfsdk:"rule"`
+
+	// Computed
+	Id             ovhtypes.TfStringValue `tfsdk:"id"`
+	Checksum       ovhtypes.TfStringValue `tfsdk:"checksum"`
+	CreatedAt      ovhtypes.TfStringValue `tfsdk:"created_at"`
+	UpdatedAt      ovhtypes.TfStringValue `tfsdk:"updated_at"`
+	ResourceStatus ovhtypes.TfStringValue `tfsdk:"resource_status"`
+	CurrentState   types.Object           `tfsdk:"current_state"`
+}
+
+// API response types
+type CloudSecurityGroupAPIResponse struct {
+	Id             string                             `json:"id"`
+	Checksum       string                             `json:"checksum"`
+	CreatedAt      string                             `json:"createdAt"`
+	UpdatedAt      string                             `json:"updatedAt"`
+	ResourceStatus string                             `json:"resourceStatus"`
+	CurrentState   *CloudSecurityGroupAPICurrentState `json:"currentState,omitempty"`
+	TargetSpec     *CloudSecurityGroupAPITargetSpec   `json:"targetSpec,omitempty"`
+}
+
+type CloudSecurityGroupAPICurrentState struct {
+	Name         string                           `json:"name,omitempty"`
+	Description  string                           `json:"description,omitempty"`
+	Location     *CloudSecurityGroupAPILocation   `json:"location,omitempty"`
+	Rules        []CloudSecurityGroupAPIStateRule `json:"rules,omitempty"`
+	DefaultRules []CloudSecurityGroupAPIStateRule `json:"defaultRules,omitempty"`
+}
+
+type CloudSecurityGroupAPITargetSpec struct {
+	Name        string                            `json:"name"`
+	Description string                            `json:"description,omitempty"`
+	Location    *CloudSecurityGroupAPILocation    `json:"location,omitempty"`
+	Rules       []CloudSecurityGroupAPITargetRule `json:"rules,omitempty"`
+}
+
+type CloudSecurityGroupAPIUpdateTargetSpec struct {
+	Name        string                            `json:"name"`
+	Description string                            `json:"description"`
+	Rules       []CloudSecurityGroupAPITargetRule `json:"rules,omitempty"`
+}
+
+type CloudSecurityGroupAPILocation struct {
+	Region string `json:"region,omitempty"`
+}
+
+type CloudSecurityGroupAPITargetRule struct {
+	Direction      string                            `json:"direction"`
+	EthernetType   string                            `json:"ethernetType"`
+	Protocol       string                            `json:"protocol,omitempty"`
+	PortRangeMin   *int64                            `json:"portRangeMin,omitempty"`
+	PortRangeMax   *int64                            `json:"portRangeMax,omitempty"`
+	RemoteGroup    *CloudSecurityGroupAPIRemoteGroup `json:"remoteGroup,omitempty"`
+	RemoteIpPrefix string                            `json:"remoteIpPrefix,omitempty"`
+	Description    string                            `json:"description,omitempty"`
+}
+
+type CloudSecurityGroupAPIStateRule struct {
+	Id             string                            `json:"id,omitempty"`
+	Direction      string                            `json:"direction"`
+	EthernetType   string                            `json:"ethernetType"`
+	Protocol       string                            `json:"protocol,omitempty"`
+	PortRangeMin   *int64                            `json:"portRangeMin,omitempty"`
+	PortRangeMax   *int64                            `json:"portRangeMax,omitempty"`
+	RemoteGroup    *CloudSecurityGroupAPIRemoteGroup `json:"remoteGroup,omitempty"`
+	RemoteIpPrefix string                            `json:"remoteIpPrefix,omitempty"`
+	Description    string                            `json:"description,omitempty"`
+}
+
+type CloudSecurityGroupAPIRemoteGroup struct {
+	Id string `json:"id"`
+}
+
+// Create payload
+type CloudSecurityGroupCreatePayload struct {
+	TargetSpec *CloudSecurityGroupAPITargetSpec `json:"targetSpec"`
+}
+
+// Update payload
+type CloudSecurityGroupUpdatePayload struct {
+	Checksum   string                                 `json:"checksum"`
+	TargetSpec *CloudSecurityGroupAPIUpdateTargetSpec `json:"targetSpec"`
+}
+
+// ToCreate converts the Terraform model to the API create payload
+func (m *CloudSecurityGroupModel) ToCreate() *CloudSecurityGroupCreatePayload {
+	targetSpec := &CloudSecurityGroupAPITargetSpec{
+		Name:        m.Name.ValueString(),
+		Description: m.Description.ValueString(),
+		Location: &CloudSecurityGroupAPILocation{
+			Region: m.Region.ValueString(),
+		},
+		Rules: buildSecurityGroupTargetRules(m.Rule),
+	}
+
+	return &CloudSecurityGroupCreatePayload{TargetSpec: targetSpec}
+}
+
+// ToUpdate converts the Terraform model to the API update payload
+func (m *CloudSecurityGroupModel) ToUpdate(checksum string) *CloudSecurityGroupUpdatePayload {
+	return &CloudSecurityGroupUpdatePayload{
+		Checksum: checksum,
+		TargetSpec: &CloudSecurityGroupAPIUpdateTargetSpec{
+			Name:        m.Name.ValueString(),
+			Description: m.Description.ValueString(),
+			Rules:       buildSecurityGroupTargetRules(m.Rule),
+		},
+	}
+}
+
+func buildSecurityGroupTargetRules(ruleList types.List) []CloudSecurityGroupAPITargetRule {
+	if ruleList.IsNull() || ruleList.IsUnknown() {
+		return nil
+	}
+
+	rules := make([]CloudSecurityGroupAPITargetRule, 0, len(ruleList.Elements()))
+	for _, elem := range ruleList.Elements() {
+		obj, ok := elem.(basetypes.ObjectValue)
+		if !ok {
+			continue
+		}
+		attrs := obj.Attributes()
+
+		rule := CloudSecurityGroupAPITargetRule{}
+
+		if v, ok := attrs["direction"].(ovhtypes.TfStringValue); ok && !v.IsNull() && !v.IsUnknown() {
+			rule.Direction = v.ValueString()
+		}
+		if v, ok := attrs["ethernet_type"].(ovhtypes.TfStringValue); ok && !v.IsNull() && !v.IsUnknown() {
+			rule.EthernetType = v.ValueString()
+		}
+		if v, ok := attrs["protocol"].(ovhtypes.TfStringValue); ok && !v.IsNull() && !v.IsUnknown() {
+			rule.Protocol = v.ValueString()
+		}
+		if v, ok := attrs["port_range_min"].(basetypes.Int64Value); ok && !v.IsNull() && !v.IsUnknown() {
+			val := v.ValueInt64()
+			rule.PortRangeMin = &val
+		}
+		if v, ok := attrs["port_range_max"].(basetypes.Int64Value); ok && !v.IsNull() && !v.IsUnknown() {
+			val := v.ValueInt64()
+			rule.PortRangeMax = &val
+		}
+		if v, ok := attrs["remote_group_id"].(ovhtypes.TfStringValue); ok && !v.IsNull() && !v.IsUnknown() {
+			rule.RemoteGroup = &CloudSecurityGroupAPIRemoteGroup{
+				Id: v.ValueString(),
+			}
+		}
+		if v, ok := attrs["remote_ip_prefix"].(ovhtypes.TfStringValue); ok && !v.IsNull() && !v.IsUnknown() {
+			rule.RemoteIpPrefix = v.ValueString()
+		}
+		if v, ok := attrs["description"].(ovhtypes.TfStringValue); ok && !v.IsNull() && !v.IsUnknown() {
+			rule.Description = v.ValueString()
+		}
+
+		rules = append(rules, rule)
+	}
+
+	return rules
+}
+
+// SecurityGroupRuleAttrTypes returns the attribute types for a rule nested object
+func SecurityGroupRuleAttrTypes() map[string]attr.Type {
+	return map[string]attr.Type{
+		"direction":        ovhtypes.TfStringType{},
+		"ethernet_type":    ovhtypes.TfStringType{},
+		"protocol":         ovhtypes.TfStringType{},
+		"port_range_min":   types.Int64Type,
+		"port_range_max":   types.Int64Type,
+		"remote_group_id":  ovhtypes.TfStringType{},
+		"remote_ip_prefix": ovhtypes.TfStringType{},
+		"description":      ovhtypes.TfStringType{},
+	}
+}
+
+// SecurityGroupCurrentStateRuleAttrTypes returns the attribute types for a current_state rule
+func SecurityGroupCurrentStateRuleAttrTypes() map[string]attr.Type {
+	return map[string]attr.Type{
+		"id":               ovhtypes.TfStringType{},
+		"direction":        ovhtypes.TfStringType{},
+		"ethernet_type":    ovhtypes.TfStringType{},
+		"protocol":         ovhtypes.TfStringType{},
+		"port_range_min":   types.Int64Type,
+		"port_range_max":   types.Int64Type,
+		"remote_group_id":  ovhtypes.TfStringType{},
+		"remote_ip_prefix": ovhtypes.TfStringType{},
+		"description":      ovhtypes.TfStringType{},
+	}
+}
+
+// SecurityGroupCurrentStateAttrTypes returns the attribute types for current_state
+func SecurityGroupCurrentStateAttrTypes() map[string]attr.Type {
+	ruleObjType := types.ObjectType{
+		AttrTypes: SecurityGroupCurrentStateRuleAttrTypes(),
+	}
+	return map[string]attr.Type{
+		"name":        ovhtypes.TfStringType{},
+		"description": ovhtypes.TfStringType{},
+		"region":      ovhtypes.TfStringType{},
+		"rules": types.ListType{
+			ElemType: ruleObjType,
+		},
+		"default_rules": types.ListType{
+			ElemType: ruleObjType,
+		},
+	}
+}
+
+// buildStateRulesList converts a slice of API state rules into a Terraform list value.
+func buildStateRulesList(apiRules []CloudSecurityGroupAPIStateRule) basetypes.ListValue {
+	ruleAttrTypes := SecurityGroupCurrentStateRuleAttrTypes()
+	ruleObjType := types.ObjectType{AttrTypes: ruleAttrTypes}
+
+	if apiRules == nil {
+		return types.ListNull(ruleObjType)
+	}
+
+	ruleObjs := make([]attr.Value, len(apiRules))
+	for i, rule := range apiRules {
+		var portRangeMin, portRangeMax attr.Value
+		if rule.PortRangeMin != nil {
+			portRangeMin = types.Int64Value(*rule.PortRangeMin)
+		} else {
+			portRangeMin = types.Int64Null()
+		}
+		if rule.PortRangeMax != nil {
+			portRangeMax = types.Int64Value(*rule.PortRangeMax)
+		} else {
+			portRangeMax = types.Int64Null()
+		}
+
+		remoteGroupId := ""
+		if rule.RemoteGroup != nil {
+			remoteGroupId = rule.RemoteGroup.Id
+		}
+
+		ruleObj, _ := types.ObjectValue(
+			ruleAttrTypes,
+			map[string]attr.Value{
+				"id":               ovhtypes.TfStringValue{StringValue: types.StringValue(rule.Id)},
+				"direction":        ovhtypes.TfStringValue{StringValue: types.StringValue(rule.Direction)},
+				"ethernet_type":    ovhtypes.TfStringValue{StringValue: types.StringValue(rule.EthernetType)},
+				"protocol":         ovhtypes.TfStringValue{StringValue: types.StringValue(rule.Protocol)},
+				"port_range_min":   portRangeMin,
+				"port_range_max":   portRangeMax,
+				"remote_group_id":  ovhtypes.TfStringValue{StringValue: types.StringValue(remoteGroupId)},
+				"remote_ip_prefix": ovhtypes.TfStringValue{StringValue: types.StringValue(rule.RemoteIpPrefix)},
+				"description":      ovhtypes.TfStringValue{StringValue: types.StringValue(rule.Description)},
+			},
+		)
+		ruleObjs[i] = ruleObj
+	}
+	val, _ := types.ListValue(ruleObjType, ruleObjs)
+	return val
+}
+
+// buildSecurityGroupTargetRulesList converts the targetSpec rules of an API
+// response into a Terraform list value matching the root `rule` attribute type.
+// Returns a null list when there are no rules. Shared by MergeWith (resource +
+// singular data source) and the plural data source list builder.
+func buildSecurityGroupTargetRulesList(rules []CloudSecurityGroupAPITargetRule) basetypes.ListValue {
+	ruleAttrTypes := SecurityGroupRuleAttrTypes()
+	ruleObjType := types.ObjectType{AttrTypes: ruleAttrTypes}
+
+	if rules == nil {
+		return types.ListNull(ruleObjType)
+	}
+
+	ruleObjs := make([]attr.Value, len(rules))
+	for i, rule := range rules {
+		var portRangeMin, portRangeMax attr.Value
+		if rule.PortRangeMin != nil {
+			portRangeMin = types.Int64Value(*rule.PortRangeMin)
+		} else {
+			portRangeMin = types.Int64Null()
+		}
+		if rule.PortRangeMax != nil {
+			portRangeMax = types.Int64Value(*rule.PortRangeMax)
+		} else {
+			portRangeMax = types.Int64Null()
+		}
+
+		remoteGroupId := ""
+		if rule.RemoteGroup != nil {
+			remoteGroupId = rule.RemoteGroup.Id
+		}
+
+		var remoteGroupIdVal attr.Value
+		if remoteGroupId != "" {
+			remoteGroupIdVal = ovhtypes.TfStringValue{StringValue: types.StringValue(remoteGroupId)}
+		} else {
+			remoteGroupIdVal = ovhtypes.TfStringValue{StringValue: types.StringNull()}
+		}
+
+		var protocolVal attr.Value
+		if rule.Protocol != "" {
+			protocolVal = ovhtypes.TfStringValue{StringValue: types.StringValue(rule.Protocol)}
+		} else {
+			protocolVal = ovhtypes.TfStringValue{StringValue: types.StringNull()}
+		}
+
+		var remoteIpPrefixVal attr.Value
+		if rule.RemoteIpPrefix != "" {
+			remoteIpPrefixVal = ovhtypes.TfStringValue{StringValue: types.StringValue(rule.RemoteIpPrefix)}
+		} else {
+			remoteIpPrefixVal = ovhtypes.TfStringValue{StringValue: types.StringNull()}
+		}
+
+		var descriptionVal attr.Value
+		if rule.Description != "" {
+			descriptionVal = ovhtypes.TfStringValue{StringValue: types.StringValue(rule.Description)}
+		} else {
+			descriptionVal = ovhtypes.TfStringValue{StringValue: types.StringNull()}
+		}
+
+		ruleObj, _ := types.ObjectValue(
+			ruleAttrTypes,
+			map[string]attr.Value{
+				"direction":        ovhtypes.TfStringValue{StringValue: types.StringValue(rule.Direction)},
+				"ethernet_type":    ovhtypes.TfStringValue{StringValue: types.StringValue(rule.EthernetType)},
+				"protocol":         protocolVal,
+				"port_range_min":   portRangeMin,
+				"port_range_max":   portRangeMax,
+				"remote_group_id":  remoteGroupIdVal,
+				"remote_ip_prefix": remoteIpPrefixVal,
+				"description":      descriptionVal,
+			},
+		)
+		ruleObjs[i] = ruleObj
+	}
+
+	val, _ := types.ListValue(ruleObjType, ruleObjs)
+	return val
+}
+
+func buildSecurityGroupCurrentStateObject(ctx context.Context, state *CloudSecurityGroupAPICurrentState) types.Object {
+	region := ""
+	if state.Location != nil {
+		region = state.Location.Region
+	}
+
+	obj, _ := types.ObjectValue(
+		SecurityGroupCurrentStateAttrTypes(),
+		map[string]attr.Value{
+			"name":          ovhtypes.TfStringValue{StringValue: types.StringValue(state.Name)},
+			"description":   ovhtypes.TfStringValue{StringValue: types.StringValue(state.Description)},
+			"region":        ovhtypes.TfStringValue{StringValue: types.StringValue(region)},
+			"rules":         buildStateRulesList(state.Rules),
+			"default_rules": buildStateRulesList(state.DefaultRules),
+		},
+	)
+
+	return obj
+}
+
+// MergeWith merges API response data into the Terraform model
+func (m *CloudSecurityGroupModel) MergeWith(ctx context.Context, response *CloudSecurityGroupAPIResponse) {
+	m.Id = ovhtypes.TfStringValue{StringValue: types.StringValue(response.Id)}
+	m.Checksum = ovhtypes.TfStringValue{StringValue: types.StringValue(response.Checksum)}
+	m.CreatedAt = ovhtypes.TfStringValue{StringValue: types.StringValue(response.CreatedAt)}
+	m.UpdatedAt = ovhtypes.TfStringValue{StringValue: types.StringValue(response.UpdatedAt)}
+	m.ResourceStatus = ovhtypes.TfStringValue{StringValue: types.StringValue(response.ResourceStatus)}
+
+	// Build current_state from API currentState
+	if response.CurrentState != nil {
+		m.CurrentState = buildSecurityGroupCurrentStateObject(ctx, response.CurrentState)
+	} else {
+		m.CurrentState = types.ObjectNull(SecurityGroupCurrentStateAttrTypes())
+	}
+
+	// Set root-level fields from targetSpec
+	if response.TargetSpec != nil {
+		m.Name = ovhtypes.TfStringValue{StringValue: types.StringValue(response.TargetSpec.Name)}
+
+		if response.TargetSpec.Description != "" || (!m.Description.IsNull() && !m.Description.IsUnknown()) {
+			m.Description = ovhtypes.TfStringValue{StringValue: types.StringValue(response.TargetSpec.Description)}
+		}
+
+		if response.TargetSpec.Location != nil {
+			m.Region = ovhtypes.TfStringValue{StringValue: types.StringValue(response.TargetSpec.Location.Region)}
+		}
+
+		// Rebuild rule list from targetSpec rules to keep Terraform state in sync
+		m.Rule = buildSecurityGroupTargetRulesList(response.TargetSpec.Rules)
+	}
+}

--- a/ovh/types_cloud_security_group.go
+++ b/ovh/types_cloud_security_group.go
@@ -284,7 +284,9 @@ func buildSecurityGroupTargetRulesList(rules []CloudSecurityGroupAPITargetRule) 
 	ruleAttrTypes := SecurityGroupRuleAttrTypes()
 	ruleObjType := types.ObjectType{AttrTypes: ruleAttrTypes}
 
-	if rules == nil {
+	// An empty array from the API is treated like an absent one (null), so an
+	// omitted `rule` config round-trips instead of becoming an empty list.
+	if len(rules) == 0 {
 		return types.ListNull(ruleObjType)
 	}
 
@@ -402,7 +404,9 @@ func (m *CloudSecurityGroupModel) MergeWith(ctx context.Context, response *Cloud
 			m.Region = ovhtypes.TfStringValue{StringValue: types.StringValue(response.TargetSpec.Location.Region)}
 		}
 
-		// Rebuild rule list from targetSpec rules to keep Terraform state in sync
+		// Rebuild rule list from targetSpec rules to keep Terraform state in sync.
+		// An empty array from the API is treated like an absent one (null), so an
+		// omitted `rule` config round-trips instead of becoming an empty list.
 		m.Rule = buildSecurityGroupTargetRulesList(response.TargetSpec.Rules)
 	}
 }


### PR DESCRIPTION
# Description

This PR adds the new public cloud security group resources and datasources:

## Type of change

- [x] New feature 

 Resource
  - ovh_cloud_security_group 

Datasources
  - ovh_cloud_security_group
  - ovh_cloud_security_groups


# How Has This Been Tested?
`-> % make testacc TESTARGS="-run 'CloudSecurityGroup'"                     
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -run 'CloudSecurityGroup' -timeout 600m -p 10
?       github.com/ovh/terraform-provider-ovh/v2        [no test files]
=== RUN   TestAccDataSourceCloudSecurityGroup_basic
--- PASS: TestAccDataSourceCloudSecurityGroup_basic (25.95s)
=== RUN   TestAccDataSourceCloudSecurityGroups_basic
--- PASS: TestAccDataSourceCloudSecurityGroups_basic (23.38s)
=== RUN   TestAccCloudSecurityGroup_basic
--- PASS: TestAccCloudSecurityGroup_basic (23.35s)
=== RUN   TestAccCloudSecurityGroup_update
--- PASS: TestAccCloudSecurityGroup_update (46.88s)
=== RUN   TestAccCloudSecurityGroup_noRules
--- PASS: TestAccCloudSecurityGroup_noRules (23.59s)
=== RUN   TestAccCloudSecurityGroup_comprehensive
--- PASS: TestAccCloudSecurityGroup_comprehensive (23.46s)
=== RUN   TestAccCloudSecurityGroup_remoteGroup
--- PASS: TestAccCloudSecurityGroup_remoteGroup (43.67s)
PASS
ok      github.com/ovh/terraform-provider-ovh/v2/ovh    210.310s
?       github.com/ovh/terraform-provider-ovh/v2/ovh/datasources/cloud_project_rancher  [no test files]
testing: warning: no tests to run
PASS
ok      github.com/ovh/terraform-provider-ovh/v2/ovh/helpers    (cached) [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/ovh/terraform-provider-ovh/v2/ovh/helpers/hashcode   (cached) [no tests to run]
?       github.com/ovh/terraform-provider-ovh/v2/ovh/ovhwrap    [no test files]
?       github.com/ovh/terraform-provider-ovh/v2/ovh/resources/cloud_project_rancher    [no test files]
?       github.com/ovh/terraform-provider-ovh/v2/ovh/types      [no test files]`

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings or issues
- [X] I have added acceptance tests that prove my fix is effective or that my feature works
- [X] New and existing acceptance tests pass locally with my changes
- [X] I ran successfully `go mod vendor` if I added or modify `go.mod` file
