### PR TITLE
feat: Add new cloud floating IPs resources and datasources

### DIFF
--- a/docs/data-sources/cloud_additional_ip.md
+++ b/docs/data-sources/cloud_additional_ip.md
@@ -1,0 +1,51 @@
+---
+subcategory : "Public IPs"
+---
+
+# ovh_cloud_additional_ip (Data Source)
+
+Use this data source to retrieve information about an additional IP in a public cloud project. Additional IPs are created and deleted through the lifecycle of other products (typically instances they are attached to), so this data source is a read-only view.
+
+## Example Usage
+
+```terraform
+data "ovh_cloud_additional_ip" "ip" {
+  service_name = "<public cloud project ID>"
+  id           = "<additional IP address>"
+}
+
+output "additional_ip_status" {
+  value = data.ovh_cloud_additional_ip.ip.resource_status
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `service_name` - (Required) Service name of the resource representing the id of the cloud project.
+* `id` - (Required) IP address of the additional IP.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `checksum` - Checksum field of the API envelope. Always empty for this read-only IP type.
+* `resource_status` - Additional IP readiness in the system (`CREATING`, `DELETING`, `ERROR`, `OUT_OF_SYNC`, `READY`, `UNKNOWN`, `UPDATING`).
+* `current_state` - Current state of the additional IP:
+  * `id` - Identifier of the additional IP.
+  * `ip` - IP address of the additional IP.
+  * `ip_block` - IP block the additional IP belongs to. May be null.
+  * `associated_resource` - Resource the additional IP is currently attached to. Null when the IP is not attached to any resource:
+    * `id` - ID of the associated resource.
+    * `type` - Type of the associated resource.
+  * `location` - Location details:
+    * `region` - Region.
+    * `availability_zone` - Availability zone.
+* `current_tasks` - Ongoing asynchronous tasks related to the additional IP. Each element exports:
+  * `id` - Identifier of the current task.
+  * `link` - Link to the task details.
+  * `status` - Current global status of the current task.
+  * `type` - Type of the current task.
+  * `errors` - Errors that occurred on the task:
+    * `message` - Error description.

--- a/docs/data-sources/cloud_additional_ips.md
+++ b/docs/data-sources/cloud_additional_ips.md
@@ -1,0 +1,51 @@
+---
+subcategory : "Public IPs"
+---
+
+# ovh_cloud_additional_ips (Data Source)
+
+Use this data source to list the additional IPs of a public cloud project. Additional IPs are created and deleted through the lifecycle of other products (typically instances they are attached to), so this data source is a read-only view.
+
+## Example Usage
+
+```terraform
+data "ovh_cloud_additional_ips" "ips" {
+  service_name = "<public cloud project ID>"
+}
+
+output "additional_ip_addresses" {
+  value = [for ip in data.ovh_cloud_additional_ips.ips.additional_ips : ip.id]
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `service_name` - (Required) Service name of the resource representing the id of the cloud project.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `additional_ips` - List of additional IPs. Each element exports:
+  * `id` - IP address of the additional IP.
+  * `checksum` - Checksum field of the API envelope. Always empty for this read-only IP type.
+  * `resource_status` - Additional IP readiness in the system (`CREATING`, `DELETING`, `ERROR`, `OUT_OF_SYNC`, `READY`, `UNKNOWN`, `UPDATING`).
+  * `current_state` - Current state of the additional IP:
+    * `id` - Identifier of the additional IP.
+    * `ip` - IP address of the additional IP.
+    * `ip_block` - IP block the additional IP belongs to. May be null.
+    * `associated_resource` - Resource the additional IP is currently attached to. Null when the IP is not attached to any resource:
+      * `id` - ID of the associated resource.
+      * `type` - Type of the associated resource.
+    * `location` - Location details:
+      * `region` - Region.
+      * `availability_zone` - Availability zone.
+  * `current_tasks` - Ongoing asynchronous tasks related to the additional IP. Each element exports:
+    * `id` - Identifier of the current task.
+    * `link` - Link to the task details.
+    * `status` - Current global status of the current task.
+    * `type` - Type of the current task.
+    * `errors` - Errors that occurred on the task:
+      * `message` - Error description.

--- a/docs/data-sources/cloud_ext_net_ip.md
+++ b/docs/data-sources/cloud_ext_net_ip.md
@@ -1,0 +1,52 @@
+---
+subcategory : "Public IPs"
+---
+
+# ovh_cloud_ext_net_ip (Data Source)
+
+Use this data source to retrieve information about an external network IP in a public cloud project. External network IPs are created and deleted through the lifecycle of other products (typically instances attached to the public network), so this data source is a read-only view.
+
+## Example Usage
+
+```terraform
+data "ovh_cloud_ext_net_ip" "ip" {
+  service_name = "<public cloud project ID>"
+  id           = "<external network IP address>"
+}
+
+output "ext_net_ip_status" {
+  value = data.ovh_cloud_ext_net_ip.ip.resource_status
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `service_name` - (Required) Service name of the resource representing the id of the cloud project.
+* `id` - (Required) IP address of the external network IP.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `checksum` - Checksum field of the API envelope. Always empty for this read-only IP type.
+* `created_at` - Creation date of the external network IP.
+* `updated_at` - Last update date of the external network IP.
+* `resource_status` - External network IP readiness in the system (`CREATING`, `DELETING`, `ERROR`, `OUT_OF_SYNC`, `READY`, `UPDATING`).
+* `current_state` - Current state of the external network IP:
+  * `id` - Identifier of the external network IP.
+  * `ip` - IP address of the external network IP.
+  * `associated_resource` - Resource the external network IP is currently attached to. Null when the IP is not attached to any resource:
+    * `id` - ID of the associated resource.
+    * `type` - Type of the associated resource.
+  * `location` - Location details:
+    * `region` - Region.
+    * `availability_zone` - Availability zone.
+* `current_tasks` - Ongoing asynchronous tasks related to the external network IP. Each element exports:
+  * `id` - Identifier of the current task.
+  * `link` - Link to the task details.
+  * `status` - Current global status of the current task.
+  * `type` - Type of the current task.
+  * `errors` - Errors that occurred on the task:
+    * `message` - Error description.

--- a/docs/data-sources/cloud_ext_net_ips.md
+++ b/docs/data-sources/cloud_ext_net_ips.md
@@ -1,0 +1,52 @@
+---
+subcategory : "Public IPs"
+---
+
+# ovh_cloud_ext_net_ips (Data Source)
+
+Use this data source to list the external network IPs of a public cloud project. External network IPs are created and deleted through the lifecycle of other products (typically instances attached to the public network), so this data source is a read-only view.
+
+## Example Usage
+
+```terraform
+data "ovh_cloud_ext_net_ips" "ips" {
+  service_name = "<public cloud project ID>"
+}
+
+output "ext_net_ip_addresses" {
+  value = [for ip in data.ovh_cloud_ext_net_ips.ips.ext_net_ips : ip.id]
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `service_name` - (Required) Service name of the resource representing the id of the cloud project.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `ext_net_ips` - List of external network IPs. Each element exports:
+  * `id` - IP address of the external network IP.
+  * `checksum` - Checksum field of the API envelope. Always empty for this read-only IP type.
+  * `created_at` - Creation date of the external network IP.
+  * `updated_at` - Last update date of the external network IP.
+  * `resource_status` - External network IP readiness in the system (`CREATING`, `DELETING`, `ERROR`, `OUT_OF_SYNC`, `READY`, `UPDATING`).
+  * `current_state` - Current state of the external network IP:
+    * `id` - Identifier of the external network IP.
+    * `ip` - IP address of the external network IP.
+    * `associated_resource` - Resource the external network IP is currently attached to. Null when the IP is not attached to any resource:
+      * `id` - ID of the associated resource.
+      * `type` - Type of the associated resource.
+    * `location` - Location details:
+      * `region` - Region.
+      * `availability_zone` - Availability zone.
+  * `current_tasks` - Ongoing asynchronous tasks related to the external network IP. Each element exports:
+    * `id` - Identifier of the current task.
+    * `link` - Link to the task details.
+    * `status` - Current global status of the current task.
+    * `type` - Type of the current task.
+    * `errors` - Errors that occurred on the task:
+      * `message` - Error description.

--- a/docs/data-sources/cloud_floating_ip.md
+++ b/docs/data-sources/cloud_floating_ip.md
@@ -1,0 +1,60 @@
+---
+subcategory : "Public IPs"
+---
+
+# ovh_cloud_floating_ip (Data Source)
+
+Use this data source to retrieve information about a floating IP in a public cloud project.
+
+## Example Usage
+
+```terraform
+data "ovh_cloud_floating_ip" "ip" {
+  service_name = "<public cloud project ID>"
+  id           = "<floating IP address>"
+}
+
+output "floating_ip_status" {
+  value = data.ovh_cloud_floating_ip.ip.resource_status
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `service_name` - (Required) Service name of the resource representing the id of the cloud project.
+* `id` - (Required) IP address of the floating IP.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `description` - Description of the floating IP.
+* `location` - Location of the floating IP:
+  * `region` - Region.
+  * `availability_zone` - Availability zone.
+* `checksum` - Computed hash representing the current target specification value.
+* `created_at` - Creation date of the floating IP.
+* `updated_at` - Last update date of the floating IP.
+* `resource_status` - Floating IP readiness in the system (`CREATING`, `DELETING`, `ERROR`, `OUT_OF_SYNC`, `READY`, `UPDATING`).
+* `current_state` - Current state of the floating IP:
+  * `id` - OpenStack identifier of the floating IP.
+  * `ip` - IP address of the floating IP.
+  * `status` - OpenStack status of the floating IP (`ACTIVE`, `DOWN`, `ERROR`).
+  * `description` - Description of the floating IP.
+  * `network` - External network the floating IP belongs to:
+    * `id` - Network ID.
+  * `associated_resource` - Resource the floating IP is currently attached to. Null when the floating IP is not attached to any resource:
+    * `id` - ID of the associated resource.
+    * `type` - Type of the associated resource.
+  * `location` - Location details:
+    * `region` - Region.
+    * `availability_zone` - Availability zone.
+* `current_tasks` - Ongoing asynchronous tasks related to the floating IP. Each element exports:
+  * `id` - Identifier of the current task.
+  * `link` - Link to the task details.
+  * `status` - Current global status of the current task.
+  * `type` - Type of the current task.
+  * `errors` - Errors that occurred on the task:
+    * `message` - Error description.

--- a/docs/data-sources/cloud_floating_ips.md
+++ b/docs/data-sources/cloud_floating_ips.md
@@ -1,0 +1,60 @@
+---
+subcategory : "Public IPs"
+---
+
+# ovh_cloud_floating_ips (Data Source)
+
+Use this data source to list the floating IPs of a public cloud project.
+
+## Example Usage
+
+```terraform
+data "ovh_cloud_floating_ips" "ips" {
+  service_name = "<public cloud project ID>"
+}
+
+output "floating_ip_addresses" {
+  value = [for ip in data.ovh_cloud_floating_ips.ips.floating_ips : ip.id]
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `service_name` - (Required) Service name of the resource representing the id of the cloud project.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `floating_ips` - List of floating IPs. Each element exports:
+  * `id` - IP address of the floating IP.
+  * `description` - Description of the floating IP.
+  * `location` - Location of the floating IP:
+    * `region` - Region.
+    * `availability_zone` - Availability zone.
+  * `checksum` - Computed hash representing the current target specification value.
+  * `created_at` - Creation date of the floating IP.
+  * `updated_at` - Last update date of the floating IP.
+  * `resource_status` - Floating IP readiness in the system (`CREATING`, `DELETING`, `ERROR`, `OUT_OF_SYNC`, `READY`, `UPDATING`).
+  * `current_state` - Current state of the floating IP:
+    * `id` - OpenStack identifier of the floating IP.
+    * `ip` - IP address of the floating IP.
+    * `status` - OpenStack status of the floating IP (`ACTIVE`, `DOWN`, `ERROR`).
+    * `description` - Description of the floating IP.
+    * `network` - External network the floating IP belongs to:
+      * `id` - Network ID.
+    * `associated_resource` - Resource the floating IP is currently attached to. Null when the floating IP is not attached to any resource:
+      * `id` - ID of the associated resource.
+      * `type` - Type of the associated resource.
+    * `location` - Location details:
+      * `region` - Region.
+      * `availability_zone` - Availability zone.
+  * `current_tasks` - Ongoing asynchronous tasks related to the floating IP. Each element exports:
+    * `id` - Identifier of the current task.
+    * `link` - Link to the task details.
+    * `status` - Current global status of the current task.
+    * `type` - Type of the current task.
+    * `errors` - Errors that occurred on the task:
+      * `message` - Error description.

--- a/docs/data-sources/cloud_project_floatingips.md
+++ b/docs/data-sources/cloud_project_floatingips.md
@@ -4,6 +4,8 @@ subcategory : "Public IPs"
 
 # ovh_cloud_project_floatingips
 
+~> **NOTE** We recommend using the `ovh_cloud_floating_ips` data source instead. Floating IPs can now also be managed directly with the `ovh_cloud_floating_ip` resource.
+
 Use this data source to get the floating IPs of a public cloud project.
 
 ## Example Usage

--- a/docs/data-sources/cloud_public_ips.md
+++ b/docs/data-sources/cloud_public_ips.md
@@ -1,0 +1,33 @@
+---
+subcategory : "Public IPs"
+---
+
+# ovh_cloud_public_ips (Data Source)
+
+Use this data source to list all public IPs (additional, external network and floating IPs) of a public cloud project.
+
+## Example Usage
+
+```terraform
+data "ovh_cloud_public_ips" "all" {
+  service_name = "<public cloud project ID>"
+}
+
+output "public_ips" {
+  value = data.ovh_cloud_public_ips.all.public_ips
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `service_name` - (Required) Service name of the resource representing the id of the cloud project.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `public_ips` - List of public IPs of the project. Each element exports:
+  * `ip` - Public IP address.
+  * `type` - Type of the public IP (`ADDITIONAL_IP`, `EXT_NET_IP`, `FLOATING_IP`).

--- a/docs/resources/cloud_floating_ip.md
+++ b/docs/resources/cloud_floating_ip.md
@@ -1,0 +1,71 @@
+---
+subcategory : "Public IPs"
+---
+
+# ovh_cloud_floating_ip
+
+Creates a floating IP in a public cloud project.
+
+## Example Usage
+
+```terraform
+resource "ovh_cloud_floating_ip" "ip" {
+  service_name = "<public cloud project ID>"
+  region       = "GRA1"
+  description  = "my-floating-ip"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `service_name` - (Required) Service name of the resource representing the id of the cloud project. **Changing this value recreates the resource.**
+* `region` - (Required) Region where the floating IP will be created. **Changing this value recreates the resource.**
+* `availability_zone` - (Optional) Availability zone for the floating IP. **Changing this value recreates the resource.**
+* `description` - (Optional) Description of the floating IP. This is the only argument that can be updated in place.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `id` - IP address of the floating IP.
+* `checksum` - Computed hash representing the current target specification value.
+* `created_at` - Creation date of the floating IP.
+* `updated_at` - Last update date of the floating IP.
+* `resource_status` - Floating IP readiness in the system (`CREATING`, `DELETING`, `ERROR`, `OUT_OF_SYNC`, `READY`, `UPDATING`).
+* `current_state` - Current state of the floating IP:
+  * `id` - OpenStack identifier of the floating IP.
+  * `ip` - IP address of the floating IP.
+  * `status` - OpenStack status of the floating IP (`ACTIVE`, `DOWN`, `ERROR`).
+  * `description` - Description of the floating IP.
+  * `network` - External network the floating IP belongs to:
+    * `id` - Network ID.
+  * `associated_resource` - Resource the floating IP is currently attached to. Null when the floating IP is not attached to any resource:
+    * `id` - ID of the associated resource.
+    * `type` - Type of the associated resource.
+  * `location` - Location details:
+    * `region` - Region.
+    * `availability_zone` - Availability zone.
+* `current_tasks` - Ongoing asynchronous tasks related to the floating IP. Each element exports:
+  * `id` - Identifier of the current task.
+  * `link` - Link to the task details.
+  * `status` - Current global status of the current task.
+  * `type` - Type of the current task.
+  * `errors` - Errors that occurred on the task:
+    * `message` - Error description.
+
+## Import
+
+A floating IP can be imported using the `service_name` and the IP address, separated by `/`:
+
+```terraform
+import {
+  to = ovh_cloud_floating_ip.ip
+  id = "<service_name>/<ip>"
+}
+```
+
+```bash
+$ terraform import ovh_cloud_floating_ip.ip service_name/ip
+```

--- a/ovh/data_cloud_additional_ip.go
+++ b/ovh/data_cloud_additional_ip.go
@@ -1,0 +1,208 @@
+package ovh
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	ovhtypes "github.com/ovh/terraform-provider-ovh/v2/ovh/types"
+)
+
+var _ datasource.DataSourceWithConfigure = (*cloudAdditionalIPDataSource)(nil)
+
+func NewCloudAdditionalIPDataSource() datasource.DataSource {
+	return &cloudAdditionalIPDataSource{}
+}
+
+type cloudAdditionalIPDataSource struct {
+	config *Config
+}
+
+func (d *cloudAdditionalIPDataSource) Metadata(ctx context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_cloud_additional_ip"
+}
+
+func (d *cloudAdditionalIPDataSource) Configure(_ context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+
+	config, ok := req.ProviderData.(*Config)
+	if !ok {
+		resp.Diagnostics.AddError(
+			"Unexpected Data Source Configure Type",
+			fmt.Sprintf("Expected *Config, got: %T. Please report this issue to the provider developers.", req.ProviderData),
+		)
+		return
+	}
+
+	d.config = config
+}
+
+func (d *cloudAdditionalIPDataSource) Schema(ctx context.Context, req datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Description: "Use this data source to retrieve information about an additional IP in a public cloud project.",
+		Attributes: map[string]schema.Attribute{
+			"service_name": schema.StringAttribute{
+				CustomType:  ovhtypes.TfStringType{},
+				Required:    true,
+				Description: "Service name of the resource representing the id of the cloud project",
+			},
+			"id": schema.StringAttribute{
+				CustomType:  ovhtypes.TfStringType{},
+				Required:    true,
+				Description: "IP address of the additional IP",
+			},
+			"checksum": schema.StringAttribute{
+				CustomType:  ovhtypes.TfStringType{},
+				Computed:    true,
+				Description: "Checksum field of the API envelope. Always empty for this read-only IP type.",
+			},
+			"resource_status": schema.StringAttribute{
+				CustomType:  ovhtypes.TfStringType{},
+				Computed:    true,
+				Description: "Additional IP readiness in the system (CREATING, DELETING, ERROR, OUT_OF_SYNC, READY, UPDATING)",
+			},
+			"current_state": schema.SingleNestedAttribute{
+				Computed:    true,
+				Description: "Current state of the additional IP",
+				Attributes: map[string]schema.Attribute{
+					"id": schema.StringAttribute{
+						CustomType:  ovhtypes.TfStringType{},
+						Computed:    true,
+						Description: "Identifier of the additional IP",
+					},
+					"ip": schema.StringAttribute{
+						CustomType:  ovhtypes.TfStringType{},
+						Computed:    true,
+						Description: "IP address of the additional IP",
+					},
+					"ip_block": schema.StringAttribute{
+						CustomType:  ovhtypes.TfStringType{},
+						Computed:    true,
+						Description: "IP block the additional IP belongs to",
+					},
+					"associated_resource": schema.SingleNestedAttribute{
+						Computed:    true,
+						Description: "Resource the additional IP is currently attached to",
+						Attributes: map[string]schema.Attribute{
+							"id": schema.StringAttribute{
+								CustomType:  ovhtypes.TfStringType{},
+								Computed:    true,
+								Description: "ID of the associated resource",
+							},
+							"type": schema.StringAttribute{
+								CustomType:  ovhtypes.TfStringType{},
+								Computed:    true,
+								Description: "Type of the associated resource",
+							},
+						},
+					},
+					"location": schema.SingleNestedAttribute{
+						Computed:    true,
+						Description: "Location details",
+						Attributes: map[string]schema.Attribute{
+							"region": schema.StringAttribute{
+								CustomType:  ovhtypes.TfStringType{},
+								Computed:    true,
+								Description: "Region",
+							},
+							"availability_zone": schema.StringAttribute{
+								CustomType:  ovhtypes.TfStringType{},
+								Computed:    true,
+								Description: "Availability zone",
+							},
+						},
+					},
+				},
+			},
+			"current_tasks": schema.ListNestedAttribute{
+				Computed:    true,
+				Description: "Ongoing asynchronous tasks related to the additional IP",
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]schema.Attribute{
+						"errors": schema.ListNestedAttribute{
+							Computed:    true,
+							Description: "Errors that occured on the task",
+							NestedObject: schema.NestedAttributeObject{
+								Attributes: map[string]schema.Attribute{
+									"message": schema.StringAttribute{
+										CustomType:  ovhtypes.TfStringType{},
+										Computed:    true,
+										Description: "Error description",
+									},
+								},
+							},
+						},
+						"id": schema.StringAttribute{
+							CustomType:  ovhtypes.TfStringType{},
+							Computed:    true,
+							Description: "Identifier of the current task",
+						},
+						"link": schema.StringAttribute{
+							CustomType:  ovhtypes.TfStringType{},
+							Computed:    true,
+							Description: "Link to the task details",
+						},
+						"status": schema.StringAttribute{
+							CustomType:  ovhtypes.TfStringType{},
+							Computed:    true,
+							Description: "Current global status of the current task",
+						},
+						"type": schema.StringAttribute{
+							CustomType:  ovhtypes.TfStringType{},
+							Computed:    true,
+							Description: "Type of the current task",
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+// cloudAdditionalIPDataSourceModel is the Terraform state model for this data source.
+type cloudAdditionalIPDataSourceModel struct {
+	ServiceName    ovhtypes.TfStringValue `tfsdk:"service_name"`
+	Id             ovhtypes.TfStringValue `tfsdk:"id"`
+	Checksum       ovhtypes.TfStringValue `tfsdk:"checksum"`
+	ResourceStatus ovhtypes.TfStringValue `tfsdk:"resource_status"`
+	CurrentState   types.Object           `tfsdk:"current_state"`
+	CurrentTasks   types.List             `tfsdk:"current_tasks"`
+}
+
+func (d *cloudAdditionalIPDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+	var data cloudAdditionalIPDataSourceModel
+
+	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	endpoint := "/v2/publicCloud/project/" + url.PathEscape(data.ServiceName.ValueString()) + "/publicIp/additional/" + url.PathEscape(data.Id.ValueString())
+
+	var responseData CloudAdditionalIPAPIResponse
+	if err := d.config.OVHClient.Get(endpoint, &responseData); err != nil {
+		resp.Diagnostics.AddError(
+			fmt.Sprintf("Error calling Get %s", endpoint),
+			err.Error(),
+		)
+		return
+	}
+
+	data.Checksum = ovhtypes.TfStringValue{StringValue: types.StringValue(responseData.Checksum)}
+	data.ResourceStatus = ovhtypes.TfStringValue{StringValue: types.StringValue(responseData.ResourceStatus)}
+
+	if responseData.CurrentState != nil {
+		data.CurrentState = buildCloudAdditionalIPCurrentStateObject(ctx, responseData.CurrentState)
+	} else {
+		data.CurrentState = types.ObjectNull(CloudAdditionalIPCurrentStateAttrTypes())
+	}
+
+	data.CurrentTasks = buildCloudPublicIPCurrentTasksList(responseData.CurrentTasks)
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}

--- a/ovh/data_cloud_additional_ip_test.go
+++ b/ovh/data_cloud_additional_ip_test.go
@@ -1,0 +1,46 @@
+package ovh
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+func TestAccDataSourceCloudAdditionalIP_basic(t *testing.T) {
+	serviceName := os.Getenv("OVH_CLOUD_PROJECT_SERVICE_TEST")
+
+	// Additional IPs cannot be created from Terraform: the test requires an
+	// existing additional IP in the test project.
+	additionalIP := os.Getenv("OVH_CLOUD_PUBLIC_IP_ADDITIONAL_TEST")
+	if additionalIP == "" {
+		t.Skip("OVH_CLOUD_PUBLIC_IP_ADDITIONAL_TEST not set")
+	}
+
+	config := fmt.Sprintf(`
+data "ovh_cloud_additional_ip" "test" {
+  service_name = "%s"
+  id           = "%s"
+}
+`, serviceName, additionalIP)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheckCloudPublicIP(t)
+		},
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("data.ovh_cloud_additional_ip.test", "service_name", serviceName),
+					resource.TestCheckResourceAttr("data.ovh_cloud_additional_ip.test", "id", additionalIP),
+					resource.TestCheckResourceAttrSet("data.ovh_cloud_additional_ip.test", "current_state.id"),
+					resource.TestCheckResourceAttrSet("data.ovh_cloud_additional_ip.test", "resource_status"),
+					resource.TestCheckResourceAttrSet("data.ovh_cloud_additional_ip.test", "current_state.ip"),
+				),
+			},
+		},
+	})
+}

--- a/ovh/data_cloud_additional_ips.go
+++ b/ovh/data_cloud_additional_ips.go
@@ -1,0 +1,211 @@
+package ovh
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/ovh/terraform-provider-ovh/v2/ovh/helpers"
+	ovhtypes "github.com/ovh/terraform-provider-ovh/v2/ovh/types"
+)
+
+var _ datasource.DataSourceWithConfigure = (*cloudAdditionalIPsDataSource)(nil)
+
+func NewCloudAdditionalIPsDataSource() datasource.DataSource {
+	return &cloudAdditionalIPsDataSource{}
+}
+
+type cloudAdditionalIPsDataSource struct {
+	config *Config
+}
+
+// cloudAdditionalIPsDataSourceModel is the model for the plural additional IPs data source.
+type cloudAdditionalIPsDataSourceModel struct {
+	ServiceName   ovhtypes.TfStringValue `tfsdk:"service_name"`
+	AdditionalIPs types.List             `tfsdk:"additional_ips"`
+}
+
+func (d *cloudAdditionalIPsDataSource) Metadata(ctx context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_cloud_additional_ips"
+}
+
+func (d *cloudAdditionalIPsDataSource) Configure(_ context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+
+	config, ok := req.ProviderData.(*Config)
+	if !ok {
+		resp.Diagnostics.AddError(
+			"Unexpected Data Source Configure Type",
+			fmt.Sprintf("Expected *Config, got: %T. Please report this issue to the provider developers.", req.ProviderData),
+		)
+		return
+	}
+
+	d.config = config
+}
+
+func (d *cloudAdditionalIPsDataSource) Schema(ctx context.Context, req datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Description: "Use this data source to list the additional IPs of a public cloud project.",
+		Attributes: map[string]schema.Attribute{
+			"service_name": schema.StringAttribute{
+				CustomType:  ovhtypes.TfStringType{},
+				Required:    true,
+				Description: "Service name of the resource representing the id of the cloud project",
+			},
+			"additional_ips": schema.ListNestedAttribute{
+				Computed:    true,
+				Description: "List of additional IPs",
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]schema.Attribute{
+						"id": schema.StringAttribute{
+							CustomType:  ovhtypes.TfStringType{},
+							Computed:    true,
+							Description: "IP address of the additional IP",
+						},
+						"checksum": schema.StringAttribute{
+							CustomType:  ovhtypes.TfStringType{},
+							Computed:    true,
+							Description: "Checksum field of the API envelope. Always empty for this read-only IP type.",
+						},
+						"resource_status": schema.StringAttribute{
+							CustomType:  ovhtypes.TfStringType{},
+							Computed:    true,
+							Description: "Additional IP readiness in the system (CREATING, DELETING, ERROR, OUT_OF_SYNC, READY, UPDATING)",
+						},
+						"current_state": schema.SingleNestedAttribute{
+							Computed:    true,
+							Description: "Current state of the additional IP",
+							Attributes: map[string]schema.Attribute{
+								"id": schema.StringAttribute{
+									CustomType:  ovhtypes.TfStringType{},
+									Computed:    true,
+									Description: "Identifier of the additional IP",
+								},
+								"ip": schema.StringAttribute{
+									CustomType:  ovhtypes.TfStringType{},
+									Computed:    true,
+									Description: "IP address of the additional IP",
+								},
+								"ip_block": schema.StringAttribute{
+									CustomType:  ovhtypes.TfStringType{},
+									Computed:    true,
+									Description: "IP block the additional IP belongs to",
+								},
+								"associated_resource": schema.SingleNestedAttribute{
+									Computed:    true,
+									Description: "Resource the additional IP is currently attached to",
+									Attributes: map[string]schema.Attribute{
+										"id": schema.StringAttribute{
+											CustomType:  ovhtypes.TfStringType{},
+											Computed:    true,
+											Description: "ID of the associated resource",
+										},
+										"type": schema.StringAttribute{
+											CustomType:  ovhtypes.TfStringType{},
+											Computed:    true,
+											Description: "Type of the associated resource",
+										},
+									},
+								},
+								"location": schema.SingleNestedAttribute{
+									Computed:    true,
+									Description: "Location details",
+									Attributes: map[string]schema.Attribute{
+										"region": schema.StringAttribute{
+											CustomType:  ovhtypes.TfStringType{},
+											Computed:    true,
+											Description: "Region",
+										},
+										"availability_zone": schema.StringAttribute{
+											CustomType:  ovhtypes.TfStringType{},
+											Computed:    true,
+											Description: "Availability zone",
+										},
+									},
+								},
+							},
+						},
+						"current_tasks": schema.ListNestedAttribute{
+							Computed:    true,
+							Description: "Ongoing asynchronous tasks related to the additional IP",
+							NestedObject: schema.NestedAttributeObject{
+								Attributes: map[string]schema.Attribute{
+									"errors": schema.ListNestedAttribute{
+										Computed:    true,
+										Description: "Errors that occured on the task",
+										NestedObject: schema.NestedAttributeObject{
+											Attributes: map[string]schema.Attribute{
+												"message": schema.StringAttribute{
+													CustomType:  ovhtypes.TfStringType{},
+													Computed:    true,
+													Description: "Error description",
+												},
+											},
+										},
+									},
+									"id": schema.StringAttribute{
+										CustomType:  ovhtypes.TfStringType{},
+										Computed:    true,
+										Description: "Identifier of the current task",
+									},
+									"link": schema.StringAttribute{
+										CustomType:  ovhtypes.TfStringType{},
+										Computed:    true,
+										Description: "Link to the task details",
+									},
+									"status": schema.StringAttribute{
+										CustomType:  ovhtypes.TfStringType{},
+										Computed:    true,
+										Description: "Current global status of the current task",
+									},
+									"type": schema.StringAttribute{
+										CustomType:  ovhtypes.TfStringType{},
+										Computed:    true,
+										Description: "Type of the current task",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func (d *cloudAdditionalIPsDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+	var data cloudAdditionalIPsDataSourceModel
+
+	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	endpoint := "/v2/publicCloud/project/" + url.PathEscape(data.ServiceName.ValueString()) + "/publicIp/additional"
+
+	responseData, err := helpers.GetAllPagesV2[CloudAdditionalIPAPIResponse](ctx, d.config.OVHClient, endpoint)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			fmt.Sprintf("Error calling Get %s", endpoint),
+			err.Error(),
+		)
+		return
+	}
+
+	itemObjType := types.ObjectType{AttrTypes: CloudAdditionalIPListItemAttrTypes()}
+	items := make([]attr.Value, 0, len(responseData))
+	for i := range responseData {
+		items = append(items, buildCloudAdditionalIPListItemObject(ctx, &responseData[i]))
+	}
+
+	data.AdditionalIPs = types.ListValueMust(itemObjType, items)
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}

--- a/ovh/data_cloud_additional_ips_test.go
+++ b/ovh/data_cloud_additional_ips_test.go
@@ -1,0 +1,37 @@
+package ovh
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+func TestAccDataSourceCloudAdditionalIPs_basic(t *testing.T) {
+	serviceName := os.Getenv("OVH_CLOUD_PROJECT_SERVICE_TEST")
+
+	// Additional IPs cannot be created from Terraform: this test only checks
+	// that the listing works, even when the project has no additional IP.
+	config := fmt.Sprintf(`
+data "ovh_cloud_additional_ips" "test" {
+  service_name = "%s"
+}
+`, serviceName)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheckCloudPublicIP(t)
+		},
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("data.ovh_cloud_additional_ips.test", "service_name", serviceName),
+					resource.TestCheckResourceAttrSet("data.ovh_cloud_additional_ips.test", "additional_ips.#"),
+				),
+			},
+		},
+	})
+}

--- a/ovh/data_cloud_ext_net_ip.go
+++ b/ovh/data_cloud_ext_net_ip.go
@@ -1,0 +1,217 @@
+package ovh
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	ovhtypes "github.com/ovh/terraform-provider-ovh/v2/ovh/types"
+)
+
+var _ datasource.DataSourceWithConfigure = (*cloudExtNetIPDataSource)(nil)
+
+func NewCloudExtNetIPDataSource() datasource.DataSource {
+	return &cloudExtNetIPDataSource{}
+}
+
+type cloudExtNetIPDataSource struct {
+	config *Config
+}
+
+func (d *cloudExtNetIPDataSource) Metadata(ctx context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_cloud_ext_net_ip"
+}
+
+func (d *cloudExtNetIPDataSource) Configure(_ context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+
+	config, ok := req.ProviderData.(*Config)
+	if !ok {
+		resp.Diagnostics.AddError(
+			"Unexpected Data Source Configure Type",
+			fmt.Sprintf("Expected *Config, got: %T. Please report this issue to the provider developers.", req.ProviderData),
+		)
+		return
+	}
+
+	d.config = config
+}
+
+func (d *cloudExtNetIPDataSource) Schema(ctx context.Context, req datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Description: "Use this data source to retrieve information about an external network IP in a public cloud project.",
+		Attributes: map[string]schema.Attribute{
+			"service_name": schema.StringAttribute{
+				CustomType:  ovhtypes.TfStringType{},
+				Required:    true,
+				Description: "Service name of the resource representing the id of the cloud project",
+			},
+			"id": schema.StringAttribute{
+				CustomType:  ovhtypes.TfStringType{},
+				Required:    true,
+				Description: "IP address of the external network IP",
+			},
+			"checksum": schema.StringAttribute{
+				CustomType:  ovhtypes.TfStringType{},
+				Computed:    true,
+				Description: "Checksum field of the API envelope. Always empty for this read-only IP type.",
+			},
+			"created_at": schema.StringAttribute{
+				CustomType:  ovhtypes.TfStringType{},
+				Computed:    true,
+				Description: "Creation date of the external network IP",
+			},
+			"updated_at": schema.StringAttribute{
+				CustomType:  ovhtypes.TfStringType{},
+				Computed:    true,
+				Description: "Last update date of the external network IP",
+			},
+			"resource_status": schema.StringAttribute{
+				CustomType:  ovhtypes.TfStringType{},
+				Computed:    true,
+				Description: "External network IP readiness in the system (CREATING, DELETING, ERROR, OUT_OF_SYNC, READY, UPDATING)",
+			},
+			"current_state": schema.SingleNestedAttribute{
+				Computed:    true,
+				Description: "Current state of the external network IP",
+				Attributes: map[string]schema.Attribute{
+					"id": schema.StringAttribute{
+						CustomType:  ovhtypes.TfStringType{},
+						Computed:    true,
+						Description: "Identifier of the external network IP",
+					},
+					"ip": schema.StringAttribute{
+						CustomType:  ovhtypes.TfStringType{},
+						Computed:    true,
+						Description: "IP address of the external network IP",
+					},
+					"associated_resource": schema.SingleNestedAttribute{
+						Computed:    true,
+						Description: "Resource the external network IP is currently attached to",
+						Attributes: map[string]schema.Attribute{
+							"id": schema.StringAttribute{
+								CustomType:  ovhtypes.TfStringType{},
+								Computed:    true,
+								Description: "ID of the associated resource",
+							},
+							"type": schema.StringAttribute{
+								CustomType:  ovhtypes.TfStringType{},
+								Computed:    true,
+								Description: "Type of the associated resource",
+							},
+						},
+					},
+					"location": schema.SingleNestedAttribute{
+						Computed:    true,
+						Description: "Location details",
+						Attributes: map[string]schema.Attribute{
+							"region": schema.StringAttribute{
+								CustomType:  ovhtypes.TfStringType{},
+								Computed:    true,
+								Description: "Region",
+							},
+							"availability_zone": schema.StringAttribute{
+								CustomType:  ovhtypes.TfStringType{},
+								Computed:    true,
+								Description: "Availability zone",
+							},
+						},
+					},
+				},
+			},
+			"current_tasks": schema.ListNestedAttribute{
+				Computed:    true,
+				Description: "Ongoing asynchronous tasks related to the external network IP",
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]schema.Attribute{
+						"errors": schema.ListNestedAttribute{
+							Computed:    true,
+							Description: "Errors that occured on the task",
+							NestedObject: schema.NestedAttributeObject{
+								Attributes: map[string]schema.Attribute{
+									"message": schema.StringAttribute{
+										CustomType:  ovhtypes.TfStringType{},
+										Computed:    true,
+										Description: "Error description",
+									},
+								},
+							},
+						},
+						"id": schema.StringAttribute{
+							CustomType:  ovhtypes.TfStringType{},
+							Computed:    true,
+							Description: "Identifier of the current task",
+						},
+						"link": schema.StringAttribute{
+							CustomType:  ovhtypes.TfStringType{},
+							Computed:    true,
+							Description: "Link to the task details",
+						},
+						"status": schema.StringAttribute{
+							CustomType:  ovhtypes.TfStringType{},
+							Computed:    true,
+							Description: "Current global status of the current task",
+						},
+						"type": schema.StringAttribute{
+							CustomType:  ovhtypes.TfStringType{},
+							Computed:    true,
+							Description: "Type of the current task",
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+// cloudExtNetIPDataSourceModel is the Terraform state model for this data source.
+type cloudExtNetIPDataSourceModel struct {
+	ServiceName    ovhtypes.TfStringValue `tfsdk:"service_name"`
+	Id             ovhtypes.TfStringValue `tfsdk:"id"`
+	Checksum       ovhtypes.TfStringValue `tfsdk:"checksum"`
+	CreatedAt      ovhtypes.TfStringValue `tfsdk:"created_at"`
+	UpdatedAt      ovhtypes.TfStringValue `tfsdk:"updated_at"`
+	ResourceStatus ovhtypes.TfStringValue `tfsdk:"resource_status"`
+	CurrentState   types.Object           `tfsdk:"current_state"`
+	CurrentTasks   types.List             `tfsdk:"current_tasks"`
+}
+
+func (d *cloudExtNetIPDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+	var data cloudExtNetIPDataSourceModel
+
+	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	endpoint := "/v2/publicCloud/project/" + url.PathEscape(data.ServiceName.ValueString()) + "/publicIp/extNet/" + url.PathEscape(data.Id.ValueString())
+
+	var responseData CloudExtNetIPAPIResponse
+	if err := d.config.OVHClient.Get(endpoint, &responseData); err != nil {
+		resp.Diagnostics.AddError(
+			fmt.Sprintf("Error calling Get %s", endpoint),
+			err.Error(),
+		)
+		return
+	}
+
+	data.Checksum = ovhtypes.TfStringValue{StringValue: types.StringValue(responseData.Checksum)}
+	data.CreatedAt = ovhtypes.TfStringValue{StringValue: types.StringValue(responseData.CreatedAt)}
+	data.UpdatedAt = ovhtypes.TfStringValue{StringValue: types.StringValue(responseData.UpdatedAt)}
+	data.ResourceStatus = ovhtypes.TfStringValue{StringValue: types.StringValue(responseData.ResourceStatus)}
+
+	if responseData.CurrentState != nil {
+		data.CurrentState = buildCloudExtNetIPCurrentStateObject(ctx, responseData.CurrentState)
+	} else {
+		data.CurrentState = types.ObjectNull(CloudExtNetIPCurrentStateAttrTypes())
+	}
+
+	data.CurrentTasks = buildCloudPublicIPCurrentTasksList(responseData.CurrentTasks)
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}

--- a/ovh/data_cloud_ext_net_ip_test.go
+++ b/ovh/data_cloud_ext_net_ip_test.go
@@ -1,0 +1,86 @@
+package ovh
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+// testAccCloudExtNetIPInstanceConfig returns the configuration of an
+// instance attached to a public network, so that an Ext-Net IP exists in the
+// project. It mirrors the fixture of resource_cloud_project_instance_test.go.
+func testAccCloudExtNetIPInstanceConfig(serviceName, region, image, flavor string) string {
+	return fmt.Sprintf(`
+resource "ovh_cloud_project_instance" "instance" {
+	service_name = "%s"
+	region = "%s"
+	billing_period = "hourly"
+	boot_from {
+		image_id = "%s"
+	}
+	flavor {
+		flavor_id = "%s"
+	}
+	name = "TestInstance"
+	ssh_key {
+		name = "%s"
+	}
+	network {
+		public = true
+	}
+}
+`,
+		serviceName,
+		region,
+		image,
+		flavor,
+		os.Getenv("OVH_CLOUD_PROJECT_SSH_NAME_TEST"))
+}
+
+// testAccPreCheckCloudExtNetIP is the PreCheck for the Ext-Net IP data
+// source tests, which spawn an instance attached to a public network.
+func testAccPreCheckCloudExtNetIP(t *testing.T) {
+	testAccPreCheckCloudPublicIP(t)
+	checkEnvOrSkip(t, "OVH_CLOUD_PROJECT_SSH_NAME_TEST")
+}
+
+func TestAccDataSourceCloudExtNetIP_basic(t *testing.T) {
+	serviceName := os.Getenv("OVH_CLOUD_PROJECT_SERVICE_TEST")
+	region := os.Getenv("OVH_CLOUD_PROJECT_REGION_TEST")
+	flavor, image, err := getFlavorAndImage(serviceName, region)
+	if err != nil {
+		t.Skipf("failed to retrieve a flavor and an image: %s", err)
+	}
+
+	config := testAccCloudExtNetIPInstanceConfig(serviceName, region, image, flavor) + fmt.Sprintf(`
+data "ovh_cloud_ext_net_ip" "test" {
+  service_name = "%s"
+  id           = [for address in ovh_cloud_project_instance.instance.addresses : address.ip if address.version == 4][0]
+}
+`, serviceName)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheckCloudExtNetIP(t)
+		},
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("data.ovh_cloud_ext_net_ip.test", "service_name", serviceName),
+					resource.TestCheckResourceAttrSet("data.ovh_cloud_ext_net_ip.test", "id"),
+					resource.TestCheckResourceAttrSet("data.ovh_cloud_ext_net_ip.test", "resource_status"),
+					resource.TestCheckResourceAttrSet("data.ovh_cloud_ext_net_ip.test", "current_state.ip"),
+					resource.TestCheckResourceAttrSet("data.ovh_cloud_ext_net_ip.test", "current_state.id"),
+					resource.TestCheckResourceAttrPair(
+						"data.ovh_cloud_ext_net_ip.test", "id",
+						"data.ovh_cloud_ext_net_ip.test", "current_state.ip",
+					),
+				),
+			},
+		},
+	})
+}

--- a/ovh/data_cloud_ext_net_ips.go
+++ b/ovh/data_cloud_ext_net_ips.go
@@ -1,0 +1,216 @@
+package ovh
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/ovh/terraform-provider-ovh/v2/ovh/helpers"
+	ovhtypes "github.com/ovh/terraform-provider-ovh/v2/ovh/types"
+)
+
+var _ datasource.DataSourceWithConfigure = (*cloudExtNetIPsDataSource)(nil)
+
+func NewCloudExtNetIPsDataSource() datasource.DataSource {
+	return &cloudExtNetIPsDataSource{}
+}
+
+type cloudExtNetIPsDataSource struct {
+	config *Config
+}
+
+// cloudExtNetIPsDataSourceModel is the model for the plural external network IPs data source.
+type cloudExtNetIPsDataSourceModel struct {
+	ServiceName ovhtypes.TfStringValue `tfsdk:"service_name"`
+	ExtNetIPs   types.List             `tfsdk:"ext_net_ips"`
+}
+
+func (d *cloudExtNetIPsDataSource) Metadata(ctx context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_cloud_ext_net_ips"
+}
+
+func (d *cloudExtNetIPsDataSource) Configure(_ context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+
+	config, ok := req.ProviderData.(*Config)
+	if !ok {
+		resp.Diagnostics.AddError(
+			"Unexpected Data Source Configure Type",
+			fmt.Sprintf("Expected *Config, got: %T. Please report this issue to the provider developers.", req.ProviderData),
+		)
+		return
+	}
+
+	d.config = config
+}
+
+func (d *cloudExtNetIPsDataSource) Schema(ctx context.Context, req datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Description: "Use this data source to list the external network IPs of a public cloud project.",
+		Attributes: map[string]schema.Attribute{
+			"service_name": schema.StringAttribute{
+				CustomType:  ovhtypes.TfStringType{},
+				Required:    true,
+				Description: "Service name of the resource representing the id of the cloud project",
+			},
+			"ext_net_ips": schema.ListNestedAttribute{
+				Computed:    true,
+				Description: "List of external network IPs",
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]schema.Attribute{
+						"id": schema.StringAttribute{
+							CustomType:  ovhtypes.TfStringType{},
+							Computed:    true,
+							Description: "IP address of the external network IP",
+						},
+						"checksum": schema.StringAttribute{
+							CustomType:  ovhtypes.TfStringType{},
+							Computed:    true,
+							Description: "Checksum field of the API envelope. Always empty for this read-only IP type.",
+						},
+						"created_at": schema.StringAttribute{
+							CustomType:  ovhtypes.TfStringType{},
+							Computed:    true,
+							Description: "Creation date of the external network IP",
+						},
+						"updated_at": schema.StringAttribute{
+							CustomType:  ovhtypes.TfStringType{},
+							Computed:    true,
+							Description: "Last update date of the external network IP",
+						},
+						"resource_status": schema.StringAttribute{
+							CustomType:  ovhtypes.TfStringType{},
+							Computed:    true,
+							Description: "External network IP readiness in the system (CREATING, DELETING, ERROR, OUT_OF_SYNC, READY, UPDATING)",
+						},
+						"current_state": schema.SingleNestedAttribute{
+							Computed:    true,
+							Description: "Current state of the external network IP",
+							Attributes: map[string]schema.Attribute{
+								"id": schema.StringAttribute{
+									CustomType:  ovhtypes.TfStringType{},
+									Computed:    true,
+									Description: "Identifier of the external network IP",
+								},
+								"ip": schema.StringAttribute{
+									CustomType:  ovhtypes.TfStringType{},
+									Computed:    true,
+									Description: "IP address of the external network IP",
+								},
+								"associated_resource": schema.SingleNestedAttribute{
+									Computed:    true,
+									Description: "Resource the external network IP is currently attached to",
+									Attributes: map[string]schema.Attribute{
+										"id": schema.StringAttribute{
+											CustomType:  ovhtypes.TfStringType{},
+											Computed:    true,
+											Description: "ID of the associated resource",
+										},
+										"type": schema.StringAttribute{
+											CustomType:  ovhtypes.TfStringType{},
+											Computed:    true,
+											Description: "Type of the associated resource",
+										},
+									},
+								},
+								"location": schema.SingleNestedAttribute{
+									Computed:    true,
+									Description: "Location details",
+									Attributes: map[string]schema.Attribute{
+										"region": schema.StringAttribute{
+											CustomType:  ovhtypes.TfStringType{},
+											Computed:    true,
+											Description: "Region",
+										},
+										"availability_zone": schema.StringAttribute{
+											CustomType:  ovhtypes.TfStringType{},
+											Computed:    true,
+											Description: "Availability zone",
+										},
+									},
+								},
+							},
+						},
+						"current_tasks": schema.ListNestedAttribute{
+							Computed:    true,
+							Description: "Ongoing asynchronous tasks related to the external network IP",
+							NestedObject: schema.NestedAttributeObject{
+								Attributes: map[string]schema.Attribute{
+									"errors": schema.ListNestedAttribute{
+										Computed:    true,
+										Description: "Errors that occured on the task",
+										NestedObject: schema.NestedAttributeObject{
+											Attributes: map[string]schema.Attribute{
+												"message": schema.StringAttribute{
+													CustomType:  ovhtypes.TfStringType{},
+													Computed:    true,
+													Description: "Error description",
+												},
+											},
+										},
+									},
+									"id": schema.StringAttribute{
+										CustomType:  ovhtypes.TfStringType{},
+										Computed:    true,
+										Description: "Identifier of the current task",
+									},
+									"link": schema.StringAttribute{
+										CustomType:  ovhtypes.TfStringType{},
+										Computed:    true,
+										Description: "Link to the task details",
+									},
+									"status": schema.StringAttribute{
+										CustomType:  ovhtypes.TfStringType{},
+										Computed:    true,
+										Description: "Current global status of the current task",
+									},
+									"type": schema.StringAttribute{
+										CustomType:  ovhtypes.TfStringType{},
+										Computed:    true,
+										Description: "Type of the current task",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func (d *cloudExtNetIPsDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+	var data cloudExtNetIPsDataSourceModel
+
+	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	endpoint := "/v2/publicCloud/project/" + url.PathEscape(data.ServiceName.ValueString()) + "/publicIp/extNet"
+
+	responseData, err := helpers.GetAllPagesV2[CloudExtNetIPAPIResponse](ctx, d.config.OVHClient, endpoint)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			fmt.Sprintf("Error calling Get %s", endpoint),
+			err.Error(),
+		)
+		return
+	}
+
+	itemObjType := types.ObjectType{AttrTypes: CloudExtNetIPListItemAttrTypes()}
+	items := make([]attr.Value, 0, len(responseData))
+	for i := range responseData {
+		items = append(items, buildCloudExtNetIPListItemObject(ctx, &responseData[i]))
+	}
+
+	data.ExtNetIPs = types.ListValueMust(itemObjType, items)
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}

--- a/ovh/data_cloud_ext_net_ips_test.go
+++ b/ovh/data_cloud_ext_net_ips_test.go
@@ -1,0 +1,43 @@
+package ovh
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+func TestAccDataSourceCloudExtNetIPs_basic(t *testing.T) {
+	serviceName := os.Getenv("OVH_CLOUD_PROJECT_SERVICE_TEST")
+	region := os.Getenv("OVH_CLOUD_PROJECT_REGION_TEST")
+	flavor, image, err := getFlavorAndImage(serviceName, region)
+	if err != nil {
+		t.Skipf("failed to retrieve a flavor and an image: %s", err)
+	}
+
+	config := testAccCloudExtNetIPInstanceConfig(serviceName, region, image, flavor) + fmt.Sprintf(`
+data "ovh_cloud_ext_net_ips" "test" {
+  service_name = "%s"
+
+  depends_on = [ovh_cloud_project_instance.instance]
+}
+`, serviceName)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheckCloudExtNetIP(t)
+		},
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("data.ovh_cloud_ext_net_ips.test", "service_name", serviceName),
+					resource.TestCheckResourceAttrSet("data.ovh_cloud_ext_net_ips.test", "ext_net_ips.#"),
+					resource.TestCheckResourceAttrWith("data.ovh_cloud_ext_net_ips.test", "ext_net_ips.#", testAccCheckCloudPublicIPListNotEmpty),
+				),
+			},
+		},
+	})
+}

--- a/ovh/data_cloud_floating_ip.go
+++ b/ovh/data_cloud_floating_ip.go
@@ -1,0 +1,280 @@
+package ovh
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	ovhtypes "github.com/ovh/terraform-provider-ovh/v2/ovh/types"
+)
+
+var _ datasource.DataSourceWithConfigure = (*cloudFloatingIPDataSource)(nil)
+
+func NewCloudFloatingIPDataSource() datasource.DataSource {
+	return &cloudFloatingIPDataSource{}
+}
+
+type cloudFloatingIPDataSource struct {
+	config *Config
+}
+
+func (d *cloudFloatingIPDataSource) Metadata(ctx context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_cloud_floating_ip"
+}
+
+func (d *cloudFloatingIPDataSource) Configure(_ context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+
+	config, ok := req.ProviderData.(*Config)
+	if !ok {
+		resp.Diagnostics.AddError(
+			"Unexpected Data Source Configure Type",
+			fmt.Sprintf("Expected *Config, got: %T. Please report this issue to the provider developers.", req.ProviderData),
+		)
+		return
+	}
+
+	d.config = config
+}
+
+func (d *cloudFloatingIPDataSource) Schema(ctx context.Context, req datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Description: "Use this data source to retrieve information about a floating IP in a public cloud project.",
+		Attributes: map[string]schema.Attribute{
+			"service_name": schema.StringAttribute{
+				CustomType:  ovhtypes.TfStringType{},
+				Required:    true,
+				Description: "Service name of the resource representing the id of the cloud project",
+			},
+			"id": schema.StringAttribute{
+				CustomType:  ovhtypes.TfStringType{},
+				Required:    true,
+				Description: "IP address of the floating IP",
+			},
+			"description": schema.StringAttribute{
+				CustomType:  ovhtypes.TfStringType{},
+				Computed:    true,
+				Description: "Description of the floating IP",
+			},
+			"location": schema.SingleNestedAttribute{
+				Computed:    true,
+				Description: "Location of the floating IP",
+				Attributes: map[string]schema.Attribute{
+					"region": schema.StringAttribute{
+						CustomType:  ovhtypes.TfStringType{},
+						Computed:    true,
+						Description: "Region",
+					},
+					"availability_zone": schema.StringAttribute{
+						CustomType:  ovhtypes.TfStringType{},
+						Computed:    true,
+						Description: "Availability zone",
+					},
+				},
+			},
+			"checksum": schema.StringAttribute{
+				CustomType:  ovhtypes.TfStringType{},
+				Computed:    true,
+				Description: "Computed hash representing the current target specification value",
+			},
+			"created_at": schema.StringAttribute{
+				CustomType:  ovhtypes.TfStringType{},
+				Computed:    true,
+				Description: "Creation date of the floating IP",
+			},
+			"updated_at": schema.StringAttribute{
+				CustomType:  ovhtypes.TfStringType{},
+				Computed:    true,
+				Description: "Last update date of the floating IP",
+			},
+			"resource_status": schema.StringAttribute{
+				CustomType:  ovhtypes.TfStringType{},
+				Computed:    true,
+				Description: "Floating IP readiness in the system (CREATING, DELETING, ERROR, OUT_OF_SYNC, READY, UPDATING)",
+			},
+			"current_state": schema.SingleNestedAttribute{
+				Computed:    true,
+				Description: "Current state of the floating IP",
+				Attributes: map[string]schema.Attribute{
+					"id": schema.StringAttribute{
+						CustomType:  ovhtypes.TfStringType{},
+						Computed:    true,
+						Description: "OpenStack identifier of the floating IP",
+					},
+					"ip": schema.StringAttribute{
+						CustomType:  ovhtypes.TfStringType{},
+						Computed:    true,
+						Description: "IP address of the floating IP",
+					},
+					"status": schema.StringAttribute{
+						CustomType:  ovhtypes.TfStringType{},
+						Computed:    true,
+						Description: "OpenStack status of the floating IP (ACTIVE, DOWN, ERROR)",
+					},
+					"description": schema.StringAttribute{
+						CustomType:  ovhtypes.TfStringType{},
+						Computed:    true,
+						Description: "Description of the floating IP",
+					},
+					"network": schema.SingleNestedAttribute{
+						Computed:    true,
+						Description: "External network the floating IP belongs to",
+						Attributes: map[string]schema.Attribute{
+							"id": schema.StringAttribute{
+								CustomType:  ovhtypes.TfStringType{},
+								Computed:    true,
+								Description: "Network ID",
+							},
+						},
+					},
+					"associated_resource": schema.SingleNestedAttribute{
+						Computed:    true,
+						Description: "Resource the floating IP is currently attached to",
+						Attributes: map[string]schema.Attribute{
+							"id": schema.StringAttribute{
+								CustomType:  ovhtypes.TfStringType{},
+								Computed:    true,
+								Description: "ID of the associated resource",
+							},
+							"type": schema.StringAttribute{
+								CustomType:  ovhtypes.TfStringType{},
+								Computed:    true,
+								Description: "Type of the associated resource",
+							},
+						},
+					},
+					"location": schema.SingleNestedAttribute{
+						Computed:    true,
+						Description: "Location details",
+						Attributes: map[string]schema.Attribute{
+							"region": schema.StringAttribute{
+								CustomType:  ovhtypes.TfStringType{},
+								Computed:    true,
+								Description: "Region",
+							},
+							"availability_zone": schema.StringAttribute{
+								CustomType:  ovhtypes.TfStringType{},
+								Computed:    true,
+								Description: "Availability zone",
+							},
+						},
+					},
+				},
+			},
+			"current_tasks": schema.ListNestedAttribute{
+				Computed:    true,
+				Description: "Ongoing asynchronous tasks related to the floating IP",
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]schema.Attribute{
+						"errors": schema.ListNestedAttribute{
+							Computed:    true,
+							Description: "Errors that occured on the task",
+							NestedObject: schema.NestedAttributeObject{
+								Attributes: map[string]schema.Attribute{
+									"message": schema.StringAttribute{
+										CustomType:  ovhtypes.TfStringType{},
+										Computed:    true,
+										Description: "Error description",
+									},
+								},
+							},
+						},
+						"id": schema.StringAttribute{
+							CustomType:  ovhtypes.TfStringType{},
+							Computed:    true,
+							Description: "Identifier of the current task",
+						},
+						"link": schema.StringAttribute{
+							CustomType:  ovhtypes.TfStringType{},
+							Computed:    true,
+							Description: "Link to the task details",
+						},
+						"status": schema.StringAttribute{
+							CustomType:  ovhtypes.TfStringType{},
+							Computed:    true,
+							Description: "Current global status of the current task",
+						},
+						"type": schema.StringAttribute{
+							CustomType:  ovhtypes.TfStringType{},
+							Computed:    true,
+							Description: "Type of the current task",
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+// cloudFloatingIPDataSourceModel is the Terraform state model for this data
+// source. It mirrors the resource model but exposes the location as a nested
+// object (the floating IP is fetched by IP, so region/AZ are computed, not user
+// input).
+type cloudFloatingIPDataSourceModel struct {
+	ServiceName    ovhtypes.TfStringValue `tfsdk:"service_name"`
+	Id             ovhtypes.TfStringValue `tfsdk:"id"`
+	Description    ovhtypes.TfStringValue `tfsdk:"description"`
+	Location       types.Object           `tfsdk:"location"`
+	Checksum       ovhtypes.TfStringValue `tfsdk:"checksum"`
+	CreatedAt      ovhtypes.TfStringValue `tfsdk:"created_at"`
+	UpdatedAt      ovhtypes.TfStringValue `tfsdk:"updated_at"`
+	ResourceStatus ovhtypes.TfStringValue `tfsdk:"resource_status"`
+	CurrentState   types.Object           `tfsdk:"current_state"`
+	CurrentTasks   types.List             `tfsdk:"current_tasks"`
+}
+
+func (d *cloudFloatingIPDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+	var data cloudFloatingIPDataSourceModel
+
+	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	endpoint := "/v2/publicCloud/project/" + url.PathEscape(data.ServiceName.ValueString()) + "/publicIp/floating/" + url.PathEscape(data.Id.ValueString())
+
+	var responseData CloudFloatingIPAPIResponse
+	if err := d.config.OVHClient.Get(endpoint, &responseData); err != nil {
+		resp.Diagnostics.AddError(
+			fmt.Sprintf("Error calling Get %s", endpoint),
+			err.Error(),
+		)
+		return
+	}
+
+	// Reuse the resource model's mapping, then project it onto the data source
+	// model which exposes the location as a nested computed object.
+	var m CloudFloatingIPModel
+	m.ServiceName = data.ServiceName
+	m.Id = data.Id
+	m.MergeWith(ctx, &responseData)
+
+	locationVal, diags := types.ObjectValue(
+		cloudPublicIPLocationAttrTypes(),
+		map[string]attr.Value{
+			"region":            m.Region,
+			"availability_zone": m.AvailabilityZone,
+		},
+	)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	data.Location = locationVal
+	data.Description = m.Description
+	data.Checksum = m.Checksum
+	data.CreatedAt = m.CreatedAt
+	data.UpdatedAt = m.UpdatedAt
+	data.ResourceStatus = m.ResourceStatus
+	data.CurrentState = m.CurrentState
+	data.CurrentTasks = m.CurrentTasks
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}

--- a/ovh/data_cloud_floating_ip_test.go
+++ b/ovh/data_cloud_floating_ip_test.go
@@ -1,0 +1,50 @@
+package ovh
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+func TestAccDataSourceCloudFloatingIP_basic(t *testing.T) {
+	serviceName := os.Getenv("OVH_CLOUD_PROJECT_SERVICE_TEST")
+	region := os.Getenv("OVH_CLOUD_PROJECT_REGION_TEST")
+
+	description := acctest.RandomWithPrefix(testAccResourceCloudFloatingIPDescriptionPrefix)
+
+	config := fmt.Sprintf(`
+resource "ovh_cloud_floating_ip" "test" {
+  service_name = "%s"
+  region       = "%s"
+  description  = "%s"
+}
+
+data "ovh_cloud_floating_ip" "test" {
+  service_name = ovh_cloud_floating_ip.test.service_name
+  id           = ovh_cloud_floating_ip.test.id
+}
+`, serviceName, region, description)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheckCloudPublicIP(t)
+		},
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("data.ovh_cloud_floating_ip.test", "service_name", serviceName),
+					resource.TestCheckResourceAttr("data.ovh_cloud_floating_ip.test", "description", description),
+					resource.TestCheckResourceAttr("data.ovh_cloud_floating_ip.test", "location.region", region),
+					resource.TestCheckResourceAttrSet("data.ovh_cloud_floating_ip.test", "id"),
+					resource.TestCheckResourceAttrSet("data.ovh_cloud_floating_ip.test", "checksum"),
+					resource.TestCheckResourceAttrSet("data.ovh_cloud_floating_ip.test", "current_state.ip"),
+				),
+			},
+		},
+	})
+}

--- a/ovh/data_cloud_floating_ips.go
+++ b/ovh/data_cloud_floating_ips.go
@@ -1,0 +1,258 @@
+package ovh
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/ovh/terraform-provider-ovh/v2/ovh/helpers"
+	ovhtypes "github.com/ovh/terraform-provider-ovh/v2/ovh/types"
+)
+
+var _ datasource.DataSourceWithConfigure = (*cloudFloatingIPsDataSource)(nil)
+
+func NewCloudFloatingIPsDataSource() datasource.DataSource {
+	return &cloudFloatingIPsDataSource{}
+}
+
+type cloudFloatingIPsDataSource struct {
+	config *Config
+}
+
+// cloudFloatingIPsDataSourceModel is the model for the plural floating IPs data source.
+type cloudFloatingIPsDataSourceModel struct {
+	ServiceName ovhtypes.TfStringValue `tfsdk:"service_name"`
+	FloatingIPs types.List             `tfsdk:"floating_ips"`
+}
+
+func (d *cloudFloatingIPsDataSource) Metadata(ctx context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_cloud_floating_ips"
+}
+
+func (d *cloudFloatingIPsDataSource) Configure(_ context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+
+	config, ok := req.ProviderData.(*Config)
+	if !ok {
+		resp.Diagnostics.AddError(
+			"Unexpected Data Source Configure Type",
+			fmt.Sprintf("Expected *Config, got: %T. Please report this issue to the provider developers.", req.ProviderData),
+		)
+		return
+	}
+
+	d.config = config
+}
+
+func (d *cloudFloatingIPsDataSource) Schema(ctx context.Context, req datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Description: "Use this data source to list the floating IPs of a public cloud project.",
+		Attributes: map[string]schema.Attribute{
+			"service_name": schema.StringAttribute{
+				CustomType:  ovhtypes.TfStringType{},
+				Required:    true,
+				Description: "Service name of the resource representing the id of the cloud project",
+			},
+			"floating_ips": schema.ListNestedAttribute{
+				Computed:    true,
+				Description: "List of floating IPs",
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]schema.Attribute{
+						"id": schema.StringAttribute{
+							CustomType:  ovhtypes.TfStringType{},
+							Computed:    true,
+							Description: "IP address of the floating IP",
+						},
+						"description": schema.StringAttribute{
+							CustomType:  ovhtypes.TfStringType{},
+							Computed:    true,
+							Description: "Description of the floating IP",
+						},
+						"location": schema.SingleNestedAttribute{
+							Computed:    true,
+							Description: "Location of the floating IP",
+							Attributes: map[string]schema.Attribute{
+								"region": schema.StringAttribute{
+									CustomType:  ovhtypes.TfStringType{},
+									Computed:    true,
+									Description: "Region",
+								},
+								"availability_zone": schema.StringAttribute{
+									CustomType:  ovhtypes.TfStringType{},
+									Computed:    true,
+									Description: "Availability zone",
+								},
+							},
+						},
+						"checksum": schema.StringAttribute{
+							CustomType:  ovhtypes.TfStringType{},
+							Computed:    true,
+							Description: "Computed hash representing the current target specification value",
+						},
+						"created_at": schema.StringAttribute{
+							CustomType:  ovhtypes.TfStringType{},
+							Computed:    true,
+							Description: "Creation date of the floating IP",
+						},
+						"updated_at": schema.StringAttribute{
+							CustomType:  ovhtypes.TfStringType{},
+							Computed:    true,
+							Description: "Last update date of the floating IP",
+						},
+						"resource_status": schema.StringAttribute{
+							CustomType:  ovhtypes.TfStringType{},
+							Computed:    true,
+							Description: "Floating IP readiness in the system (CREATING, DELETING, ERROR, OUT_OF_SYNC, READY, UPDATING)",
+						},
+						"current_state": schema.SingleNestedAttribute{
+							Computed:    true,
+							Description: "Current state of the floating IP",
+							Attributes: map[string]schema.Attribute{
+								"id": schema.StringAttribute{
+									CustomType:  ovhtypes.TfStringType{},
+									Computed:    true,
+									Description: "OpenStack identifier of the floating IP",
+								},
+								"ip": schema.StringAttribute{
+									CustomType:  ovhtypes.TfStringType{},
+									Computed:    true,
+									Description: "IP address of the floating IP",
+								},
+								"status": schema.StringAttribute{
+									CustomType:  ovhtypes.TfStringType{},
+									Computed:    true,
+									Description: "OpenStack status of the floating IP (ACTIVE, DOWN, ERROR)",
+								},
+								"description": schema.StringAttribute{
+									CustomType:  ovhtypes.TfStringType{},
+									Computed:    true,
+									Description: "Description of the floating IP",
+								},
+								"network": schema.SingleNestedAttribute{
+									Computed:    true,
+									Description: "External network the floating IP belongs to",
+									Attributes: map[string]schema.Attribute{
+										"id": schema.StringAttribute{
+											CustomType:  ovhtypes.TfStringType{},
+											Computed:    true,
+											Description: "Network ID",
+										},
+									},
+								},
+								"associated_resource": schema.SingleNestedAttribute{
+									Computed:    true,
+									Description: "Resource the floating IP is currently attached to",
+									Attributes: map[string]schema.Attribute{
+										"id": schema.StringAttribute{
+											CustomType:  ovhtypes.TfStringType{},
+											Computed:    true,
+											Description: "ID of the associated resource",
+										},
+										"type": schema.StringAttribute{
+											CustomType:  ovhtypes.TfStringType{},
+											Computed:    true,
+											Description: "Type of the associated resource",
+										},
+									},
+								},
+								"location": schema.SingleNestedAttribute{
+									Computed:    true,
+									Description: "Location details",
+									Attributes: map[string]schema.Attribute{
+										"region": schema.StringAttribute{
+											CustomType:  ovhtypes.TfStringType{},
+											Computed:    true,
+											Description: "Region",
+										},
+										"availability_zone": schema.StringAttribute{
+											CustomType:  ovhtypes.TfStringType{},
+											Computed:    true,
+											Description: "Availability zone",
+										},
+									},
+								},
+							},
+						},
+						"current_tasks": schema.ListNestedAttribute{
+							Computed:    true,
+							Description: "Ongoing asynchronous tasks related to the floating IP",
+							NestedObject: schema.NestedAttributeObject{
+								Attributes: map[string]schema.Attribute{
+									"errors": schema.ListNestedAttribute{
+										Computed:    true,
+										Description: "Errors that occured on the task",
+										NestedObject: schema.NestedAttributeObject{
+											Attributes: map[string]schema.Attribute{
+												"message": schema.StringAttribute{
+													CustomType:  ovhtypes.TfStringType{},
+													Computed:    true,
+													Description: "Error description",
+												},
+											},
+										},
+									},
+									"id": schema.StringAttribute{
+										CustomType:  ovhtypes.TfStringType{},
+										Computed:    true,
+										Description: "Identifier of the current task",
+									},
+									"link": schema.StringAttribute{
+										CustomType:  ovhtypes.TfStringType{},
+										Computed:    true,
+										Description: "Link to the task details",
+									},
+									"status": schema.StringAttribute{
+										CustomType:  ovhtypes.TfStringType{},
+										Computed:    true,
+										Description: "Current global status of the current task",
+									},
+									"type": schema.StringAttribute{
+										CustomType:  ovhtypes.TfStringType{},
+										Computed:    true,
+										Description: "Type of the current task",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func (d *cloudFloatingIPsDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+	var data cloudFloatingIPsDataSourceModel
+
+	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	endpoint := "/v2/publicCloud/project/" + url.PathEscape(data.ServiceName.ValueString()) + "/publicIp/floating"
+
+	responseData, err := helpers.GetAllPagesV2[CloudFloatingIPAPIResponse](ctx, d.config.OVHClient, endpoint)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			fmt.Sprintf("Error calling Get %s", endpoint),
+			err.Error(),
+		)
+		return
+	}
+
+	itemObjType := types.ObjectType{AttrTypes: CloudFloatingIPListItemAttrTypes()}
+	items := make([]attr.Value, 0, len(responseData))
+	for i := range responseData {
+		items = append(items, buildCloudFloatingIPListItemObject(ctx, &responseData[i]))
+	}
+
+	data.FloatingIPs = types.ListValueMust(itemObjType, items)
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}

--- a/ovh/data_cloud_floating_ips_test.go
+++ b/ovh/data_cloud_floating_ips_test.go
@@ -1,0 +1,47 @@
+package ovh
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+func TestAccDataSourceCloudFloatingIPs_basic(t *testing.T) {
+	serviceName := os.Getenv("OVH_CLOUD_PROJECT_SERVICE_TEST")
+	region := os.Getenv("OVH_CLOUD_PROJECT_REGION_TEST")
+
+	description := acctest.RandomWithPrefix(testAccResourceCloudFloatingIPDescriptionPrefix)
+
+	config := fmt.Sprintf(`
+resource "ovh_cloud_floating_ip" "test" {
+  service_name = "%s"
+  region       = "%s"
+  description  = "%s"
+}
+
+data "ovh_cloud_floating_ips" "test" {
+  service_name = ovh_cloud_floating_ip.test.service_name
+
+  depends_on = [ovh_cloud_floating_ip.test]
+}
+`, serviceName, region, description)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheckCloudPublicIP(t)
+		},
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("data.ovh_cloud_floating_ips.test", "service_name", serviceName),
+					resource.TestCheckResourceAttrWith("data.ovh_cloud_floating_ips.test", "floating_ips.#", testAccCheckCloudPublicIPListNotEmpty),
+				),
+			},
+		},
+	})
+}

--- a/ovh/data_cloud_public_ips.go
+++ b/ovh/data_cloud_public_ips.go
@@ -1,0 +1,141 @@
+package ovh
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/ovh/terraform-provider-ovh/v2/ovh/helpers"
+	ovhtypes "github.com/ovh/terraform-provider-ovh/v2/ovh/types"
+)
+
+var _ datasource.DataSourceWithConfigure = (*cloudPublicIPsDataSource)(nil)
+
+func NewCloudPublicIPsDataSource() datasource.DataSource {
+	return &cloudPublicIPsDataSource{}
+}
+
+type cloudPublicIPsDataSource struct {
+	config *Config
+}
+
+func (d *cloudPublicIPsDataSource) Metadata(ctx context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_cloud_public_ips"
+}
+
+func (d *cloudPublicIPsDataSource) Configure(_ context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+
+	config, ok := req.ProviderData.(*Config)
+	if !ok {
+		resp.Diagnostics.AddError(
+			"Unexpected Data Source Configure Type",
+			fmt.Sprintf("Expected *Config, got: %T. Please report this issue to the provider developers.", req.ProviderData),
+		)
+		return
+	}
+
+	d.config = config
+}
+
+func (d *cloudPublicIPsDataSource) Schema(ctx context.Context, req datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Description: "Use this data source to list all public IPs (additional, external network and floating IPs) of a public cloud project.",
+		Attributes: map[string]schema.Attribute{
+			"service_name": schema.StringAttribute{
+				CustomType:  ovhtypes.TfStringType{},
+				Required:    true,
+				Description: "Service name of the resource representing the id of the cloud project",
+			},
+			"public_ips": schema.ListNestedAttribute{
+				Computed:    true,
+				Description: "List of public IPs of the project",
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]schema.Attribute{
+						"ip": schema.StringAttribute{
+							CustomType:  ovhtypes.TfStringType{},
+							Computed:    true,
+							Description: "Public IP address",
+						},
+						"type": schema.StringAttribute{
+							CustomType:  ovhtypes.TfStringType{},
+							Computed:    true,
+							Description: "Type of the public IP (ADDITIONAL_IP, EXT_NET_IP, FLOATING_IP)",
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+// cloudPublicIPsDataSourceModel is the Terraform state model for this data source.
+type cloudPublicIPsDataSourceModel struct {
+	ServiceName ovhtypes.TfStringValue `tfsdk:"service_name"`
+	PublicIPs   types.List             `tfsdk:"public_ips"`
+}
+
+// cloudPublicIPSummaryAttrTypes returns the attribute types for a single public IP
+// item of the list.
+func cloudPublicIPSummaryAttrTypes() map[string]attr.Type {
+	return map[string]attr.Type{
+		"ip":   ovhtypes.TfStringType{},
+		"type": ovhtypes.TfStringType{},
+	}
+}
+
+func (d *cloudPublicIPsDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+	var data cloudPublicIPsDataSourceModel
+
+	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	endpoint := "/v2/publicCloud/project/" + url.PathEscape(data.ServiceName.ValueString()) + "/publicIp"
+
+	apiPublicIPs, err := helpers.GetAllPagesV2[CloudPublicIPSummary](ctx, d.config.OVHClient, endpoint)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			fmt.Sprintf("Error calling Get %s", endpoint),
+			err.Error(),
+		)
+		return
+	}
+
+	publicIPObjs := make([]attr.Value, 0, len(apiPublicIPs))
+	for _, publicIP := range apiPublicIPs {
+		itemObj, diags := types.ObjectValue(
+			cloudPublicIPSummaryAttrTypes(),
+			map[string]attr.Value{
+				"ip":   ovhtypes.TfStringValue{StringValue: types.StringValue(publicIP.IP)},
+				"type": ovhtypes.TfStringValue{StringValue: types.StringValue(publicIP.Type)},
+			},
+		)
+		resp.Diagnostics.Append(diags...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+
+		publicIPObjs = append(publicIPObjs, itemObj)
+	}
+
+	publicIPsList, diags := types.ListValue(
+		types.ObjectType{AttrTypes: cloudPublicIPSummaryAttrTypes()},
+		publicIPObjs,
+	)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	data.PublicIPs = publicIPsList
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}

--- a/ovh/data_cloud_public_ips_test.go
+++ b/ovh/data_cloud_public_ips_test.go
@@ -1,0 +1,47 @@
+package ovh
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+func TestAccDataSourceCloudPublicIPs_basic(t *testing.T) {
+	serviceName := os.Getenv("OVH_CLOUD_PROJECT_SERVICE_TEST")
+	region := os.Getenv("OVH_CLOUD_PROJECT_REGION_TEST")
+
+	description := acctest.RandomWithPrefix(testAccResourceCloudFloatingIPDescriptionPrefix)
+
+	config := fmt.Sprintf(`
+resource "ovh_cloud_floating_ip" "test" {
+  service_name = "%s"
+  region       = "%s"
+  description  = "%s"
+}
+
+data "ovh_cloud_public_ips" "test" {
+  service_name = ovh_cloud_floating_ip.test.service_name
+
+  depends_on = [ovh_cloud_floating_ip.test]
+}
+`, serviceName, region, description)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheckCloudPublicIP(t)
+		},
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("data.ovh_cloud_public_ips.test", "service_name", serviceName),
+					resource.TestCheckResourceAttrWith("data.ovh_cloud_public_ips.test", "public_ips.#", testAccCheckCloudPublicIPListNotEmpty),
+				),
+			},
+		},
+	})
+}

--- a/ovh/provider_new.go
+++ b/ovh/provider_new.go
@@ -227,12 +227,19 @@ func (p *OvhProvider) Configure(ctx context.Context, req provider.ConfigureReque
 // DataSources defines the data sources implemented in the provider.
 func (p *OvhProvider) DataSources(_ context.Context) []func() datasource.DataSource {
 	return []func() datasource.DataSource{
+		NewCloudAdditionalIPDataSource,
+		NewCloudAdditionalIPsDataSource,
+		NewCloudExtNetIPDataSource,
+		NewCloudExtNetIPsDataSource,
+		NewCloudFloatingIPDataSource,
+		NewCloudFloatingIPsDataSource,
 		NewCloudGatewayDataSource,
 		NewCloudGatewaysDataSource,
 		NewCloudNetworkPrivateVrackDataSource,
 		NewCloudNetworkPrivateVracksDataSource,
 		NewCloudNetworkPrivateVrackSubnetDataSource,
 		NewCloudNetworkPrivateVrackSubnetsDataSource,
+		NewCloudPublicIPsDataSource,
 		NewCloudQuotaDataSource,
 		NewCloudSecurityGroupDataSource,
 		NewCloudSecurityGroupsDataSource,
@@ -318,6 +325,7 @@ func (p *OvhProvider) DataSources(_ context.Context) []func() datasource.DataSou
 // Resources defines the resources implemented in the provider.
 func (p *OvhProvider) Resources(_ context.Context) []func() resource.Resource {
 	return []func() resource.Resource{
+		NewCloudFloatingIPResource,
 		NewCloudGatewayResource,
 		NewCloudNetworkPrivateVrackResource,
 		NewCloudNetworkPrivateVrackSubnetResource,

--- a/ovh/resource_cloud_floating_ip.go
+++ b/ovh/resource_cloud_floating_ip.go
@@ -1,0 +1,449 @@
+package ovh
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
+	"github.com/ovh/go-ovh/ovh"
+	"github.com/ovh/terraform-provider-ovh/v2/ovh/helpers"
+	ovhtypes "github.com/ovh/terraform-provider-ovh/v2/ovh/types"
+)
+
+var (
+	_ resource.Resource                = (*cloudFloatingIPResource)(nil)
+	_ resource.ResourceWithConfigure   = (*cloudFloatingIPResource)(nil)
+	_ resource.ResourceWithImportState = (*cloudFloatingIPResource)(nil)
+)
+
+func NewCloudFloatingIPResource() resource.Resource {
+	return &cloudFloatingIPResource{}
+}
+
+type cloudFloatingIPResource struct {
+	config *Config
+}
+
+func (r *cloudFloatingIPResource) Metadata(ctx context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_cloud_floating_ip"
+}
+
+func (r *cloudFloatingIPResource) Configure(ctx context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+
+	config, ok := req.ProviderData.(*Config)
+	if !ok {
+		resp.Diagnostics.AddError(
+			"Unexpected Resource Configure Type",
+			fmt.Sprintf("Expected *Config, got: %T. Please report this issue to the provider developers.", req.ProviderData),
+		)
+		return
+	}
+
+	r.config = config
+}
+
+var floatingIPMutableAttrs = MutableAttrs{
+	Strings: []string{"description"},
+}
+
+func (r *cloudFloatingIPResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Description: "Creates a floating IP in a public cloud project.",
+		Attributes: map[string]schema.Attribute{
+			"service_name": schema.StringAttribute{
+				CustomType:          ovhtypes.TfStringType{},
+				Required:            true,
+				Description:         "Service name of the resource representing the id of the cloud project",
+				MarkdownDescription: "Service name of the resource representing the id of the cloud project",
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+			},
+			"region": schema.StringAttribute{
+				CustomType:          ovhtypes.TfStringType{},
+				Required:            true,
+				Description:         "Region where the floating IP will be created",
+				MarkdownDescription: "Region where the floating IP will be created",
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+			},
+			"availability_zone": schema.StringAttribute{
+				CustomType:          ovhtypes.TfStringType{},
+				Optional:            true,
+				Description:         "Availability zone for the floating IP",
+				MarkdownDescription: "Availability zone for the floating IP",
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+			},
+			"description": schema.StringAttribute{
+				CustomType:          ovhtypes.TfStringType{},
+				Optional:            true,
+				Description:         "Description of the floating IP",
+				MarkdownDescription: "Description of the floating IP",
+			},
+			"id": schema.StringAttribute{
+				CustomType:          ovhtypes.TfStringType{},
+				Computed:            true,
+				Description:         "IP address of the floating IP",
+				MarkdownDescription: "IP address of the floating IP",
+			},
+			"checksum": schema.StringAttribute{
+				CustomType:          ovhtypes.TfStringType{},
+				Computed:            true,
+				Description:         "Computed hash representing the current target specification value",
+				MarkdownDescription: "Computed hash representing the current target specification value",
+				PlanModifiers: []planmodifier.String{
+					UnknownDuringUpdateStringModifier(floatingIPMutableAttrs),
+				},
+			},
+			"created_at": schema.StringAttribute{
+				CustomType:          ovhtypes.TfStringType{},
+				Computed:            true,
+				Description:         "Creation date of the floating IP",
+				MarkdownDescription: "Creation date of the floating IP",
+			},
+			"updated_at": schema.StringAttribute{
+				CustomType:          ovhtypes.TfStringType{},
+				Computed:            true,
+				Description:         "Last update date of the floating IP",
+				MarkdownDescription: "Last update date of the floating IP",
+				PlanModifiers: []planmodifier.String{
+					UnknownDuringUpdateStringModifier(floatingIPMutableAttrs),
+				},
+			},
+			"resource_status": schema.StringAttribute{
+				CustomType:          ovhtypes.TfStringType{},
+				Computed:            true,
+				Description:         "Floating IP readiness in the system (CREATING, DELETING, ERROR, OUT_OF_SYNC, READY, UPDATING)",
+				MarkdownDescription: "Floating IP readiness in the system (`CREATING`, `DELETING`, `ERROR`, `OUT_OF_SYNC`, `READY`, `UPDATING`)",
+				PlanModifiers: []planmodifier.String{
+					OutOfSyncPlanModifier(),
+				},
+			},
+			"current_state": schema.SingleNestedAttribute{
+				Computed:    true,
+				Description: "Current state of the floating IP",
+				PlanModifiers: []planmodifier.Object{
+					UnknownDuringUpdateObjectModifier(floatingIPMutableAttrs),
+				},
+				Attributes: map[string]schema.Attribute{
+					"id": schema.StringAttribute{
+						CustomType:  ovhtypes.TfStringType{},
+						Computed:    true,
+						Description: "OpenStack identifier of the floating IP",
+					},
+					"ip": schema.StringAttribute{
+						CustomType:  ovhtypes.TfStringType{},
+						Computed:    true,
+						Description: "IP address of the floating IP",
+					},
+					"status": schema.StringAttribute{
+						CustomType:  ovhtypes.TfStringType{},
+						Computed:    true,
+						Description: "OpenStack status of the floating IP (ACTIVE, DOWN, ERROR)",
+					},
+					"description": schema.StringAttribute{
+						CustomType:  ovhtypes.TfStringType{},
+						Computed:    true,
+						Description: "Description of the floating IP",
+					},
+					"network": schema.SingleNestedAttribute{
+						Computed:    true,
+						Description: "External network the floating IP belongs to",
+						Attributes: map[string]schema.Attribute{
+							"id": schema.StringAttribute{
+								CustomType:  ovhtypes.TfStringType{},
+								Computed:    true,
+								Description: "Network ID",
+							},
+						},
+					},
+					"associated_resource": schema.SingleNestedAttribute{
+						Computed:    true,
+						Description: "Resource the floating IP is currently attached to",
+						Attributes: map[string]schema.Attribute{
+							"id": schema.StringAttribute{
+								CustomType:  ovhtypes.TfStringType{},
+								Computed:    true,
+								Description: "ID of the associated resource",
+							},
+							"type": schema.StringAttribute{
+								CustomType:  ovhtypes.TfStringType{},
+								Computed:    true,
+								Description: "Type of the associated resource",
+							},
+						},
+					},
+					"location": schema.SingleNestedAttribute{
+						Computed:    true,
+						Description: "Location details",
+						Attributes: map[string]schema.Attribute{
+							"region": schema.StringAttribute{
+								CustomType:  ovhtypes.TfStringType{},
+								Computed:    true,
+								Description: "Region",
+							},
+							"availability_zone": schema.StringAttribute{
+								CustomType:  ovhtypes.TfStringType{},
+								Computed:    true,
+								Description: "Availability zone",
+							},
+						},
+					},
+				},
+			},
+			"current_tasks": schema.ListNestedAttribute{
+				Computed:            true,
+				Description:         "Ongoing asynchronous tasks related to the floating IP",
+				MarkdownDescription: "Ongoing asynchronous tasks related to the floating IP",
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]schema.Attribute{
+						"errors": schema.ListNestedAttribute{
+							Computed:    true,
+							Description: "Errors that occured on the task",
+							NestedObject: schema.NestedAttributeObject{
+								Attributes: map[string]schema.Attribute{
+									"message": schema.StringAttribute{
+										CustomType:  ovhtypes.TfStringType{},
+										Computed:    true,
+										Description: "Error description",
+									},
+								},
+							},
+						},
+						"id": schema.StringAttribute{
+							CustomType:  ovhtypes.TfStringType{},
+							Computed:    true,
+							Description: "Identifier of the current task",
+						},
+						"link": schema.StringAttribute{
+							CustomType:  ovhtypes.TfStringType{},
+							Computed:    true,
+							Description: "Link to the task details",
+						},
+						"status": schema.StringAttribute{
+							CustomType:  ovhtypes.TfStringType{},
+							Computed:    true,
+							Description: "Current global status of the current task",
+						},
+						"type": schema.StringAttribute{
+							CustomType:  ovhtypes.TfStringType{},
+							Computed:    true,
+							Description: "Type of the current task",
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func (r *cloudFloatingIPResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	splits := strings.Split(req.ID, "/")
+	if len(splits) != 2 {
+		resp.Diagnostics.AddError("Given ID is malformed", "ID must be formatted like the following: <service_name>/<ip>")
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("service_name"), splits[0])...)
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("id"), splits[1])...)
+}
+
+func (r *cloudFloatingIPResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	var data CloudFloatingIPModel
+
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	createPayload := data.ToCreate()
+
+	endpoint := "/v2/publicCloud/project/" + url.PathEscape(data.ServiceName.ValueString()) + "/publicIp/floating"
+
+	var responseData CloudFloatingIPAPIResponse
+	if err := r.config.OVHClient.Post(endpoint, createPayload, &responseData); err != nil {
+		resp.Diagnostics.AddError(
+			fmt.Sprintf("Error calling Post %s", endpoint),
+			err.Error(),
+		)
+		return
+	}
+
+	if responseData.ID == "" {
+		resp.Diagnostics.AddError(
+			"API did not return the created floating IP",
+			"The creation request was accepted but the API response does not contain the IP address of the "+
+				"created floating IP. The API deployment serving this project is too old to return the created IP: "+
+				"the floating IP may have been created but cannot be tracked by Terraform. Please check your "+
+				"project for orphaned floating IPs and contact OVHcloud support to upgrade the API deployment.",
+		)
+		return
+	}
+
+	// Save state immediately so the resource IP is tracked even if the workflow fails
+	data.MergeWith(ctx, &responseData)
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+
+	// Wait for floating IP to be READY
+	itemEndpoint := endpoint + "/" + url.PathEscape(responseData.ID)
+	if err := helpers.WaitForAPIv2ResourceStatusReady(ctx, r.config.OVHClient, itemEndpoint); err != nil {
+		resp.Diagnostics.AddError(
+			"Error waiting for floating IP to be ready",
+			err.Error(),
+		)
+		return
+	}
+
+	// Read final state
+	if err := r.config.OVHClient.Get(itemEndpoint, &responseData); err != nil {
+		resp.Diagnostics.AddError(
+			fmt.Sprintf("Error calling Get %s", itemEndpoint),
+			err.Error(),
+		)
+		return
+	}
+
+	data.MergeWith(ctx, &responseData)
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+func (r *cloudFloatingIPResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	var data CloudFloatingIPModel
+
+	resp.Diagnostics.Append(req.State.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	endpoint := "/v2/publicCloud/project/" + url.PathEscape(data.ServiceName.ValueString()) + "/publicIp/floating/" + url.PathEscape(data.Id.ValueString())
+
+	var responseData CloudFloatingIPAPIResponse
+	if err := r.config.OVHClient.Get(endpoint, &responseData); err != nil {
+		if errOvh, ok := err.(*ovh.APIError); ok && errOvh.Code == 404 {
+			resp.State.RemoveResource(ctx)
+			return
+		}
+		resp.Diagnostics.AddError(
+			fmt.Sprintf("Error calling Get %s", endpoint),
+			err.Error(),
+		)
+		return
+	}
+
+	data.MergeWith(ctx, &responseData)
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+func (r *cloudFloatingIPResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	var data, planData CloudFloatingIPModel
+
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &planData)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	resp.Diagnostics.Append(req.State.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	updatePayload := planData.ToUpdate(data.Checksum.ValueString())
+
+	endpoint := "/v2/publicCloud/project/" + url.PathEscape(data.ServiceName.ValueString()) + "/publicIp/floating/" + url.PathEscape(data.Id.ValueString())
+
+	var responseData CloudFloatingIPAPIResponse
+	if err := r.config.OVHClient.Put(endpoint, updatePayload, &responseData); err != nil {
+		resp.Diagnostics.AddError(
+			fmt.Sprintf("Error calling Put %s", endpoint),
+			err.Error(),
+		)
+		return
+	}
+
+	// Wait for floating IP to be READY
+	if err := helpers.WaitForAPIv2ResourceStatusReady(ctx, r.config.OVHClient, endpoint); err != nil {
+		resp.Diagnostics.AddError(
+			"Error waiting for floating IP to be ready after update",
+			err.Error(),
+		)
+		return
+	}
+
+	// Read final state
+	if err := r.config.OVHClient.Get(endpoint, &responseData); err != nil {
+		resp.Diagnostics.AddError(
+			fmt.Sprintf("Error calling Get %s", endpoint),
+			err.Error(),
+		)
+		return
+	}
+
+	planData.MergeWith(ctx, &responseData)
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &planData)...)
+}
+
+func (r *cloudFloatingIPResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	var data CloudFloatingIPModel
+
+	resp.Diagnostics.Append(req.State.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	endpoint := "/v2/publicCloud/project/" + url.PathEscape(data.ServiceName.ValueString()) + "/publicIp/floating/" + url.PathEscape(data.Id.ValueString())
+
+	if err := r.config.OVHClient.Delete(endpoint, nil); err != nil {
+		if errOvh, ok := err.(*ovh.APIError); ok && errOvh.Code == 404 {
+			return
+		}
+		resp.Diagnostics.AddError(
+			fmt.Sprintf("Error calling Delete %s", endpoint),
+			err.Error(),
+		)
+		return
+	}
+
+	// Wait for deletion to complete
+	stateConf := &retry.StateChangeConf{
+		Pending: []string{"DELETING"},
+		Target:  []string{"DELETED"},
+		Refresh: func() (interface{}, string, error) {
+			res := &CloudFloatingIPAPIResponse{}
+			err := r.config.OVHClient.GetWithContext(ctx, endpoint, res)
+			if err != nil {
+				if errOvh, ok := err.(*ovh.APIError); ok && errOvh.Code == 404 {
+					return res, "DELETED", nil
+				}
+				return res, "", err
+			}
+			return res, res.ResourceStatus, nil
+		},
+		Timeout:    20 * time.Minute,
+		Delay:      10 * time.Second,
+		MinTimeout: 5 * time.Second,
+	}
+
+	if _, err := stateConf.WaitForStateContext(ctx); err != nil {
+		resp.Diagnostics.AddError(
+			"Error waiting for floating IP to be deleted",
+			err.Error(),
+		)
+	}
+}

--- a/ovh/resource_cloud_floating_ip_test.go
+++ b/ovh/resource_cloud_floating_ip_test.go
@@ -1,0 +1,153 @@
+package ovh
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+)
+
+const testAccResourceCloudFloatingIPDescriptionPrefix = "tf-test-public-ip-floating-"
+
+func TestAccCloudFloatingIP_basic(t *testing.T) {
+	serviceName := os.Getenv("OVH_CLOUD_PROJECT_SERVICE_TEST")
+	region := os.Getenv("OVH_CLOUD_PROJECT_REGION_TEST")
+
+	description := acctest.RandomWithPrefix(testAccResourceCloudFloatingIPDescriptionPrefix)
+
+	config := fmt.Sprintf(`
+resource "ovh_cloud_floating_ip" "test" {
+  service_name = "%s"
+  region       = "%s"
+  description  = "%s"
+}
+`, serviceName, region, description)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheckCloudPublicIP(t)
+		},
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("ovh_cloud_floating_ip.test", "service_name", serviceName),
+					resource.TestCheckResourceAttr("ovh_cloud_floating_ip.test", "region", region),
+					resource.TestCheckResourceAttr("ovh_cloud_floating_ip.test", "description", description),
+					resource.TestCheckResourceAttr("ovh_cloud_floating_ip.test", "resource_status", "READY"),
+					resource.TestCheckResourceAttrSet("ovh_cloud_floating_ip.test", "id"),
+					resource.TestCheckResourceAttrSet("ovh_cloud_floating_ip.test", "checksum"),
+					resource.TestCheckResourceAttrSet("ovh_cloud_floating_ip.test", "created_at"),
+					resource.TestCheckResourceAttrSet("ovh_cloud_floating_ip.test", "current_state.ip"),
+					resource.TestCheckResourceAttrSet("ovh_cloud_floating_ip.test", "current_state.status"),
+					resource.TestCheckResourceAttrSet("ovh_cloud_floating_ip.test", "current_state.id"),
+					resource.TestCheckResourceAttr("ovh_cloud_floating_ip.test", "current_state.location.region", region),
+				),
+			},
+			// Test import
+			{
+				ResourceName:      "ovh_cloud_floating_ip.test",
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testAccCloudFloatingIPImportStateIdFunc("ovh_cloud_floating_ip.test"),
+			},
+		},
+	})
+}
+
+func TestAccCloudFloatingIP_updateDescription(t *testing.T) {
+	serviceName := os.Getenv("OVH_CLOUD_PROJECT_SERVICE_TEST")
+	region := os.Getenv("OVH_CLOUD_PROJECT_REGION_TEST")
+
+	configTemplate := `
+resource "ovh_cloud_floating_ip" "test" {
+  service_name = "%s"
+  region       = "%s"
+  description  = "%s"
+}
+`
+
+	config := fmt.Sprintf(configTemplate, serviceName, region, "initial")
+	updatedConfig := fmt.Sprintf(configTemplate, serviceName, region, "updated")
+
+	// Captured in step 1 and compared in step 2 to prove the floating IP was
+	// updated in place, not replaced.
+	var floatingIPID string
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheckCloudPublicIP(t)
+		},
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("ovh_cloud_floating_ip.test", "description", "initial"),
+					resource.TestCheckResourceAttr("ovh_cloud_floating_ip.test", "resource_status", "READY"),
+					resource.TestCheckResourceAttrWith("ovh_cloud_floating_ip.test", "id", func(value string) error {
+						if value == "" {
+							return fmt.Errorf("expected floating IP id to be set")
+						}
+						floatingIPID = value
+						return nil
+					}),
+				),
+			},
+			{
+				Config: updatedConfig,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("ovh_cloud_floating_ip.test", "description", "updated"),
+					resource.TestCheckResourceAttr("ovh_cloud_floating_ip.test", "resource_status", "READY"),
+					resource.TestCheckResourceAttrSet("ovh_cloud_floating_ip.test", "checksum"),
+					resource.TestCheckResourceAttrWith("ovh_cloud_floating_ip.test", "id", func(value string) error {
+						if value != floatingIPID {
+							return fmt.Errorf("floating IP was replaced during update: id changed from %q to %q", floatingIPID, value)
+						}
+						return nil
+					}),
+				),
+			},
+		},
+	})
+}
+
+// testAccPreCheckCloudPublicIP is the shared PreCheck for the public IP family
+// (floating, extNet, additional, aggregate) acceptance tests.
+func testAccPreCheckCloudPublicIP(t *testing.T) {
+	testAccPreCheckCredentials(t)
+	if os.Getenv("OVH_CLOUD_PROJECT_SERVICE_TEST") == "" {
+		t.Skip("OVH_CLOUD_PROJECT_SERVICE_TEST not set")
+	}
+	if os.Getenv("OVH_CLOUD_PROJECT_REGION_TEST") == "" {
+		t.Skip("OVH_CLOUD_PROJECT_REGION_TEST not set")
+	}
+}
+
+func testAccCloudFloatingIPImportStateIdFunc(resourceName string) resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return "", fmt.Errorf("not found: %s", resourceName)
+		}
+		return fmt.Sprintf("%s/%s", rs.Primary.Attributes["service_name"], rs.Primary.Attributes["id"]), nil
+	}
+}
+
+// testAccCheckCloudPublicIPListNotEmpty checks that a list count attribute
+// (e.g. "floating_ips.#") parses to at least one element.
+func testAccCheckCloudPublicIPListNotEmpty(value string) error {
+	count, err := strconv.Atoi(value)
+	if err != nil {
+		return fmt.Errorf("failed to parse list length %q: %w", value, err)
+	}
+	if count < 1 {
+		return fmt.Errorf("expected at least one element in the list, got %d", count)
+	}
+	return nil
+}

--- a/ovh/types_cloud_public_ip.go
+++ b/ovh/types_cloud_public_ip.go
@@ -1,0 +1,651 @@
+package ovh
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
+	ovhtypes "github.com/ovh/terraform-provider-ovh/v2/ovh/types"
+)
+
+// Shared API types for the public IP family (floating, extNet, additional, aggregate)
+
+// CloudPublicIPLocation is the location of a public IP.
+type CloudPublicIPLocation struct {
+	Region           string `json:"region"`
+	AvailabilityZone string `json:"availabilityZone,omitempty"`
+}
+
+// CloudPublicIPAssociatedResource describes the resource a public IP is currently attached to.
+type CloudPublicIPAssociatedResource struct {
+	ID   string `json:"id"`
+	Type string `json:"type"`
+}
+
+// CloudFloatingIPNetwork references the external network of a floating IP.
+type CloudFloatingIPNetwork struct {
+	ID string `json:"id"`
+}
+
+// CloudPublicIPTaskError is an error that occurred on an asynchronous public IP task.
+type CloudPublicIPTaskError struct {
+	Message string `json:"message"`
+}
+
+// CloudPublicIPResourceTask represents an asynchronous operation on a public IP.
+type CloudPublicIPResourceTask struct {
+	ID     string                   `json:"id"`
+	Link   string                   `json:"link"`
+	Type   string                   `json:"type"`
+	Status string                   `json:"status,omitempty"`
+	Errors []CloudPublicIPTaskError `json:"errors,omitempty"`
+}
+
+// Floating IP API types
+
+// CloudFloatingIPCurrentState is the current state of a floating public IP.
+type CloudFloatingIPCurrentState struct {
+	ID                 string                           `json:"id"`
+	IP                 string                           `json:"ip,omitempty"`
+	Status             string                           `json:"status,omitempty"`
+	Description        string                           `json:"description,omitempty"`
+	Network            *CloudFloatingIPNetwork          `json:"network,omitempty"`
+	AssociatedResource *CloudPublicIPAssociatedResource `json:"associatedResource,omitempty"`
+	Location           *CloudPublicIPLocation           `json:"location,omitempty"`
+}
+
+// CloudFloatingIPTargetSpec is the desired specification for a floating public IP.
+type CloudFloatingIPTargetSpec struct {
+	Description string                 `json:"description,omitempty"`
+	Location    *CloudPublicIPLocation `json:"location,omitempty"`
+}
+
+// CloudFloatingIPAPIResponse is the read envelope for a floating public IP.
+type CloudFloatingIPAPIResponse struct {
+	ID             string                       `json:"id"`
+	Checksum       string                       `json:"checksum"`
+	CreatedAt      string                       `json:"createdAt"`
+	UpdatedAt      string                       `json:"updatedAt"`
+	ResourceStatus string                       `json:"resourceStatus"`
+	CurrentTasks   []CloudPublicIPResourceTask  `json:"currentTasks,omitempty"`
+	CurrentState   *CloudFloatingIPCurrentState `json:"currentState,omitempty"`
+	TargetSpec     *CloudFloatingIPTargetSpec   `json:"targetSpec,omitempty"`
+}
+
+// CloudFloatingIPCreatePayload is the POST body to create a floating public IP.
+type CloudFloatingIPCreatePayload struct {
+	TargetSpec *CloudFloatingIPTargetSpec `json:"targetSpec"`
+}
+
+// CloudFloatingIPUpdateTargetSpec is the update spec of a floating public IP.
+// Note: location is immutable, description is the only mutable field.
+type CloudFloatingIPUpdateTargetSpec struct {
+	Description string `json:"description"`
+}
+
+// CloudFloatingIPUpdatePayload is the PUT body to update a floating public IP.
+type CloudFloatingIPUpdatePayload struct {
+	Checksum   string                           `json:"checksum"`
+	TargetSpec *CloudFloatingIPUpdateTargetSpec `json:"targetSpec"`
+}
+
+// ExtNet IP API types (read-only, no targetSpec)
+
+// CloudExtNetIPCurrentState is the current state of an external-network public IP.
+type CloudExtNetIPCurrentState struct {
+	ID                 string                           `json:"id"`
+	IP                 string                           `json:"ip,omitempty"`
+	AssociatedResource *CloudPublicIPAssociatedResource `json:"associatedResource,omitempty"`
+	Location           *CloudPublicIPLocation           `json:"location,omitempty"`
+}
+
+// CloudExtNetIPAPIResponse is the read envelope for an external-network public IP.
+type CloudExtNetIPAPIResponse struct {
+	ID             string                      `json:"id"`
+	Checksum       string                      `json:"checksum"`
+	CreatedAt      string                      `json:"createdAt"`
+	UpdatedAt      string                      `json:"updatedAt"`
+	ResourceStatus string                      `json:"resourceStatus"`
+	CurrentTasks   []CloudPublicIPResourceTask `json:"currentTasks,omitempty"`
+	CurrentState   *CloudExtNetIPCurrentState  `json:"currentState,omitempty"`
+}
+
+// Additional IP API types (read-only, no targetSpec, no createdAt/updatedAt)
+
+// CloudAdditionalIPCurrentState is the current state of an additional public IP (IP alias).
+type CloudAdditionalIPCurrentState struct {
+	ID                 string                           `json:"id"`
+	IP                 string                           `json:"ip,omitempty"`
+	IPBlock            string                           `json:"ipBlock,omitempty"`
+	AssociatedResource *CloudPublicIPAssociatedResource `json:"associatedResource,omitempty"`
+	Location           *CloudPublicIPLocation           `json:"location,omitempty"`
+}
+
+// CloudAdditionalIPAPIResponse is the read envelope for an additional public IP (IP alias).
+type CloudAdditionalIPAPIResponse struct {
+	ID             string                         `json:"id"`
+	Checksum       string                         `json:"checksum"`
+	ResourceStatus string                         `json:"resourceStatus"`
+	CurrentTasks   []CloudPublicIPResourceTask    `json:"currentTasks,omitempty"`
+	CurrentState   *CloudAdditionalIPCurrentState `json:"currentState,omitempty"`
+}
+
+// Aggregate API types
+
+// CloudPublicIPSummary is the aggregated public IP entry returned by the
+// list-all endpoint. It carries only the IP address and its type.
+type CloudPublicIPSummary struct {
+	IP   string `json:"ip"`
+	Type string `json:"type"`
+}
+
+// Terraform attribute types
+
+// cloudPublicIPLocationAttrTypes returns the attribute types for the nested location object.
+func cloudPublicIPLocationAttrTypes() map[string]attr.Type {
+	return map[string]attr.Type{
+		"region":            ovhtypes.TfStringType{},
+		"availability_zone": ovhtypes.TfStringType{},
+	}
+}
+
+// cloudPublicIPAssociatedResourceAttrTypes returns the attribute types for the
+// nested associated_resource object.
+func cloudPublicIPAssociatedResourceAttrTypes() map[string]attr.Type {
+	return map[string]attr.Type{
+		"id":   ovhtypes.TfStringType{},
+		"type": ovhtypes.TfStringType{},
+	}
+}
+
+// cloudFloatingIPNetworkAttrTypes returns the attribute types for the nested network object.
+func cloudFloatingIPNetworkAttrTypes() map[string]attr.Type {
+	return map[string]attr.Type{
+		"id": ovhtypes.TfStringType{},
+	}
+}
+
+// cloudPublicIPTaskErrorAttrTypes returns the attribute types for a single
+// error entry of a current_tasks entry.
+func cloudPublicIPTaskErrorAttrTypes() map[string]attr.Type {
+	return map[string]attr.Type{
+		"message": ovhtypes.TfStringType{},
+	}
+}
+
+// cloudPublicIPResourceTaskAttrTypes returns the attribute types for a single current_tasks entry.
+func cloudPublicIPResourceTaskAttrTypes() map[string]attr.Type {
+	return map[string]attr.Type{
+		"errors": types.ListType{
+			ElemType: types.ObjectType{
+				AttrTypes: cloudPublicIPTaskErrorAttrTypes(),
+			},
+		},
+		"id":     ovhtypes.TfStringType{},
+		"link":   ovhtypes.TfStringType{},
+		"status": ovhtypes.TfStringType{},
+		"type":   ovhtypes.TfStringType{},
+	}
+}
+
+// CloudFloatingIPCurrentStateAttrTypes returns the attribute types for the
+// current_state object of a floating public IP.
+func CloudFloatingIPCurrentStateAttrTypes() map[string]attr.Type {
+	return map[string]attr.Type{
+		"id":          ovhtypes.TfStringType{},
+		"ip":          ovhtypes.TfStringType{},
+		"status":      ovhtypes.TfStringType{},
+		"description": ovhtypes.TfStringType{},
+		"network": types.ObjectType{
+			AttrTypes: cloudFloatingIPNetworkAttrTypes(),
+		},
+		"associated_resource": types.ObjectType{
+			AttrTypes: cloudPublicIPAssociatedResourceAttrTypes(),
+		},
+		"location": types.ObjectType{
+			AttrTypes: cloudPublicIPLocationAttrTypes(),
+		},
+	}
+}
+
+// CloudExtNetIPCurrentStateAttrTypes returns the attribute types for the
+// current_state object of an external-network public IP.
+func CloudExtNetIPCurrentStateAttrTypes() map[string]attr.Type {
+	return map[string]attr.Type{
+		"id": ovhtypes.TfStringType{},
+		"ip": ovhtypes.TfStringType{},
+		"associated_resource": types.ObjectType{
+			AttrTypes: cloudPublicIPAssociatedResourceAttrTypes(),
+		},
+		"location": types.ObjectType{
+			AttrTypes: cloudPublicIPLocationAttrTypes(),
+		},
+	}
+}
+
+// CloudAdditionalIPCurrentStateAttrTypes returns the attribute types for the
+// current_state object of an additional public IP.
+func CloudAdditionalIPCurrentStateAttrTypes() map[string]attr.Type {
+	return map[string]attr.Type{
+		"id":       ovhtypes.TfStringType{},
+		"ip":       ovhtypes.TfStringType{},
+		"ip_block": ovhtypes.TfStringType{},
+		"associated_resource": types.ObjectType{
+			AttrTypes: cloudPublicIPAssociatedResourceAttrTypes(),
+		},
+		"location": types.ObjectType{
+			AttrTypes: cloudPublicIPLocationAttrTypes(),
+		},
+	}
+}
+
+// Terraform object builders
+
+// buildCloudPublicIPLocationObject constructs the nested location object from the API location.
+func buildCloudPublicIPLocationObject(location *CloudPublicIPLocation) basetypes.ObjectValue {
+	if location == nil {
+		return types.ObjectNull(cloudPublicIPLocationAttrTypes())
+	}
+
+	locationObj, _ := types.ObjectValue(
+		cloudPublicIPLocationAttrTypes(),
+		map[string]attr.Value{
+			"region":            ovhtypes.TfStringValue{StringValue: types.StringValue(location.Region)},
+			"availability_zone": ovhtypes.TfStringValue{StringValue: types.StringValue(location.AvailabilityZone)},
+		},
+	)
+
+	return locationObj
+}
+
+// buildCloudPublicIPAssociatedResourceObject constructs the nested associated_resource
+// object from the API associated resource.
+func buildCloudPublicIPAssociatedResourceObject(associatedResource *CloudPublicIPAssociatedResource) basetypes.ObjectValue {
+	if associatedResource == nil {
+		return types.ObjectNull(cloudPublicIPAssociatedResourceAttrTypes())
+	}
+
+	associatedResourceObj, _ := types.ObjectValue(
+		cloudPublicIPAssociatedResourceAttrTypes(),
+		map[string]attr.Value{
+			"id":   ovhtypes.TfStringValue{StringValue: types.StringValue(associatedResource.ID)},
+			"type": ovhtypes.TfStringValue{StringValue: types.StringValue(associatedResource.Type)},
+		},
+	)
+
+	return associatedResourceObj
+}
+
+// buildCloudFloatingIPNetworkObject constructs the nested network object from the API network.
+func buildCloudFloatingIPNetworkObject(network *CloudFloatingIPNetwork) basetypes.ObjectValue {
+	if network == nil {
+		return types.ObjectNull(cloudFloatingIPNetworkAttrTypes())
+	}
+
+	networkObj, _ := types.ObjectValue(
+		cloudFloatingIPNetworkAttrTypes(),
+		map[string]attr.Value{
+			"id": ovhtypes.TfStringValue{StringValue: types.StringValue(network.ID)},
+		},
+	)
+
+	return networkObj
+}
+
+// buildCloudPublicIPTaskErrorsList constructs the errors list of a current_tasks entry
+// from the API task errors.
+func buildCloudPublicIPTaskErrorsList(taskErrors []CloudPublicIPTaskError) basetypes.ListValue {
+	errorObjType := types.ObjectType{AttrTypes: cloudPublicIPTaskErrorAttrTypes()}
+
+	if taskErrors == nil {
+		return types.ListNull(errorObjType)
+	}
+
+	errorObjs := make([]attr.Value, len(taskErrors))
+	for i, taskError := range taskErrors {
+		errorObj, _ := types.ObjectValue(
+			cloudPublicIPTaskErrorAttrTypes(),
+			map[string]attr.Value{
+				"message": ovhtypes.TfStringValue{StringValue: types.StringValue(taskError.Message)},
+			},
+		)
+		errorObjs[i] = errorObj
+	}
+
+	errorsVal, _ := types.ListValue(errorObjType, errorObjs)
+
+	return errorsVal
+}
+
+// buildCloudPublicIPCurrentTasksList constructs the current_tasks list from the API tasks.
+func buildCloudPublicIPCurrentTasksList(tasks []CloudPublicIPResourceTask) basetypes.ListValue {
+	taskObjType := types.ObjectType{AttrTypes: cloudPublicIPResourceTaskAttrTypes()}
+
+	if tasks == nil {
+		return types.ListNull(taskObjType)
+	}
+
+	taskObjs := make([]attr.Value, len(tasks))
+	for i, task := range tasks {
+		taskObj, _ := types.ObjectValue(
+			cloudPublicIPResourceTaskAttrTypes(),
+			map[string]attr.Value{
+				"errors": buildCloudPublicIPTaskErrorsList(task.Errors),
+				"id":     ovhtypes.TfStringValue{StringValue: types.StringValue(task.ID)},
+				"link":   ovhtypes.TfStringValue{StringValue: types.StringValue(task.Link)},
+				"status": ovhtypes.TfStringValue{StringValue: types.StringValue(task.Status)},
+				"type":   ovhtypes.TfStringValue{StringValue: types.StringValue(task.Type)},
+			},
+		)
+		taskObjs[i] = taskObj
+	}
+
+	tasksVal, _ := types.ListValue(taskObjType, taskObjs)
+
+	return tasksVal
+}
+
+// buildCloudFloatingIPCurrentStateObject constructs the current_state object
+// of a floating public IP from the API response.
+func buildCloudFloatingIPCurrentStateObject(ctx context.Context, state *CloudFloatingIPCurrentState) basetypes.ObjectValue {
+	currentStateObj, _ := types.ObjectValue(
+		CloudFloatingIPCurrentStateAttrTypes(),
+		map[string]attr.Value{
+			"id":                  ovhtypes.TfStringValue{StringValue: types.StringValue(state.ID)},
+			"ip":                  ovhtypes.TfStringValue{StringValue: types.StringValue(state.IP)},
+			"status":              ovhtypes.TfStringValue{StringValue: types.StringValue(state.Status)},
+			"description":         ovhtypes.TfStringValue{StringValue: types.StringValue(state.Description)},
+			"network":             buildCloudFloatingIPNetworkObject(state.Network),
+			"associated_resource": buildCloudPublicIPAssociatedResourceObject(state.AssociatedResource),
+			"location":            buildCloudPublicIPLocationObject(state.Location),
+		},
+	)
+
+	return currentStateObj
+}
+
+// buildCloudExtNetIPCurrentStateObject constructs the current_state object
+// of an external-network public IP from the API response.
+func buildCloudExtNetIPCurrentStateObject(ctx context.Context, state *CloudExtNetIPCurrentState) basetypes.ObjectValue {
+	currentStateObj, _ := types.ObjectValue(
+		CloudExtNetIPCurrentStateAttrTypes(),
+		map[string]attr.Value{
+			"id":                  ovhtypes.TfStringValue{StringValue: types.StringValue(state.ID)},
+			"ip":                  ovhtypes.TfStringValue{StringValue: types.StringValue(state.IP)},
+			"associated_resource": buildCloudPublicIPAssociatedResourceObject(state.AssociatedResource),
+			"location":            buildCloudPublicIPLocationObject(state.Location),
+		},
+	)
+
+	return currentStateObj
+}
+
+// buildCloudAdditionalIPCurrentStateObject constructs the current_state object
+// of an additional public IP from the API response.
+func buildCloudAdditionalIPCurrentStateObject(ctx context.Context, state *CloudAdditionalIPCurrentState) basetypes.ObjectValue {
+	currentStateObj, _ := types.ObjectValue(
+		CloudAdditionalIPCurrentStateAttrTypes(),
+		map[string]attr.Value{
+			"id":                  ovhtypes.TfStringValue{StringValue: types.StringValue(state.ID)},
+			"ip":                  ovhtypes.TfStringValue{StringValue: types.StringValue(state.IP)},
+			"ip_block":            ovhtypes.TfStringValue{StringValue: types.StringValue(state.IPBlock)},
+			"associated_resource": buildCloudPublicIPAssociatedResourceObject(state.AssociatedResource),
+			"location":            buildCloudPublicIPLocationObject(state.Location),
+		},
+	)
+
+	return currentStateObj
+}
+
+// Terraform list-item attribute types for the plural datasources
+
+// CloudFloatingIPListItemAttrTypes returns the attribute types for a single
+// floating IP element of the plural datasource list.
+func CloudFloatingIPListItemAttrTypes() map[string]attr.Type {
+	return map[string]attr.Type{
+		"id":          ovhtypes.TfStringType{},
+		"description": ovhtypes.TfStringType{},
+		"location": types.ObjectType{
+			AttrTypes: cloudPublicIPLocationAttrTypes(),
+		},
+		"checksum":        ovhtypes.TfStringType{},
+		"created_at":      ovhtypes.TfStringType{},
+		"updated_at":      ovhtypes.TfStringType{},
+		"resource_status": ovhtypes.TfStringType{},
+		"current_state": types.ObjectType{
+			AttrTypes: CloudFloatingIPCurrentStateAttrTypes(),
+		},
+		"current_tasks": types.ListType{
+			ElemType: types.ObjectType{
+				AttrTypes: cloudPublicIPResourceTaskAttrTypes(),
+			},
+		},
+	}
+}
+
+// CloudExtNetIPListItemAttrTypes returns the attribute types for a single
+// external-network IP element of the plural datasource list.
+func CloudExtNetIPListItemAttrTypes() map[string]attr.Type {
+	return map[string]attr.Type{
+		"id":              ovhtypes.TfStringType{},
+		"checksum":        ovhtypes.TfStringType{},
+		"created_at":      ovhtypes.TfStringType{},
+		"updated_at":      ovhtypes.TfStringType{},
+		"resource_status": ovhtypes.TfStringType{},
+		"current_state": types.ObjectType{
+			AttrTypes: CloudExtNetIPCurrentStateAttrTypes(),
+		},
+		"current_tasks": types.ListType{
+			ElemType: types.ObjectType{
+				AttrTypes: cloudPublicIPResourceTaskAttrTypes(),
+			},
+		},
+	}
+}
+
+// CloudAdditionalIPListItemAttrTypes returns the attribute types for a single
+// additional IP element of the plural datasource list.
+func CloudAdditionalIPListItemAttrTypes() map[string]attr.Type {
+	return map[string]attr.Type{
+		"id":              ovhtypes.TfStringType{},
+		"checksum":        ovhtypes.TfStringType{},
+		"resource_status": ovhtypes.TfStringType{},
+		"current_state": types.ObjectType{
+			AttrTypes: CloudAdditionalIPCurrentStateAttrTypes(),
+		},
+		"current_tasks": types.ListType{
+			ElemType: types.ObjectType{
+				AttrTypes: cloudPublicIPResourceTaskAttrTypes(),
+			},
+		},
+	}
+}
+
+// Terraform list-item builders for the plural datasources
+
+// buildCloudFloatingIPListItemObject builds a single floating IP element of
+// the plural datasource list from an API response, reusing the shared builders
+// for nested objects.
+func buildCloudFloatingIPListItemObject(ctx context.Context, response *CloudFloatingIPAPIResponse) basetypes.ObjectValue {
+	descriptionVal := ovhtypes.TfStringValue{StringValue: types.StringNull()}
+	locationVal := types.ObjectNull(cloudPublicIPLocationAttrTypes())
+
+	if response.TargetSpec != nil {
+		descriptionVal = ovhtypes.TfStringValue{StringValue: types.StringValue(response.TargetSpec.Description)}
+		locationVal = buildCloudPublicIPLocationObject(response.TargetSpec.Location)
+	}
+
+	var currentStateVal attr.Value
+	if response.CurrentState != nil {
+		currentStateVal = buildCloudFloatingIPCurrentStateObject(ctx, response.CurrentState)
+	} else {
+		currentStateVal = types.ObjectNull(CloudFloatingIPCurrentStateAttrTypes())
+	}
+
+	obj, _ := types.ObjectValue(
+		CloudFloatingIPListItemAttrTypes(),
+		map[string]attr.Value{
+			"id":              ovhtypes.TfStringValue{StringValue: types.StringValue(response.ID)},
+			"description":     descriptionVal,
+			"location":        locationVal,
+			"checksum":        ovhtypes.TfStringValue{StringValue: types.StringValue(response.Checksum)},
+			"created_at":      ovhtypes.TfStringValue{StringValue: types.StringValue(response.CreatedAt)},
+			"updated_at":      ovhtypes.TfStringValue{StringValue: types.StringValue(response.UpdatedAt)},
+			"resource_status": ovhtypes.TfStringValue{StringValue: types.StringValue(response.ResourceStatus)},
+			"current_state":   currentStateVal,
+			"current_tasks":   buildCloudPublicIPCurrentTasksList(response.CurrentTasks),
+		},
+	)
+
+	return obj
+}
+
+// buildCloudExtNetIPListItemObject builds a single external-network IP element
+// of the plural datasource list from an API response, reusing the shared builders
+// for nested objects.
+func buildCloudExtNetIPListItemObject(ctx context.Context, response *CloudExtNetIPAPIResponse) basetypes.ObjectValue {
+	var currentStateVal attr.Value
+	if response.CurrentState != nil {
+		currentStateVal = buildCloudExtNetIPCurrentStateObject(ctx, response.CurrentState)
+	} else {
+		currentStateVal = types.ObjectNull(CloudExtNetIPCurrentStateAttrTypes())
+	}
+
+	obj, _ := types.ObjectValue(
+		CloudExtNetIPListItemAttrTypes(),
+		map[string]attr.Value{
+			"id":              ovhtypes.TfStringValue{StringValue: types.StringValue(response.ID)},
+			"checksum":        ovhtypes.TfStringValue{StringValue: types.StringValue(response.Checksum)},
+			"created_at":      ovhtypes.TfStringValue{StringValue: types.StringValue(response.CreatedAt)},
+			"updated_at":      ovhtypes.TfStringValue{StringValue: types.StringValue(response.UpdatedAt)},
+			"resource_status": ovhtypes.TfStringValue{StringValue: types.StringValue(response.ResourceStatus)},
+			"current_state":   currentStateVal,
+			"current_tasks":   buildCloudPublicIPCurrentTasksList(response.CurrentTasks),
+		},
+	)
+
+	return obj
+}
+
+// buildCloudAdditionalIPListItemObject builds a single additional IP element
+// of the plural datasource list from an API response, reusing the shared builders
+// for nested objects.
+func buildCloudAdditionalIPListItemObject(ctx context.Context, response *CloudAdditionalIPAPIResponse) basetypes.ObjectValue {
+	var currentStateVal attr.Value
+	if response.CurrentState != nil {
+		currentStateVal = buildCloudAdditionalIPCurrentStateObject(ctx, response.CurrentState)
+	} else {
+		currentStateVal = types.ObjectNull(CloudAdditionalIPCurrentStateAttrTypes())
+	}
+
+	obj, _ := types.ObjectValue(
+		CloudAdditionalIPListItemAttrTypes(),
+		map[string]attr.Value{
+			"id":              ovhtypes.TfStringValue{StringValue: types.StringValue(response.ID)},
+			"checksum":        ovhtypes.TfStringValue{StringValue: types.StringValue(response.Checksum)},
+			"resource_status": ovhtypes.TfStringValue{StringValue: types.StringValue(response.ResourceStatus)},
+			"current_state":   currentStateVal,
+			"current_tasks":   buildCloudPublicIPCurrentTasksList(response.CurrentTasks),
+		},
+	)
+
+	return obj
+}
+
+// Terraform model for the floating IP resource
+
+// CloudFloatingIPModel represents the Terraform model for the floating IP resource.
+type CloudFloatingIPModel struct {
+	// Required — immutable
+	ServiceName ovhtypes.TfStringValue `tfsdk:"service_name"`
+	Region      ovhtypes.TfStringValue `tfsdk:"region"`
+
+	// Optional — immutable
+	AvailabilityZone ovhtypes.TfStringValue `tfsdk:"availability_zone"`
+
+	// Optional — mutable
+	Description ovhtypes.TfStringValue `tfsdk:"description"`
+
+	// Computed
+	Id             ovhtypes.TfStringValue `tfsdk:"id"`
+	Checksum       ovhtypes.TfStringValue `tfsdk:"checksum"`
+	CreatedAt      ovhtypes.TfStringValue `tfsdk:"created_at"`
+	UpdatedAt      ovhtypes.TfStringValue `tfsdk:"updated_at"`
+	ResourceStatus ovhtypes.TfStringValue `tfsdk:"resource_status"`
+	CurrentState   types.Object           `tfsdk:"current_state"`
+	CurrentTasks   types.List             `tfsdk:"current_tasks"`
+}
+
+// ToCreate converts the Terraform model to the API create payload
+func (m *CloudFloatingIPModel) ToCreate() *CloudFloatingIPCreatePayload {
+	targetSpec := &CloudFloatingIPTargetSpec{
+		Location: &CloudPublicIPLocation{
+			Region: m.Region.ValueString(),
+		},
+	}
+
+	// Handle optional description
+	if !m.Description.IsNull() && !m.Description.IsUnknown() {
+		targetSpec.Description = m.Description.ValueString()
+	}
+
+	// Handle optional availability zone
+	if !m.AvailabilityZone.IsNull() && !m.AvailabilityZone.IsUnknown() {
+		targetSpec.Location.AvailabilityZone = m.AvailabilityZone.ValueString()
+	}
+
+	return &CloudFloatingIPCreatePayload{TargetSpec: targetSpec}
+}
+
+// ToUpdate converts the Terraform model to the API update payload
+// Note: location is immutable, description is the only mutable field
+func (m *CloudFloatingIPModel) ToUpdate(checksum string) *CloudFloatingIPUpdatePayload {
+	targetSpec := &CloudFloatingIPUpdateTargetSpec{}
+
+	// Handle optional description
+	if !m.Description.IsNull() && !m.Description.IsUnknown() {
+		targetSpec.Description = m.Description.ValueString()
+	}
+
+	return &CloudFloatingIPUpdatePayload{
+		Checksum:   checksum,
+		TargetSpec: targetSpec,
+	}
+}
+
+// MergeWith merges API response data into the Terraform model
+func (m *CloudFloatingIPModel) MergeWith(ctx context.Context, response *CloudFloatingIPAPIResponse) {
+	// Never overwrite the tracked IP with an empty response ID
+	if response.ID != "" {
+		m.Id = ovhtypes.TfStringValue{StringValue: types.StringValue(response.ID)}
+	}
+	m.Checksum = ovhtypes.TfStringValue{StringValue: types.StringValue(response.Checksum)}
+	m.CreatedAt = ovhtypes.TfStringValue{StringValue: types.StringValue(response.CreatedAt)}
+	m.UpdatedAt = ovhtypes.TfStringValue{StringValue: types.StringValue(response.UpdatedAt)}
+	m.ResourceStatus = ovhtypes.TfStringValue{StringValue: types.StringValue(response.ResourceStatus)}
+
+	// Build current_state from API currentState
+	if response.CurrentState != nil {
+		m.CurrentState = buildCloudFloatingIPCurrentStateObject(ctx, response.CurrentState)
+	} else {
+		m.CurrentState = types.ObjectNull(CloudFloatingIPCurrentStateAttrTypes())
+	}
+
+	m.CurrentTasks = buildCloudPublicIPCurrentTasksList(response.CurrentTasks)
+
+	// Set flattened root-level fields from targetSpec
+	if response.TargetSpec != nil {
+		// Keep description null if user didn't set it and API returns empty
+		if response.TargetSpec.Description != "" || (!m.Description.IsNull() && !m.Description.IsUnknown()) {
+			m.Description = ovhtypes.TfStringValue{StringValue: types.StringValue(response.TargetSpec.Description)}
+		}
+
+		if response.TargetSpec.Location != nil {
+			m.Region = ovhtypes.TfStringValue{StringValue: types.StringValue(response.TargetSpec.Location.Region)}
+			if response.TargetSpec.Location.AvailabilityZone != "" {
+				m.AvailabilityZone = ovhtypes.TfStringValue{StringValue: types.StringValue(response.TargetSpec.Location.AvailabilityZone)}
+			}
+		}
+	}
+}

--- a/templates/data-sources/cloud_project_floatingips.md.tmpl
+++ b/templates/data-sources/cloud_project_floatingips.md.tmpl
@@ -8,6 +8,8 @@ For example, the {{ .SchemaMarkdown }} template can be used to replace manual sc
 
 # ovh_cloud_project_floatingips
 
+~> **NOTE** We recommend using the `ovh_cloud_floating_ips` data source instead. Floating IPs can now also be managed directly with the `ovh_cloud_floating_ip` resource.
+
 Use this data source to get the floating IPs of a public cloud project.
 
 ## Example Usage


### PR DESCRIPTION
# Description

Resources:
- ovh_cloud_floating_ip

Datasources:
- ovh_cloud_floating_ip
- ovh_cloud_floating_ips
- ovh_cloud_ext_net_ip
- ovh_cloud_ext_net_ips
- ovh_cloud_additional_ip
- ovh_cloud_additional_ips
- ovh_cloud_public_ips

Fixes #1254 (issue)
Fixes #1245 (issue)

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

```txt
$ make testacc TESTARGS="-run 'TestAccCloudFloatingIP|CloudFloatingIP|CloudExtNetIP|CloudAdditionalIP|CloudPublicIPs'"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -run 'TestAccCloudFloatingIP|CloudFloatingIP|CloudExtNetIP|CloudAdditionalIP|CloudPublicIPs' -timeout 600m -p 10
?   	github.com/ovh/terraform-provider-ovh/v2	[no test files]
=== RUN   TestAccDataSourceCloudAdditionalIP_basic
--- PASS: TestAccDataSourceCloudAdditionalIP_basic (1.47s)
=== RUN   TestAccDataSourceCloudAdditionalIPs_basic
--- PASS: TestAccDataSourceCloudAdditionalIPs_basic (1.96s)
=== RUN   TestAccDataSourceCloudExtNetIP_basic
--- PASS: TestAccDataSourceCloudExtNetIP_basic (133.08s)
=== RUN   TestAccDataSourceCloudExtNetIPs_basic
--- PASS: TestAccDataSourceCloudExtNetIPs_basic (132.64s)
=== RUN   TestAccDataSourceCloudFloatingIP_basic
--- PASS: TestAccDataSourceCloudFloatingIP_basic (19.04s)
=== RUN   TestAccDataSourceCloudFloatingIPs_basic
--- PASS: TestAccDataSourceCloudFloatingIPs_basic (21.29s)
=== RUN   TestAccDataSourceCloudPublicIPs_basic
--- PASS: TestAccDataSourceCloudPublicIPs_basic (18.85s)
=== RUN   TestAccCloudFloatingIP_basic
--- PASS: TestAccCloudFloatingIP_basic (21.30s)
=== RUN   TestAccCloudFloatingIP_updateDescription
--- PASS: TestAccCloudFloatingIP_updateDescription (54.88s)
PASS
ok 
```
# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or issues
- [x] I have added acceptance tests that prove my fix is effective or that my feature works
- [x] New and existing acceptance tests pass locally with my changes
- [x] I ran successfully `go mod vendor` if I added or modify `go.mod` file 