### PR TITLE
(fix) typo in the URL

### DIFF
--- a/ovh/resource_cloud_project_file_storage_share_network.go
+++ b/ovh/resource_cloud_project_file_storage_share_network.go
@@ -62,7 +62,7 @@ func (r *cloudProjectFileStorageShareNetworkResource) ImportState(ctx context.Co
 
 func (r *cloudProjectFileStorageShareNetworkResource) endpoint(serviceName, regionName string) string {
 	return "/cloud/project/" + url.PathEscape(serviceName) +
-		"/region/" + url.PathEscape(regionName) + "/sharenetwork"
+		"/region/" + url.PathEscape(regionName) + "/shareNetwork"
 }
 
 func (r *cloudProjectFileStorageShareNetworkResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {


### PR DESCRIPTION
# Description

Fix the Public Cloud File Storage share network creation

The API call have a uppercase N in shareNetwork:
https://api.eu.ovhcloud.com/console/?section=%2Fcloud&branch=v1#post-/cloud/project/-serviceName-/region/-regionName-/shareNetwork

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings or issues
- [ ] I have added acceptance tests that prove my fix is effective or that my feature works
- [ ] New and existing acceptance tests pass locally with my changes
- [ ] I ran successfully `go mod vendor` if I added or modify `go.mod` file
