### PR TITLE
On loadbalancing ressource, considered value 0 like a real value and …

### DIFF
--- a/ovh/types_iploadbalancing.go
+++ b/ovh/types_iploadbalancing.go
@@ -253,7 +253,7 @@ type IPLoadbalancingHttpRouteOpts struct {
 	Action      IPLoadbalancingHttpRouteActionOpts `json:"action"`                //Action triggered when all rules match
 	DisplayName *string                            `json:"displayName,omitempty"` //Human readable name for your route, this field is for you
 	FrontendId  *int64                             `json:"frontendId,omitempty"`  //Route traffic for this frontend
-	Weight      *int64                             `json:"weight,omitempty"`      //Route priority ([0..255]). 0 if null. Highest priority routes are evaluated first. Only the first matching route will trigger an action
+    Weight      *int64                             `json:"weight"`                //Route priority ([0..255]). 0 if null. Highest priority routes are evaluated first. Only the first matching route will trigger an action
 }
 
 func (opts *IPLoadbalancingHttpRouteOpts) FromResource(d *schema.ResourceData) *IPLoadbalancingHttpRouteOpts {
@@ -265,7 +265,8 @@ func (opts *IPLoadbalancingHttpRouteOpts) FromResource(d *schema.ResourceData) *
 	}
 
 	opts.FrontendId = helpers.GetNilInt64PointerFromData(d, "frontend_id")
-	opts.Weight = helpers.GetNilInt64PointerFromData(d, "weight")
+    weight := int64(d.Get("weight").(int))
+    opts.Weight = &weight
 
 	return opts
 }
@@ -348,7 +349,7 @@ type IPLoadbalancingTcpRouteOpts struct {
 	Action      IPLoadbalancingTcpRouteActionOpts `json:"action"`                //Action triggered when all rules match
 	DisplayName *string                           `json:"displayName,omitempty"` //Human readable name for your route, this field is for you
 	FrontendId  *int64                            `json:"frontendId,omitempty"`  //Route traffic for this frontend
-	Weight      *int64                            `json:"weight,omitempty"`      //Route priority ([0..255]). 0 if null. Highest priority routes are evaluated first. Only the first matching route will trigger an action
+    Weight      *int64                            `json:"weight"`                //Route priority ([0..255]). 0 if null. Highest priority routes are evaluated first. Only the first matching route will trigger an action
 }
 
 func (opts *IPLoadbalancingTcpRouteOpts) FromResource(d *schema.ResourceData) *IPLoadbalancingTcpRouteOpts {
@@ -360,7 +361,8 @@ func (opts *IPLoadbalancingTcpRouteOpts) FromResource(d *schema.ResourceData) *I
 	}
 
 	opts.FrontendId = helpers.GetNilInt64PointerFromData(d, "frontend_id")
-	opts.Weight = helpers.GetNilInt64PointerFromData(d, "weight")
+    weight := int64(d.Get("weight").(int))
+    opts.Weight = &weight
 
 	return opts
 }


### PR DESCRIPTION
…not nil

# Description

For this patch, regarding the `weight` parameter of `ovh_iploadbalancing` resources, we treat 0 as a valid value—rather than a null value—in order to resolve the following issue:

Fixes need:

FYI there's an annoying issue with the Terraform provider.
If I have a route with a weight of 60.
I want to update it to 0 (zero).
If you want to switch the weight of a route from 60 to 0, applying the plan with the provider is a noop.
(noop for the Terraform state and noop for the OVH API object).

I'm forced to use the API directly to accomplish

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

For the test, I have run 3 plan terraform with a inital weight to 0, then 10 and to finish 0, the goal is to find 0 again on api side

Multiple terraform applied :
- First run

```
resource "ovh_iploadbalancing_http_route" "to_nginx001_test" {
  service_name = "loadbalancer-XXX"
  display_name = "https to nginx001"
  weight       = 0
  frontend_id  = "193856"
  action {
    target = "264305"
    type   = "farm"
  }
}
```

api result:
```
{
  "weight": 0,
....
```

- Second run

```
resource "ovh_iploadbalancing_http_route" "to_nginx001_test" {
  service_name = "loadbalancer-XXX"
  display_name = "https to nginx001"
  weight       = 10
  frontend_id  = "193856"
  action {
    target = "264305"
    type   = "farm"
  }
}
```

api result:
```
{
  "weight": 10,
....
```


- last run

```
resource "ovh_iploadbalancing_http_route" "to_nginx001_test" {
  service_name = "loadbalancer-XXX"
  display_name = "https to nginx001"
  weight       = 0
  frontend_id  = "193856"
  action {
    target = "264305"
    type   = "farm"
  }
}
```

api result:
```
{
  "weight": 0,
....
```


**Test Configuration**:
* Terraform version: `terraform version`: Terraform 1.10.5


# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings or issues
- [ ] I have added acceptance tests that prove my fix is effective or that my feature works
- [ ] New and existing acceptance tests pass locally with my changes
- [ ] I ran successfully `go mod vendor` if I added or modify `go.mod` file
