### PR TITLE
fix(cloud_project_database): Avoid perpetual diffs on advanced_configuration parameter changes

### DIFF
--- a/ovh/resource_cloud_project_database.go
+++ b/ovh/resource_cloud_project_database.go
@@ -379,7 +379,16 @@ func resourceCloudProjectDatabaseRead(ctx context.Context, d *schema.ResourceDat
 		if err := config.OVHClient.GetWithContext(ctx, advancedConfigEndpoint, advancedConfigMap); err != nil {
 			return diag.Errorf("unable to get database %s advanced configuration: %v", res.ID, err)
 		}
-		res.AdvancedConfiguration = *advancedConfigMap
+		// Only retain keys that are explicitly configured to avoid perpetual diffs
+		// caused by API-returned defaults that the user never set.
+		configuredKeys := d.Get("advanced_configuration").(map[string]interface{})
+		filtered := make(map[string]string, len(configuredKeys))
+		for k, v := range *advancedConfigMap {
+			if _, ok := configuredKeys[k]; ok {
+				filtered[k] = v
+			}
+		}
+		res.AdvancedConfiguration = filtered
 	}
 
 	for k, v := range res.toMap() {


### PR DESCRIPTION
# Description

When a user sets only a subset of keys in advanced_configuration, the OVH API returns additional default values (e.g. pg.io_combine_limit, pg.io_max_combine_limit, pglookout.max_failover_replication_time_lag, …) that were never explicitly configured. The Read function stored all of them in state, causing Terraform to plan their removal on every subsequent run.

If I run a plan without any modification :
```
  # module.database.ovh_cloud_project_database.database will be updated in-place
  ~ resource "ovh_cloud_project_database" "database" {
      ~ advanced_configuration  = {
          - "pg.io_combine_limit"                         = "16" -> null
          - "pg.io_max_combine_limit"                     = "16" -> null
          - "pg.io_max_concurrency"                       = "-1" -> null
          - "pg.io_method"                                = "worker" -> null
          - "pg.io_workers"                               = "3" -> null
          - "pglookout.max_failover_replication_time_lag" = "60" -> null
            # (1 unchanged element hidden)
        }
        id                      = "1922f1f4-8ae1-2cc5-8fd3-ba10a8b99d40"
        # (19 unchanged attributes hidden)

        # (2 unchanged blocks hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.
```

Fix: after fetching the advanced configuration map from the API, filter it to only retain keys that are explicitly present in the resource configuration. This prevents API-returned defaults from polluting the state and eliminates the perpetual diff.

## Type of change

Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] Test A: `tofu plan with old version always produce change`
- [x] Test B: `tofu plan with new version produce change only when I change advanced_configuration key`

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or issues
- [x] New and existing acceptance tests pass locally with my changes
