### PR TITLE
Dev/aamstutz/realign apiv2 design

### DIFF
--- a/docs/data-sources/cloud_gateway.md
+++ b/docs/data-sources/cloud_gateway.md
@@ -30,8 +30,9 @@ The following arguments are supported:
 
 The following attributes are exported:
 
-* `region` - Region of the gateway.
-* `availability_zone` - Availability zone of the gateway.
+* `location` - Location of the gateway:
+  * `region` - Region.
+  * `availability_zone` - Availability zone.
 * `name` - Gateway name.
 * `description` - Gateway description.
 * `external_gateway` - External gateway configuration:
@@ -52,5 +53,6 @@ The following attributes are exported:
   * `external_ip` - External IP address assigned to the gateway.
   * `subnets` - Currently attached subnets:
     * `id` - Subnet ID.
-  * `region` - Region.
-  * `availability_zone` - Availability zone.
+  * `location` - Location details:
+    * `region` - Region.
+    * `availability_zone` - Availability zone.

--- a/docs/data-sources/cloud_gateways.md
+++ b/docs/data-sources/cloud_gateways.md
@@ -32,7 +32,9 @@ The following attributes are exported:
   * `id` - Gateway ID.
   * `name` - Gateway name.
   * `description` - Gateway description.
-  * `region` - Region of the gateway.
+  * `location` - Location of the gateway:
+    * `region` - Region.
+    * `availability_zone` - Availability zone.
   * `external_gateway` - External gateway configuration:
     * `enabled` - Whether the external gateway is enabled.
     * `model` - External gateway sizing model.
@@ -50,5 +52,6 @@ The following attributes are exported:
     * `external_ip` - External IP address assigned to the gateway.
     * `subnets` - Currently attached subnets:
       * `id` - Subnet ID.
-    * `region` - Region.
-    * `availability_zone` - Availability zone.
+    * `location` - Location details:
+      * `region` - Region.
+      * `availability_zone` - Availability zone.

--- a/docs/data-sources/cloud_security_group.md
+++ b/docs/data-sources/cloud_security_group.md
@@ -30,7 +30,8 @@ The following arguments are supported:
 
 The following attributes are exported:
 
-* `region` - Region of the security group.
+* `location` - Location of the security group:
+  * `region` - Region.
 * `name` - Name of the security group.
 * `description` - Description of the security group.
 * `rule` - List of security group rules. Each rule exports:
@@ -49,7 +50,8 @@ The following attributes are exported:
 * `current_state` - Current state of the security group:
   * `name` - Name of the security group.
   * `description` - Description of the security group.
-  * `region` - Region of the security group.
+  * `location` - Location details:
+    * `region` - Region.
   * `rules` - User-specified security group rules with their IDs:
     * `id` - Rule ID.
     * `direction` - Direction of the rule.

--- a/docs/data-sources/cloud_security_groups.md
+++ b/docs/data-sources/cloud_security_groups.md
@@ -32,7 +32,8 @@ The following attributes are exported:
   * `id` - Security group ID.
   * `name` - Name of the security group.
   * `description` - Description of the security group.
-  * `region` - Region of the security group.
+  * `location` - Location of the security group:
+    * `region` - Region.
   * `rule` - List of security group rules:
     * `direction` - Direction of the rule (`INGRESS` or `EGRESS`).
     * `ethernet_type` - Ethernet type (`IPV4` or `IPV6`).
@@ -49,7 +50,8 @@ The following attributes are exported:
   * `current_state` - Current state of the security group:
     * `name` - Name of the security group.
     * `description` - Description of the security group.
-    * `region` - Region of the security group.
+    * `location` - Location details:
+      * `region` - Region.
     * `rules` - User-specified security group rules with their IDs:
       * `id` - Rule ID.
       * `direction` - Direction of the rule.

--- a/docs/resources/cloud_gateway.md
+++ b/docs/resources/cloud_gateway.md
@@ -70,8 +70,9 @@ The following attributes are exported:
   * `external_ip` - External IP address assigned to the gateway.
   * `subnets` - Currently attached subnets:
     * `id` - Subnet ID.
-  * `region` - Region.
-  * `availability_zone` - Availability zone.
+  * `location` - Location details:
+    * `region` - Region.
+    * `availability_zone` - Availability zone.
 
 ## Import
 

--- a/docs/resources/cloud_network_private_vrack.md
+++ b/docs/resources/cloud_network_private_vrack.md
@@ -12,9 +12,7 @@ Creates a private network (vRack) in a public cloud project.
 resource "ovh_cloud_network_private_vrack" "network" {
   service_name = "<public cloud project ID>"
   name         = "my-private-network"
-  location = {
-    region = "GRA1"
-  }
+  region       = "GRA1"
   description = "My private network"
   vlan_id     = 100
 }
@@ -26,8 +24,7 @@ The following arguments are supported:
 
 * `service_name` - (Required) Service name of the resource representing the id of the cloud project. **Changing this value recreates the resource.**
 * `name` - (Required) Network name.
-* `location` - (Required) Location of the network:
-  * `region` - (Required) Region where the network will be created. **Changing this value recreates the resource.**
+* `region` - (Required) Region where the network will be created. **Changing this value recreates the resource.**
 * `description` - (Optional) Network description. **Changing this value recreates the resource.**
 * `vlan_id` - (Optional) VLAN ID of the network (0-4096). Assigned by the API if not set. **Changing this value recreates the resource.** Not supported in localzone regions.
 

--- a/docs/resources/cloud_network_private_vrack_subnet.md
+++ b/docs/resources/cloud_network_private_vrack_subnet.md
@@ -22,10 +22,7 @@ resource "ovh_cloud_network_private_vrack_subnet" "subnet" {
   cidr         = "10.0.0.0/24"
   dhcp_enabled = true
   gateway_ip   = "10.0.0.1"
-
-  location = {
-    region = "GRA1"
-  }
+  region       = "GRA1"
 
   dns_nameservers = [
     "213.186.33.99",
@@ -48,9 +45,8 @@ The following arguments are supported:
 * `network_id` - (Required) Network ID of the parent private network. **Changing this value recreates the resource.**
 * `name` - (Required) Subnet name.
 * `cidr` - (Required) CIDR address range for the subnet (e.g. `10.0.0.0/24`). **Changing this value recreates the resource.**
-* `location` - (Required) Target location of the subnet:
-  * `region` - (Required) Region where the subnet will be created. **Changing this value recreates the resource.**
-  * `availability_zone` - (Optional) Availability zone within the region.
+* `region` - (Required) Region where the subnet will be created. **Changing this value recreates the resource.**
+* `availability_zone` - (Optional) Availability zone within the region.
 * `description` - (Optional) Subnet description.
 * `dhcp_enabled` - (Optional) Whether DHCP is enabled on the subnet.
 * `dns_nameservers` - (Optional) List of DNS nameserver addresses.

--- a/docs/resources/cloud_security_group.md
+++ b/docs/resources/cloud_security_group.md
@@ -74,7 +74,8 @@ The following attributes are exported:
 * `current_state` - Current state of the security group:
   * `name` - Name of the security group.
   * `description` - Description of the security group.
-  * `region` - Region of the security group.
+  * `location` - Location details:
+    * `region` - Region.
   * `rules` - User-specified security group rules with their IDs:
     * `id` - Rule ID.
     * `direction` - Direction of the rule.

--- a/ovh/data_cloud_gateway.go
+++ b/ovh/data_cloud_gateway.go
@@ -5,8 +5,10 @@ import (
 	"fmt"
 	"net/url"
 
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
 	ovhtypes "github.com/ovh/terraform-provider-ovh/v2/ovh/types"
 )
 
@@ -55,15 +57,21 @@ func (d *cloudGatewayDataSource) Schema(ctx context.Context, req datasource.Sche
 				Required:    true,
 				Description: "Gateway ID",
 			},
-			"region": schema.StringAttribute{
-				CustomType:  ovhtypes.TfStringType{},
+			"location": schema.SingleNestedAttribute{
 				Computed:    true,
-				Description: "Region of the gateway",
-			},
-			"availability_zone": schema.StringAttribute{
-				CustomType:  ovhtypes.TfStringType{},
-				Computed:    true,
-				Description: "Availability zone of the gateway",
+				Description: "Location of the gateway",
+				Attributes: map[string]schema.Attribute{
+					"region": schema.StringAttribute{
+						CustomType:  ovhtypes.TfStringType{},
+						Computed:    true,
+						Description: "Region",
+					},
+					"availability_zone": schema.StringAttribute{
+						CustomType:  ovhtypes.TfStringType{},
+						Computed:    true,
+						Description: "Availability zone",
+					},
+				},
 			},
 			"name": schema.StringAttribute{
 				CustomType:  ovhtypes.TfStringType{},
@@ -167,15 +175,21 @@ func (d *cloudGatewayDataSource) Schema(ctx context.Context, req datasource.Sche
 							},
 						},
 					},
-					"region": schema.StringAttribute{
-						CustomType:  ovhtypes.TfStringType{},
+					"location": schema.SingleNestedAttribute{
 						Computed:    true,
-						Description: "Region",
-					},
-					"availability_zone": schema.StringAttribute{
-						CustomType:  ovhtypes.TfStringType{},
-						Computed:    true,
-						Description: "Availability zone",
+						Description: "Location details",
+						Attributes: map[string]schema.Attribute{
+							"region": schema.StringAttribute{
+								CustomType:  ovhtypes.TfStringType{},
+								Computed:    true,
+								Description: "Region",
+							},
+							"availability_zone": schema.StringAttribute{
+								CustomType:  ovhtypes.TfStringType{},
+								Computed:    true,
+								Description: "Availability zone",
+							},
+						},
 					},
 				},
 			},
@@ -183,8 +197,26 @@ func (d *cloudGatewayDataSource) Schema(ctx context.Context, req datasource.Sche
 	}
 }
 
+// cloudGatewayDataSourceModel is the Terraform state model for this data source.
+// It mirrors the resource model but exposes the location as a nested object
+// (the gateway is fetched by ID, so region/AZ are computed, not user input).
+type cloudGatewayDataSourceModel struct {
+	ServiceName     ovhtypes.TfStringValue                             `tfsdk:"service_name"`
+	Id              ovhtypes.TfStringValue                             `tfsdk:"id"`
+	Location        types.Object                                       `tfsdk:"location"`
+	Name            ovhtypes.TfStringValue                             `tfsdk:"name"`
+	Description     ovhtypes.TfStringValue                             `tfsdk:"description"`
+	ExternalGateway types.Object                                       `tfsdk:"external_gateway"`
+	SubnetIds       ovhtypes.TfListNestedValue[ovhtypes.TfStringValue] `tfsdk:"subnet_ids"`
+	Checksum        ovhtypes.TfStringValue                             `tfsdk:"checksum"`
+	CreatedAt       ovhtypes.TfStringValue                             `tfsdk:"created_at"`
+	UpdatedAt       ovhtypes.TfStringValue                             `tfsdk:"updated_at"`
+	ResourceStatus  ovhtypes.TfStringValue                             `tfsdk:"resource_status"`
+	CurrentState    types.Object                                       `tfsdk:"current_state"`
+}
+
 func (d *cloudGatewayDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
-	var data CloudGatewayModel
+	var data cloudGatewayDataSourceModel
 
 	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
 	if resp.Diagnostics.HasError() {
@@ -202,7 +234,35 @@ func (d *cloudGatewayDataSource) Read(ctx context.Context, req datasource.ReadRe
 		return
 	}
 
-	data.MergeWith(ctx, &responseData)
+	// Reuse the resource model's mapping, then project it onto the data source
+	// model which exposes the location as a nested computed object.
+	var m CloudGatewayModel
+	m.ServiceName = data.ServiceName
+	m.Id = data.Id
+	m.MergeWith(ctx, &responseData)
+
+	locationVal, diags := types.ObjectValue(
+		gatewayLocationAttrTypes(),
+		map[string]attr.Value{
+			"region":            m.Region,
+			"availability_zone": m.AvailabilityZone,
+		},
+	)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	data.Location = locationVal
+	data.Name = m.Name
+	data.Description = m.Description
+	data.ExternalGateway = m.ExternalGateway
+	data.SubnetIds = m.SubnetIds
+	data.Checksum = m.Checksum
+	data.CreatedAt = m.CreatedAt
+	data.UpdatedAt = m.UpdatedAt
+	data.ResourceStatus = m.ResourceStatus
+	data.CurrentState = m.CurrentState
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }

--- a/ovh/data_cloud_gateway_test.go
+++ b/ovh/data_cloud_gateway_test.go
@@ -48,7 +48,7 @@ data "ovh_cloud_gateway" "test" {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("data.ovh_cloud_gateway.test", "service_name", serviceName),
 					resource.TestCheckResourceAttr("data.ovh_cloud_gateway.test", "name", gatewayName),
-					resource.TestCheckResourceAttr("data.ovh_cloud_gateway.test", "region", region),
+					resource.TestCheckResourceAttr("data.ovh_cloud_gateway.test", "location.region", region),
 					resource.TestCheckResourceAttr("data.ovh_cloud_gateway.test", "external_gateway.enabled", "true"),
 					resource.TestCheckResourceAttr("data.ovh_cloud_gateway.test", "external_gateway.model", gatewayModel),
 					resource.TestCheckResourceAttrSet("data.ovh_cloud_gateway.test", "id"),

--- a/ovh/data_cloud_gateways.go
+++ b/ovh/data_cloud_gateways.go
@@ -57,7 +57,9 @@ func GatewayListItemAttrTypes() map[string]attr.Type {
 		"id":          ovhtypes.TfStringType{},
 		"name":        ovhtypes.TfStringType{},
 		"description": ovhtypes.TfStringType{},
-		"region":      ovhtypes.TfStringType{},
+		"location": types.ObjectType{
+			AttrTypes: gatewayLocationAttrTypes(),
+		},
 		"external_gateway": types.ObjectType{
 			AttrTypes: ExternalGatewayAttrTypes(),
 		},
@@ -100,10 +102,21 @@ func (d *cloudGatewaysDataSource) Schema(ctx context.Context, req datasource.Sch
 							Computed:    true,
 							Description: "Gateway description",
 						},
-						"region": schema.StringAttribute{
-							CustomType:  ovhtypes.TfStringType{},
+						"location": schema.SingleNestedAttribute{
 							Computed:    true,
-							Description: "Region of the gateway",
+							Description: "Location of the gateway",
+							Attributes: map[string]schema.Attribute{
+								"region": schema.StringAttribute{
+									CustomType:  ovhtypes.TfStringType{},
+									Computed:    true,
+									Description: "Region",
+								},
+								"availability_zone": schema.StringAttribute{
+									CustomType:  ovhtypes.TfStringType{},
+									Computed:    true,
+									Description: "Availability zone",
+								},
+							},
 						},
 						"external_gateway": schema.SingleNestedAttribute{
 							Computed:    true,
@@ -192,15 +205,21 @@ func (d *cloudGatewaysDataSource) Schema(ctx context.Context, req datasource.Sch
 										},
 									},
 								},
-								"region": schema.StringAttribute{
-									CustomType:  ovhtypes.TfStringType{},
+								"location": schema.SingleNestedAttribute{
 									Computed:    true,
-									Description: "Region",
-								},
-								"availability_zone": schema.StringAttribute{
-									CustomType:  ovhtypes.TfStringType{},
-									Computed:    true,
-									Description: "Availability zone",
+									Description: "Location details",
+									Attributes: map[string]schema.Attribute{
+										"region": schema.StringAttribute{
+											CustomType:  ovhtypes.TfStringType{},
+											Computed:    true,
+											Description: "Region",
+										},
+										"availability_zone": schema.StringAttribute{
+											CustomType:  ovhtypes.TfStringType{},
+											Computed:    true,
+											Description: "Availability zone",
+										},
+									},
 								},
 							},
 						},
@@ -246,7 +265,7 @@ func (d *cloudGatewaysDataSource) Read(ctx context.Context, req datasource.ReadR
 func buildGatewayListItemObject(ctx context.Context, response *CloudGatewayAPIResponse) basetypes.ObjectValue {
 	nameVal := ovhtypes.TfStringValue{StringValue: types.StringNull()}
 	descVal := ovhtypes.TfStringValue{StringValue: types.StringNull()}
-	regionVal := ovhtypes.TfStringValue{StringValue: types.StringNull()}
+	locationVal := types.ObjectNull(gatewayLocationAttrTypes())
 	externalGatewayVal := types.ObjectNull(ExternalGatewayAttrTypes())
 
 	if response.TargetSpec != nil {
@@ -254,7 +273,13 @@ func buildGatewayListItemObject(ctx context.Context, response *CloudGatewayAPIRe
 		descVal = ovhtypes.TfStringValue{StringValue: types.StringValue(response.TargetSpec.Description)}
 
 		if response.TargetSpec.Location != nil {
-			regionVal = ovhtypes.TfStringValue{StringValue: types.StringValue(response.TargetSpec.Location.Region)}
+			locationVal, _ = types.ObjectValue(
+				gatewayLocationAttrTypes(),
+				map[string]attr.Value{
+					"region":            ovhtypes.TfStringValue{StringValue: types.StringValue(response.TargetSpec.Location.Region)},
+					"availability_zone": ovhtypes.TfStringValue{StringValue: types.StringValue(response.TargetSpec.Location.AvailabilityZone)},
+				},
+			)
 		}
 
 		if response.TargetSpec.ExternalGateway != nil {
@@ -285,7 +310,7 @@ func buildGatewayListItemObject(ctx context.Context, response *CloudGatewayAPIRe
 			"id":               ovhtypes.TfStringValue{StringValue: types.StringValue(response.Id)},
 			"name":             nameVal,
 			"description":      descVal,
-			"region":           regionVal,
+			"location":         locationVal,
 			"external_gateway": externalGatewayVal,
 			"checksum":         ovhtypes.TfStringValue{StringValue: types.StringValue(response.Checksum)},
 			"created_at":       ovhtypes.TfStringValue{StringValue: types.StringValue(response.CreatedAt)},

--- a/ovh/data_cloud_network_private_vrack_subnet_test.go
+++ b/ovh/data_cloud_network_private_vrack_subnet_test.go
@@ -20,9 +20,7 @@ func TestAccDataSourceCloudNetworkPrivateVrackSubnet_basic(t *testing.T) {
 resource "ovh_cloud_network_private_vrack" "network" {
   service_name = "%s"
   name         = "%s"
-  location = {
-	region = "%s"
-  }
+  region       = "%s"
 }
 
 resource "ovh_cloud_network_private_vrack_subnet" "test" {
@@ -31,9 +29,7 @@ resource "ovh_cloud_network_private_vrack_subnet" "test" {
   name         = "%s"
   cidr         = "10.0.0.0/24"
   dhcp_enabled = true
-  location = {
-    region = "%s"
-  }
+  region       = "%s"
 }
 
 data "ovh_cloud_network_private_vrack_subnet" "test" {

--- a/ovh/data_cloud_network_private_vrack_subnets_test.go
+++ b/ovh/data_cloud_network_private_vrack_subnets_test.go
@@ -20,9 +20,7 @@ func TestAccDataSourceCloudNetworkPrivateVrackSubnets_basic(t *testing.T) {
 resource "ovh_cloud_network_private_vrack" "network" {
   service_name = "%s"
   name         = "%s"
-  location = {
-	region = "%s"
-  }
+  region       = "%s"
 }
 
 resource "ovh_cloud_network_private_vrack_subnet" "test" {
@@ -31,9 +29,7 @@ resource "ovh_cloud_network_private_vrack_subnet" "test" {
   name         = "%s"
   cidr         = "10.0.0.0/24"
   dhcp_enabled = true
-  location = {
-    region = "%s"
-  }
+  region       = "%s"
 }
 
 data "ovh_cloud_network_private_vrack_subnets" "test" {

--- a/ovh/data_cloud_network_private_vrack_test.go
+++ b/ovh/data_cloud_network_private_vrack_test.go
@@ -19,9 +19,7 @@ func TestAccDataSourceCloudNetworkPrivateVrack_basic(t *testing.T) {
 resource "ovh_cloud_network_private_vrack" "test" {
   service_name = "%s"
   name         = "%s"
-  location = {
-    region = "%s"
-  }
+  region       = "%s"
 }
 
 data "ovh_cloud_network_private_vrack" "test" {

--- a/ovh/data_cloud_network_private_vracks_test.go
+++ b/ovh/data_cloud_network_private_vracks_test.go
@@ -19,9 +19,7 @@ func TestAccDataSourceCloudNetworkPrivateVracks_basic(t *testing.T) {
 resource "ovh_cloud_network_private_vrack" "test" {
   service_name = "%s"
   name         = "%s"
-  location = {
-    region = "%s"
-  }
+  region       = "%s"
 }
 
 data "ovh_cloud_network_private_vracks" "test" {

--- a/ovh/data_cloud_security_group.go
+++ b/ovh/data_cloud_security_group.go
@@ -5,8 +5,10 @@ import (
 	"fmt"
 	"net/url"
 
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
 	ovhtypes "github.com/ovh/terraform-provider-ovh/v2/ovh/types"
 )
 
@@ -108,10 +110,16 @@ func securityGroupDataSourceCurrentStateSchema() schema.SingleNestedAttribute {
 				Computed:    true,
 				Description: "Description of the security group",
 			},
-			"region": schema.StringAttribute{
-				CustomType:  ovhtypes.TfStringType{},
+			"location": schema.SingleNestedAttribute{
 				Computed:    true,
-				Description: "Region of the security group",
+				Description: "Location details",
+				Attributes: map[string]schema.Attribute{
+					"region": schema.StringAttribute{
+						CustomType:  ovhtypes.TfStringType{},
+						Computed:    true,
+						Description: "Region",
+					},
+				},
 			},
 			"rules": schema.ListNestedAttribute{
 				Computed:    true,
@@ -145,10 +153,16 @@ func (d *cloudSecurityGroupDataSource) Schema(ctx context.Context, req datasourc
 				Required:    true,
 				Description: "Security group ID",
 			},
-			"region": schema.StringAttribute{
-				CustomType:  ovhtypes.TfStringType{},
+			"location": schema.SingleNestedAttribute{
 				Computed:    true,
-				Description: "Region of the security group",
+				Description: "Location of the security group",
+				Attributes: map[string]schema.Attribute{
+					"region": schema.StringAttribute{
+						CustomType:  ovhtypes.TfStringType{},
+						Computed:    true,
+						Description: "Region",
+					},
+				},
 			},
 			"name": schema.StringAttribute{
 				CustomType:  ovhtypes.TfStringType{},
@@ -231,8 +245,25 @@ func (d *cloudSecurityGroupDataSource) Schema(ctx context.Context, req datasourc
 	}
 }
 
+// cloudSecurityGroupDataSourceModel is the Terraform state model for this data
+// source. It mirrors the resource model but exposes the location as a nested
+// object (the group is fetched by ID, so region is computed, not user input).
+type cloudSecurityGroupDataSourceModel struct {
+	ServiceName    ovhtypes.TfStringValue `tfsdk:"service_name"`
+	Id             ovhtypes.TfStringValue `tfsdk:"id"`
+	Location       types.Object           `tfsdk:"location"`
+	Name           ovhtypes.TfStringValue `tfsdk:"name"`
+	Description    ovhtypes.TfStringValue `tfsdk:"description"`
+	Rule           types.List             `tfsdk:"rule"`
+	Checksum       ovhtypes.TfStringValue `tfsdk:"checksum"`
+	CreatedAt      ovhtypes.TfStringValue `tfsdk:"created_at"`
+	UpdatedAt      ovhtypes.TfStringValue `tfsdk:"updated_at"`
+	ResourceStatus ovhtypes.TfStringValue `tfsdk:"resource_status"`
+	CurrentState   types.Object           `tfsdk:"current_state"`
+}
+
 func (d *cloudSecurityGroupDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
-	var data CloudSecurityGroupModel
+	var data cloudSecurityGroupDataSourceModel
 
 	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
 	if resp.Diagnostics.HasError() {
@@ -250,7 +281,33 @@ func (d *cloudSecurityGroupDataSource) Read(ctx context.Context, req datasource.
 		return
 	}
 
-	data.MergeWith(ctx, &responseData)
+	// Reuse the resource model's mapping, then project it onto the data source
+	// model which exposes the location as a nested computed object.
+	var m CloudSecurityGroupModel
+	m.ServiceName = data.ServiceName
+	m.Id = data.Id
+	m.MergeWith(ctx, &responseData)
+
+	locationVal, diags := types.ObjectValue(
+		securityGroupLocationAttrTypes(),
+		map[string]attr.Value{
+			"region": m.Region,
+		},
+	)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	data.Location = locationVal
+	data.Name = m.Name
+	data.Description = m.Description
+	data.Rule = m.Rule
+	data.Checksum = m.Checksum
+	data.CreatedAt = m.CreatedAt
+	data.UpdatedAt = m.UpdatedAt
+	data.ResourceStatus = m.ResourceStatus
+	data.CurrentState = m.CurrentState
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }

--- a/ovh/data_cloud_security_group_test.go
+++ b/ovh/data_cloud_security_group_test.go
@@ -52,7 +52,7 @@ data "ovh_cloud_security_group" "test" {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("data.ovh_cloud_security_group.test", "service_name", serviceName),
 					resource.TestCheckResourceAttr("data.ovh_cloud_security_group.test", "name", name),
-					resource.TestCheckResourceAttr("data.ovh_cloud_security_group.test", "region", region),
+					resource.TestCheckResourceAttr("data.ovh_cloud_security_group.test", "location.region", region),
 					resource.TestCheckResourceAttrPair(
 						"data.ovh_cloud_security_group.test", "id",
 						"ovh_cloud_security_group.test", "id",

--- a/ovh/data_cloud_security_groups.go
+++ b/ovh/data_cloud_security_groups.go
@@ -58,7 +58,9 @@ func SecurityGroupListItemAttrTypes() map[string]attr.Type {
 		"id":          ovhtypes.TfStringType{},
 		"name":        ovhtypes.TfStringType{},
 		"description": ovhtypes.TfStringType{},
-		"region":      ovhtypes.TfStringType{},
+		"location": types.ObjectType{
+			AttrTypes: securityGroupLocationAttrTypes(),
+		},
 		"rule": types.ListType{
 			ElemType: ruleObjType,
 		},
@@ -101,10 +103,16 @@ func (d *cloudSecurityGroupsDataSource) Schema(ctx context.Context, req datasour
 							Computed:    true,
 							Description: "Description of the security group",
 						},
-						"region": schema.StringAttribute{
-							CustomType:  ovhtypes.TfStringType{},
+						"location": schema.SingleNestedAttribute{
 							Computed:    true,
-							Description: "Region of the security group",
+							Description: "Location of the security group",
+							Attributes: map[string]schema.Attribute{
+								"region": schema.StringAttribute{
+									CustomType:  ovhtypes.TfStringType{},
+									Computed:    true,
+									Description: "Region",
+								},
+							},
 						},
 						"rule": schema.ListNestedAttribute{
 							Computed:    true,
@@ -215,7 +223,7 @@ func (d *cloudSecurityGroupsDataSource) Read(ctx context.Context, req datasource
 func buildSecurityGroupListItemObject(ctx context.Context, response *CloudSecurityGroupAPIResponse) basetypes.ObjectValue {
 	nameVal := ovhtypes.TfStringValue{StringValue: types.StringNull()}
 	descVal := ovhtypes.TfStringValue{StringValue: types.StringNull()}
-	regionVal := ovhtypes.TfStringValue{StringValue: types.StringNull()}
+	locationVal := types.ObjectNull(securityGroupLocationAttrTypes())
 	ruleVal := types.ListNull(types.ObjectType{AttrTypes: SecurityGroupRuleAttrTypes()})
 
 	if response.TargetSpec != nil {
@@ -226,7 +234,12 @@ func buildSecurityGroupListItemObject(ctx context.Context, response *CloudSecuri
 		}
 
 		if response.TargetSpec.Location != nil {
-			regionVal = ovhtypes.TfStringValue{StringValue: types.StringValue(response.TargetSpec.Location.Region)}
+			locationVal, _ = types.ObjectValue(
+				securityGroupLocationAttrTypes(),
+				map[string]attr.Value{
+					"region": ovhtypes.TfStringValue{StringValue: types.StringValue(response.TargetSpec.Location.Region)},
+				},
+			)
 		}
 
 		ruleVal = buildSecurityGroupTargetRulesList(response.TargetSpec.Rules)
@@ -245,7 +258,7 @@ func buildSecurityGroupListItemObject(ctx context.Context, response *CloudSecuri
 			"id":              ovhtypes.TfStringValue{StringValue: types.StringValue(response.Id)},
 			"name":            nameVal,
 			"description":     descVal,
-			"region":          regionVal,
+			"location":        locationVal,
 			"rule":            ruleVal,
 			"checksum":        ovhtypes.TfStringValue{StringValue: types.StringValue(response.Checksum)},
 			"created_at":      ovhtypes.TfStringValue{StringValue: types.StringValue(response.CreatedAt)},

--- a/ovh/resource_cloud_gateway.go
+++ b/ovh/resource_cloud_gateway.go
@@ -219,15 +219,21 @@ func (r *cloudGatewayResource) Schema(ctx context.Context, req resource.SchemaRe
 							},
 						},
 					},
-					"region": schema.StringAttribute{
-						CustomType:  ovhtypes.TfStringType{},
+					"location": schema.SingleNestedAttribute{
 						Computed:    true,
-						Description: "Region",
-					},
-					"availability_zone": schema.StringAttribute{
-						CustomType:  ovhtypes.TfStringType{},
-						Computed:    true,
-						Description: "Availability zone",
+						Description: "Location details",
+						Attributes: map[string]schema.Attribute{
+							"region": schema.StringAttribute{
+								CustomType:  ovhtypes.TfStringType{},
+								Computed:    true,
+								Description: "Region",
+							},
+							"availability_zone": schema.StringAttribute{
+								CustomType:  ovhtypes.TfStringType{},
+								Computed:    true,
+								Description: "Availability zone",
+							},
+						},
 					},
 				},
 			},

--- a/ovh/resource_cloud_gateway_test.go
+++ b/ovh/resource_cloud_gateway_test.go
@@ -248,9 +248,7 @@ func TestAccCloudGateway_withSubnets(t *testing.T) {
 resource "ovh_cloud_network_private_vrack" "network" {
   service_name = "%s"
   name         = "%s"
-  location = {
-    region = "%s"
-  }
+  region       = "%s"
 }
 
 resource "ovh_cloud_network_private_vrack_subnet" "subnet" {
@@ -259,9 +257,7 @@ resource "ovh_cloud_network_private_vrack_subnet" "subnet" {
   name         = "%s"
   cidr         = "10.0.0.0/24"
   dhcp_enabled = true
-  location = {
-    region = "%s"
-  }
+  region       = "%s"
 }
 
 resource "ovh_cloud_gateway" "test" {

--- a/ovh/resource_cloud_network_private_vrack.go
+++ b/ovh/resource_cloud_network_private_vrack.go
@@ -77,18 +77,12 @@ func (r *cloudNetworkPrivateVrackResource) Schema(ctx context.Context, req resou
 				Required:    true,
 				Description: "Network name",
 			},
-			"location": schema.SingleNestedAttribute{
+			"region": schema.StringAttribute{
+				CustomType:  ovhtypes.TfStringType{},
 				Required:    true,
-				Description: "Location of the network",
-				Attributes: map[string]schema.Attribute{
-					"region": schema.StringAttribute{
-						CustomType:  ovhtypes.TfStringType{},
-						Required:    true,
-						Description: "Region where the network will be created. Changing this value recreates the resource.",
-						PlanModifiers: []planmodifier.String{
-							stringplanmodifier.RequiresReplace(),
-						},
-					},
+				Description: "Region where the network will be created. Changing this value recreates the resource.",
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
 				},
 			},
 

--- a/ovh/resource_cloud_network_private_vrack_subnet.go
+++ b/ovh/resource_cloud_network_private_vrack_subnet.go
@@ -574,32 +574,20 @@ func CloudNetworkPrivateSubnetResourceSchema(ctx context.Context) schema.Schema 
 				stringplanmodifier.UseStateForUnknown(),
 			},
 		},
-		"location": schema.SingleNestedAttribute{
-			Attributes: map[string]schema.Attribute{
-				"availability_zone": schema.StringAttribute{
-					CustomType:          ovhtypes.TfStringType{},
-					Optional:            true,
-					Description:         "Availability zone within the region",
-					MarkdownDescription: "Availability zone within the region",
-				},
-				"region": schema.StringAttribute{
-					CustomType:          ovhtypes.TfStringType{},
-					Required:            true,
-					Description:         "Region code",
-					MarkdownDescription: "Region code",
-					PlanModifiers: []planmodifier.String{
-						stringplanmodifier.RequiresReplace(),
-					},
-				},
-			},
-			CustomType: TargetSpecLocationType{
-				ObjectType: types.ObjectType{
-					AttrTypes: TargetSpecLocationValue{}.AttributeTypes(ctx),
-				},
-			},
+		"region": schema.StringAttribute{
+			CustomType:          ovhtypes.TfStringType{},
 			Required:            true,
-			Description:         "Target location",
-			MarkdownDescription: "Target location",
+			Description:         "Region code",
+			MarkdownDescription: "Region code",
+			PlanModifiers: []planmodifier.String{
+				stringplanmodifier.RequiresReplace(),
+			},
+		},
+		"availability_zone": schema.StringAttribute{
+			CustomType:          ovhtypes.TfStringType{},
+			Optional:            true,
+			Description:         "Availability zone within the region",
+			MarkdownDescription: "Availability zone within the region",
 		},
 		"name": schema.StringAttribute{
 			CustomType:          ovhtypes.TfStringType{},
@@ -636,14 +624,15 @@ type CloudNetworkPrivateSubnetModel struct {
 	// the resource root. They carry json:"-" because the targetSpec object is
 	// (un)marshaled explicitly in MarshalJSON/UnmarshalJSON via the
 	// CloudNetworkPrivateSubnetTargetSpecValue DTO, never at the JSON root.
-	AllocationPools ovhtypes.TfListNestedValue[TargetSpecAllocationPoolsValue] `tfsdk:"allocation_pools" json:"-"`
-	Cidr            ovhtypes.TfStringValue                                     `tfsdk:"cidr" json:"-"`
-	Description     ovhtypes.TfStringValue                                     `tfsdk:"description" json:"-"`
-	DhcpEnabled     ovhtypes.TfBoolValue                                       `tfsdk:"dhcp_enabled" json:"-"`
-	DnsNameservers  ovhtypes.TfListNestedValue[ovhtypes.TfStringValue]         `tfsdk:"dns_nameservers" json:"-"`
-	GatewayIp       ovhtypes.TfStringValue                                     `tfsdk:"gateway_ip" json:"-"`
-	Location        TargetSpecLocationValue                                    `tfsdk:"location" json:"-"`
-	Name            ovhtypes.TfStringValue                                     `tfsdk:"name" json:"-"`
+	AllocationPools  ovhtypes.TfListNestedValue[TargetSpecAllocationPoolsValue] `tfsdk:"allocation_pools" json:"-"`
+	Cidr             ovhtypes.TfStringValue                                     `tfsdk:"cidr" json:"-"`
+	Description      ovhtypes.TfStringValue                                     `tfsdk:"description" json:"-"`
+	DhcpEnabled      ovhtypes.TfBoolValue                                       `tfsdk:"dhcp_enabled" json:"-"`
+	DnsNameservers   ovhtypes.TfListNestedValue[ovhtypes.TfStringValue]         `tfsdk:"dns_nameservers" json:"-"`
+	GatewayIp        ovhtypes.TfStringValue                                     `tfsdk:"gateway_ip" json:"-"`
+	Region           ovhtypes.TfStringValue                                     `tfsdk:"region" json:"-"`
+	AvailabilityZone ovhtypes.TfStringValue                                     `tfsdk:"availability_zone" json:"-"`
+	Name             ovhtypes.TfStringValue                                     `tfsdk:"name" json:"-"`
 }
 
 func (v *CloudNetworkPrivateSubnetModel) MergeWith(other *CloudNetworkPrivateSubnetModel) {
@@ -709,10 +698,12 @@ func (v *CloudNetworkPrivateSubnetModel) MergeWith(other *CloudNetworkPrivateSub
 		v.GatewayIp = other.GatewayIp
 	}
 
-	if v.Location.IsUnknown() && !other.Location.IsUnknown() {
-		v.Location = other.Location
-	} else if !other.Location.IsUnknown() {
-		v.Location.MergeWith(&other.Location)
+	if (v.Region.IsUnknown() || v.Region.IsNull()) && !other.Region.IsUnknown() {
+		v.Region = other.Region
+	}
+
+	if (v.AvailabilityZone.IsUnknown() || v.AvailabilityZone.IsNull()) && !other.AvailabilityZone.IsUnknown() {
+		v.AvailabilityZone = other.AvailabilityZone
 	}
 
 	if (v.Name.IsUnknown() || v.Name.IsNull()) && !other.Name.IsUnknown() {
@@ -723,7 +714,22 @@ func (v *CloudNetworkPrivateSubnetModel) MergeWith(other *CloudNetworkPrivateSub
 
 // targetSpecValue assembles the lifted root fields back into the
 // CloudNetworkPrivateSubnetTargetSpecValue DTO used for JSON (un)marshaling.
+//
+// location is create-only (immutable): the API rejects targetSpec.location on
+// PUT. We therefore build a known location only when region is set. On update,
+// the DTO's ToUpdate() drops the location, which clears the lifted region/AZ
+// (see ToUpdate), so region is null here and the location stays null — and the
+// DTO MarshalJSON omits a null location.
 func (v CloudNetworkPrivateSubnetModel) targetSpecValue() CloudNetworkPrivateSubnetTargetSpecValue {
+	location := NewTargetSpecLocationValueNull()
+	if !v.Region.IsNull() && !v.Region.IsUnknown() {
+		location = TargetSpecLocationValue{
+			AvailabilityZone: v.AvailabilityZone,
+			Region:           v.Region,
+			state:            attr.ValueStateKnown,
+		}
+	}
+
 	return CloudNetworkPrivateSubnetTargetSpecValue{
 		AllocationPools: v.AllocationPools,
 		Cidr:            v.Cidr,
@@ -731,7 +737,7 @@ func (v CloudNetworkPrivateSubnetModel) targetSpecValue() CloudNetworkPrivateSub
 		DhcpEnabled:     v.DhcpEnabled,
 		DnsNameservers:  v.DnsNameservers,
 		GatewayIp:       v.GatewayIp,
-		Location:        v.Location,
+		Location:        location,
 		Name:            v.Name,
 		state:           attr.ValueStateKnown,
 	}
@@ -747,7 +753,8 @@ func (v CloudNetworkPrivateSubnetModel) ToCreate() *CloudNetworkPrivateSubnetMod
 	res.DhcpEnabled = created.DhcpEnabled
 	res.DnsNameservers = created.DnsNameservers
 	res.GatewayIp = created.GatewayIp
-	res.Location = created.Location
+	res.Region = created.Location.Region
+	res.AvailabilityZone = created.Location.AvailabilityZone
 	res.Name = created.Name
 
 	return res
@@ -767,7 +774,8 @@ func (v CloudNetworkPrivateSubnetModel) ToUpdate() *CloudNetworkPrivateSubnetMod
 	res.DhcpEnabled = updated.DhcpEnabled
 	res.DnsNameservers = updated.DnsNameservers
 	res.GatewayIp = updated.GatewayIp
-	res.Location = updated.Location
+	res.Region = updated.Location.Region
+	res.AvailabilityZone = updated.Location.AvailabilityZone
 	res.Name = updated.Name
 
 	return res
@@ -826,7 +834,8 @@ func (v *CloudNetworkPrivateSubnetModel) UnmarshalJSON(data []byte) error {
 		v.DhcpEnabled = shadow.TargetSpec.DhcpEnabled
 		v.DnsNameservers = shadow.TargetSpec.DnsNameservers
 		v.GatewayIp = shadow.TargetSpec.GatewayIp
-		v.Location = shadow.TargetSpec.Location
+		v.Region = shadow.TargetSpec.Location.Region
+		v.AvailabilityZone = shadow.TargetSpec.Location.AvailabilityZone
 		v.Name = shadow.TargetSpec.Name
 	}
 

--- a/ovh/resource_cloud_network_private_vrack_subnet_test.go
+++ b/ovh/resource_cloud_network_private_vrack_subnet_test.go
@@ -48,9 +48,7 @@ func TestAccCloudNetworkPrivateVrackSubnet_basic(t *testing.T) {
 resource "ovh_cloud_network_private_vrack" "network" {
   service_name = "%s"
   name         = "terraform_testacc_private_net"
-  location     = {
-	region = "%s"
-  }
+  region       = "%s"
 }
 
 resource "ovh_cloud_network_private_vrack_subnet" "test" {
@@ -59,9 +57,7 @@ resource "ovh_cloud_network_private_vrack_subnet" "test" {
 
   name = "%s"
   cidr = "10.0.0.0/24"
-  location = {
-    region = "%s"
-  }
+  region       = "%s"
 }
 `, serviceName, region, subnetName, region)
 
@@ -78,7 +74,7 @@ resource "ovh_cloud_network_private_vrack_subnet" "test" {
 					resource.TestCheckResourceAttrSet("ovh_cloud_network_private_vrack_subnet.test", "network_id"),
 					resource.TestCheckResourceAttr("ovh_cloud_network_private_vrack_subnet.test", "name", subnetName),
 					resource.TestCheckResourceAttr("ovh_cloud_network_private_vrack_subnet.test", "cidr", "10.0.0.0/24"),
-					resource.TestCheckResourceAttr("ovh_cloud_network_private_vrack_subnet.test", "location.region", region),
+					resource.TestCheckResourceAttr("ovh_cloud_network_private_vrack_subnet.test", "region", region),
 					resource.TestCheckResourceAttrSet("ovh_cloud_network_private_vrack_subnet.test", "id"),
 					resource.TestCheckResourceAttrSet("ovh_cloud_network_private_vrack_subnet.test", "checksum"),
 					resource.TestCheckResourceAttrSet("ovh_cloud_network_private_vrack_subnet.test", "created_at"),
@@ -112,9 +108,7 @@ func TestAccCloudNetworkPrivateVrackSubnet_withAllOptions(t *testing.T) {
 resource "ovh_cloud_network_private_vrack" "network" {
   service_name = "%s"
   name         = "terraform_testacc_private_net"
-  location     = {
-    region = "%s"
-  }
+  region       = "%s"
 }
 
 resource "ovh_cloud_network_private_vrack_subnet" "test" {
@@ -126,9 +120,7 @@ resource "ovh_cloud_network_private_vrack_subnet" "test" {
   dhcp_enabled    = true
   gateway_ip      = "10.0.0.1"
   dns_nameservers = ["1.1.1.1", "8.8.8.8"]
-  location = {
-    region = "%s"
-  }
+  region       = "%s"
   allocation_pools = [
     {
       start = "10.0.0.10"
@@ -186,9 +178,7 @@ func TestAccCloudNetworkPrivateVrackSubnet_updateMutableFields(t *testing.T) {
 resource "ovh_cloud_network_private_vrack" "network" {
   service_name = "%s"
   name         = "terraform_testacc_private_net"
-  location     = {
-    region = "%s"
-  }
+  region       = "%s"
 }
 
 resource "ovh_cloud_network_private_vrack_subnet" "test" {
@@ -200,9 +190,7 @@ resource "ovh_cloud_network_private_vrack_subnet" "test" {
   description     = "initial description"
   dhcp_enabled    = false
   dns_nameservers = ["1.1.1.1"]
-  location = {
-    region = "%s"
-  }
+  region       = "%s"
 }
 `, serviceName, region, subnetName, region)
 
@@ -210,9 +198,7 @@ resource "ovh_cloud_network_private_vrack_subnet" "test" {
 resource "ovh_cloud_network_private_vrack" "network" {
   service_name = "%s"
   name         = "terraform_testacc_private_net"
-  location     = {
-	region = "%s"
-  }
+  region       = "%s"
 }
 
 resource "ovh_cloud_network_private_vrack_subnet" "test" {
@@ -224,9 +210,7 @@ resource "ovh_cloud_network_private_vrack_subnet" "test" {
   description     = "updated description"
   dhcp_enabled    = true
   dns_nameservers = ["8.8.8.8", "8.8.4.4"]
-  location = {
-    region = "%s"
-  }
+  region       = "%s"
 }
 `, serviceName, region, updatedName, region)
 
@@ -275,9 +259,7 @@ func TestAccCloudNetworkPrivateVrackSubnet_update(t *testing.T) {
 resource "ovh_cloud_network_private_vrack" "network" {
   service_name = "%s"
   name         = "terraform_testacc_private_net"
-  location     = {
-    region = "%s"
-  }
+  region       = "%s"
 }
 
 resource "ovh_cloud_network_private_vrack_subnet" "test" {
@@ -287,9 +269,7 @@ resource "ovh_cloud_network_private_vrack_subnet" "test" {
   name        = "%s"
   cidr        = "10.0.0.0/24"
   description = "initial description"
-  location = {
-    region = "%s"
-  }
+  region       = "%s"
 }
 `, serviceName, region, subnetName, region)
 
@@ -297,9 +277,7 @@ resource "ovh_cloud_network_private_vrack_subnet" "test" {
 resource "ovh_cloud_network_private_vrack" "network" {
   service_name = "%s"
   name         = "terraform_testacc_private_net"
-  location     = {
-    region = "%s"
-  }
+  region       = "%s"
 }
 
 resource "ovh_cloud_network_private_vrack_subnet" "test" {
@@ -309,9 +287,7 @@ resource "ovh_cloud_network_private_vrack_subnet" "test" {
   name        = "%s"
   cidr        = "10.0.0.0/24"
   description = "updated description"
-  location = {
-    region = "%s"
-  }
+  region       = "%s"
 }
 `, serviceName, region, updatedName, region)
 

--- a/ovh/resource_cloud_network_private_vrack_test.go
+++ b/ovh/resource_cloud_network_private_vrack_test.go
@@ -42,9 +42,7 @@ func TestAccCloudNetworkPrivateVrack_basic(t *testing.T) {
 resource "ovh_cloud_network_private_vrack" "test" {
   service_name = "%s"
   name         = "%s"
-  location = {
-    region = "%s"
-  }
+  region       = "%s"
 }
 `, serviceName, networkName, region)
 
@@ -59,7 +57,7 @@ resource "ovh_cloud_network_private_vrack" "test" {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("ovh_cloud_network_private_vrack.test", "service_name", serviceName),
 					resource.TestCheckResourceAttr("ovh_cloud_network_private_vrack.test", "name", networkName),
-					resource.TestCheckResourceAttr("ovh_cloud_network_private_vrack.test", "location.region", region),
+					resource.TestCheckResourceAttr("ovh_cloud_network_private_vrack.test", "region", region),
 					resource.TestCheckResourceAttrSet("ovh_cloud_network_private_vrack.test", "id"),
 					resource.TestCheckResourceAttrSet("ovh_cloud_network_private_vrack.test", "checksum"),
 					resource.TestCheckResourceAttrSet("ovh_cloud_network_private_vrack.test", "created_at"),
@@ -89,9 +87,7 @@ func TestAccCloudNetworkPrivateVrack_withDescription(t *testing.T) {
 resource "ovh_cloud_network_private_vrack" "test" {
   service_name = "%s"
   name         = "%s"
-  location = {
-    region = "%s"
-  }
+  region       = "%s"
   description  = "network created by acceptance test"
 }
 `, serviceName, networkName, region)
@@ -134,9 +130,7 @@ func TestAccCloudNetworkPrivateVrack_withVlanId(t *testing.T) {
 resource "ovh_cloud_network_private_vrack" "test" {
   service_name = "%s"
   name         = "%s"
-  location = {
-    region = "%s"
-  }
+  region       = "%s"
   vlan_id = %d
 }
 `, serviceName, networkName, region, vlanId)
@@ -179,9 +173,7 @@ func TestAccCloudNetworkPrivateVrack_update(t *testing.T) {
 resource "ovh_cloud_network_private_vrack" "test" {
   service_name = "%s"
   name         = "%s"
-  location = {
-    region = "%s"
-  }
+  region       = "%s"
 }
 `, serviceName, networkName, region)
 
@@ -189,9 +181,7 @@ resource "ovh_cloud_network_private_vrack" "test" {
 resource "ovh_cloud_network_private_vrack" "test" {
   service_name = "%s"
   name         = "%s"
-  location = {
-    region = "%s"
-  }
+  region       = "%s"
 }
 `, serviceName, updatedName, region)
 

--- a/ovh/resource_cloud_security_group.go
+++ b/ovh/resource_cloud_security_group.go
@@ -250,11 +250,17 @@ func (r *cloudSecurityGroupResource) Schema(ctx context.Context, req resource.Sc
 						Description:         "Description of the security group",
 						MarkdownDescription: "Description of the security group",
 					},
-					"region": schema.StringAttribute{
-						CustomType:          ovhtypes.TfStringType{},
-						Computed:            true,
-						Description:         "Region of the security group",
-						MarkdownDescription: "Region of the security group",
+					"location": schema.SingleNestedAttribute{
+						Computed:    true,
+						Description: "Location details",
+						Attributes: map[string]schema.Attribute{
+							"region": schema.StringAttribute{
+								CustomType:          ovhtypes.TfStringType{},
+								Computed:            true,
+								Description:         "Region code",
+								MarkdownDescription: "Region code",
+							},
+						},
 					},
 					"rules": schema.ListNestedAttribute{
 						Computed:    true,

--- a/ovh/resource_cloud_security_group_test.go
+++ b/ovh/resource_cloud_security_group_test.go
@@ -84,7 +84,7 @@ resource "ovh_cloud_security_group" "test" {
 					resource.TestCheckResourceAttr("ovh_cloud_security_group.test", "resource_status", "READY"),
 					// current_state must reflect the created rule, with an OpenStack-assigned rule ID
 					resource.TestCheckResourceAttr("ovh_cloud_security_group.test", "current_state.name", name),
-					resource.TestCheckResourceAttr("ovh_cloud_security_group.test", "current_state.region", region),
+					resource.TestCheckResourceAttr("ovh_cloud_security_group.test", "current_state.location.region", region),
 					resource.TestCheckResourceAttr("ovh_cloud_security_group.test", "current_state.rules.#", "1"),
 					resource.TestCheckResourceAttrSet("ovh_cloud_security_group.test", "current_state.rules.0.id"),
 				),

--- a/ovh/types_cloud_gateway.go
+++ b/ovh/types_cloud_gateway.go
@@ -198,6 +198,15 @@ func gatewaySubnetAttrTypes() map[string]attr.Type {
 	}
 }
 
+// gatewayLocationAttrTypes returns the attribute types for the nested location
+// object exposed by the current_state and the data sources.
+func gatewayLocationAttrTypes() map[string]attr.Type {
+	return map[string]attr.Type{
+		"region":            ovhtypes.TfStringType{},
+		"availability_zone": ovhtypes.TfStringType{},
+	}
+}
+
 // GatewayCurrentStateAttrTypes returns the attribute types for the current_state object
 func GatewayCurrentStateAttrTypes() map[string]attr.Type {
 	return map[string]attr.Type{
@@ -213,8 +222,9 @@ func GatewayCurrentStateAttrTypes() map[string]attr.Type {
 				AttrTypes: gatewaySubnetAttrTypes(),
 			},
 		},
-		"region":            ovhtypes.TfStringType{},
-		"availability_zone": ovhtypes.TfStringType{},
+		"location": types.ObjectType{
+			AttrTypes: gatewayLocationAttrTypes(),
+		},
 	}
 }
 
@@ -240,14 +250,16 @@ func buildGatewayCurrentStateObject(ctx context.Context, state *CloudGatewayAPIC
 		subnetsVal = types.ListNull(subnetObjType)
 	}
 
-	// Build region and availability_zone from location
-	regionVal := ovhtypes.TfStringValue{StringValue: types.StringValue("")}
-	azVal := ovhtypes.TfStringValue{StringValue: types.StringValue("")}
+	// Build the nested location object from the API location
+	locationVal := types.ObjectNull(gatewayLocationAttrTypes())
 	if state.Location != nil {
-		regionVal = ovhtypes.TfStringValue{StringValue: types.StringValue(state.Location.Region)}
-		if state.Location.AvailabilityZone != "" {
-			azVal = ovhtypes.TfStringValue{StringValue: types.StringValue(state.Location.AvailabilityZone)}
-		}
+		locationVal, _ = types.ObjectValue(
+			gatewayLocationAttrTypes(),
+			map[string]attr.Value{
+				"region":            ovhtypes.TfStringValue{StringValue: types.StringValue(state.Location.Region)},
+				"availability_zone": ovhtypes.TfStringValue{StringValue: types.StringValue(state.Location.AvailabilityZone)},
+			},
+		)
 	}
 
 	// Build external_gateway object
@@ -277,14 +289,13 @@ func buildGatewayCurrentStateObject(ctx context.Context, state *CloudGatewayAPIC
 	currentStateObj, _ := types.ObjectValue(
 		GatewayCurrentStateAttrTypes(),
 		map[string]attr.Value{
-			"name":              ovhtypes.TfStringValue{StringValue: types.StringValue(state.Name)},
-			"description":       ovhtypes.TfStringValue{StringValue: types.StringValue(state.Description)},
-			"status":            ovhtypes.TfStringValue{StringValue: types.StringValue(state.Status)},
-			"external_gateway":  externalGatewayVal,
-			"external_ip":       ovhtypes.TfStringValue{StringValue: types.StringValue(state.ExternalIP)},
-			"subnets":           subnetsVal,
-			"region":            regionVal,
-			"availability_zone": azVal,
+			"name":             ovhtypes.TfStringValue{StringValue: types.StringValue(state.Name)},
+			"description":      ovhtypes.TfStringValue{StringValue: types.StringValue(state.Description)},
+			"status":           ovhtypes.TfStringValue{StringValue: types.StringValue(state.Status)},
+			"external_gateway": externalGatewayVal,
+			"external_ip":      ovhtypes.TfStringValue{StringValue: types.StringValue(state.ExternalIP)},
+			"subnets":          subnetsVal,
+			"location":         locationVal,
 		},
 	)
 

--- a/ovh/types_cloud_network_private_vrack.go
+++ b/ovh/types_cloud_network_private_vrack.go
@@ -14,7 +14,7 @@ type CloudNetworkPrivateVrackModel struct {
 	// Required
 	ServiceName ovhtypes.TfStringValue `tfsdk:"service_name"`
 	Name        ovhtypes.TfStringValue `tfsdk:"name"`
-	Location    types.Object           `tfsdk:"location"`
+	Region      ovhtypes.TfStringValue `tfsdk:"region"`
 
 	// Optional
 	Description ovhtypes.TfStringValue `tfsdk:"description"`
@@ -81,34 +81,12 @@ func vrackLocationAttrTypes() map[string]attr.Type {
 	}
 }
 
-// vrackLocationRegion extracts the region value out of a root-level location
-// object. It returns an empty string when the object is null/unknown or does
-// not contain a region attribute.
-func vrackLocationRegion(location types.Object) string {
-	if location.IsNull() || location.IsUnknown() {
-		return ""
-	}
-
-	attrs := location.Attributes()
-	regionAttr, ok := attrs["region"]
-	if !ok {
-		return ""
-	}
-
-	region, ok := regionAttr.(ovhtypes.TfStringValue)
-	if !ok {
-		return ""
-	}
-
-	return region.ValueString()
-}
-
 // ToCreate converts the Terraform model to the API create payload
 func (m *CloudNetworkPrivateVrackModel) ToCreate() *CloudNetworkCreatePayload {
 	targetSpec := &CloudNetworkAPITargetSpec{
 		Name: m.Name.ValueString(),
 		Location: &CloudNetworkAPILocation{
-			Region: vrackLocationRegion(m.Location),
+			Region: m.Region.ValueString(),
 		},
 	}
 
@@ -182,14 +160,7 @@ func (m *CloudNetworkPrivateVrackModel) MergeWith(ctx context.Context, response 
 		}
 
 		if response.TargetSpec.Location != nil {
-			m.Location, _ = types.ObjectValue(
-				vrackLocationAttrTypes(),
-				map[string]attr.Value{
-					"region": ovhtypes.TfStringValue{StringValue: types.StringValue(response.TargetSpec.Location.Region)},
-				},
-			)
-		} else {
-			m.Location = types.ObjectNull(vrackLocationAttrTypes())
+			m.Region = ovhtypes.TfStringValue{StringValue: types.StringValue(response.TargetSpec.Location.Region)}
 		}
 	}
 }

--- a/ovh/types_cloud_security_group.go
+++ b/ovh/types_cloud_security_group.go
@@ -210,6 +210,14 @@ func SecurityGroupCurrentStateRuleAttrTypes() map[string]attr.Type {
 	}
 }
 
+// securityGroupLocationAttrTypes returns the attribute types for the nested
+// location object exposed by the current_state and the data sources.
+func securityGroupLocationAttrTypes() map[string]attr.Type {
+	return map[string]attr.Type{
+		"region": ovhtypes.TfStringType{},
+	}
+}
+
 // SecurityGroupCurrentStateAttrTypes returns the attribute types for current_state
 func SecurityGroupCurrentStateAttrTypes() map[string]attr.Type {
 	ruleObjType := types.ObjectType{
@@ -218,7 +226,9 @@ func SecurityGroupCurrentStateAttrTypes() map[string]attr.Type {
 	return map[string]attr.Type{
 		"name":        ovhtypes.TfStringType{},
 		"description": ovhtypes.TfStringType{},
-		"region":      ovhtypes.TfStringType{},
+		"location": types.ObjectType{
+			AttrTypes: securityGroupLocationAttrTypes(),
+		},
 		"rules": types.ListType{
 			ElemType: ruleObjType,
 		},
@@ -358,9 +368,14 @@ func buildSecurityGroupTargetRulesList(rules []CloudSecurityGroupAPITargetRule) 
 }
 
 func buildSecurityGroupCurrentStateObject(ctx context.Context, state *CloudSecurityGroupAPICurrentState) types.Object {
-	region := ""
+	locationVal := types.ObjectNull(securityGroupLocationAttrTypes())
 	if state.Location != nil {
-		region = state.Location.Region
+		locationVal, _ = types.ObjectValue(
+			securityGroupLocationAttrTypes(),
+			map[string]attr.Value{
+				"region": ovhtypes.TfStringValue{StringValue: types.StringValue(state.Location.Region)},
+			},
+		)
 	}
 
 	obj, _ := types.ObjectValue(
@@ -368,7 +383,7 @@ func buildSecurityGroupCurrentStateObject(ctx context.Context, state *CloudSecur
 		map[string]attr.Value{
 			"name":          ovhtypes.TfStringValue{StringValue: types.StringValue(state.Name)},
 			"description":   ovhtypes.TfStringValue{StringValue: types.StringValue(state.Description)},
-			"region":        ovhtypes.TfStringValue{StringValue: types.StringValue(region)},
+			"location":      locationVal,
 			"rules":         buildStateRulesList(state.Rules),
 			"default_rules": buildStateRulesList(state.DefaultRules),
 		},


### PR DESCRIPTION
# Description

Realign the design of all apiv2 resources and datasources for the `region`, `availability_zone` and `location` fields.

## Type of change

- [x] Improvement (improve existing resource(s) or datasource(s))

# How Has This Been Tested?

```
=== RUN   TestAccDataSourceCloudGateway_basic
--- PASS: TestAccDataSourceCloudGateway_basic (34.95s)
=== RUN   TestAccDataSourceCloudGateways_basic
--- PASS: TestAccDataSourceCloudGateways_basic (35.67s)
=== RUN   TestAccCloudGateway_basic
--- PASS: TestAccCloudGateway_basic (33.91s)
=== RUN   TestAccCloudGateway_update
--- PASS: TestAccCloudGateway_update (45.83s)
=== RUN   TestAccCloudGateway_disabledExternalGateway
--- PASS: TestAccCloudGateway_disabledExternalGateway (28.50s)
=== RUN   TestAccCloudGateway_updateExternalGatewayModel
--- PASS: TestAccCloudGateway_updateExternalGatewayModel (46.48s)
=== RUN   TestAccCloudGateway_withSubnets
--- PASS: TestAccCloudGateway_withSubnets (83.18s)
=== RUN   TestAccCloudNetworkPrivateVrackSubnet_basic
--- PASS: TestAccCloudNetworkPrivateVrackSubnet_basic (36.57s)
=== RUN   TestAccCloudNetworkPrivateVrackSubnet_withAllOptions
--- PASS: TestAccCloudNetworkPrivateVrackSubnet_withAllOptions (36.59s)
=== RUN   TestAccCloudNetworkPrivateVrackSubnet_updateMutableFields
--- PASS: TestAccCloudNetworkPrivateVrackSubnet_updateMutableFields (40.42s)
=== RUN   TestAccCloudNetworkPrivateVrackSubnet_update
--- PASS: TestAccCloudNetworkPrivateVrackSubnet_update (40.48s)
=== RUN   TestAccCloudNetworkPrivateVrack_basic
--- PASS: TestAccCloudNetworkPrivateVrack_basic (24.10s)
=== RUN   TestAccCloudNetworkPrivateVrack_withDescription
--- PASS: TestAccCloudNetworkPrivateVrack_withDescription (23.82s)
=== RUN   TestAccCloudNetworkPrivateVrack_withVlanId
--- PASS: TestAccCloudNetworkPrivateVrack_withVlanId (23.71s)
=== RUN   TestAccCloudNetworkPrivateVrack_update
--- PASS: TestAccCloudNetworkPrivateVrack_update (36.61s)
=== RUN   TestAccCloudSecurityGroup_basic
--- PASS: TestAccCloudSecurityGroup_basic (23.33s)
=== RUN   TestAccCloudSecurityGroup_update
--- PASS: TestAccCloudSecurityGroup_update (48.13s)
=== RUN   TestAccCloudSecurityGroup_noRules
--- PASS: TestAccCloudSecurityGroup_noRules (23.36s)
=== RUN   TestAccCloudSecurityGroup_comprehensive
--- PASS: TestAccCloudSecurityGroup_comprehensive (23.42s)
=== RUN   TestAccCloudSecurityGroup_remoteGroup
--- PASS: TestAccCloudSecurityGroup_remoteGroup (44.38s)
PASS
ok
```

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or issues
- [x] I have added acceptance tests that prove my fix is effective or that my feature works
- [x] New and existing acceptance tests pass locally with my changes
- [x] I ran successfully `go mod vendor` if I added or modify `go.mod` file
