### PR TITLE
fix: Accept OVH_CLOUD_PROJECT_SERVICE env variable for public IP reso…

### DIFF
--- a/docs/data-sources/cloud_additional_ip.md
+++ b/docs/data-sources/cloud_additional_ip.md
@@ -23,7 +23,7 @@ output "additional_ip_status" {
 
 The following arguments are supported:
 
-* `service_name` - (Required) Service name of the resource representing the id of the cloud project.
+* `service_name` - (Required) Service name of the resource representing the id of the cloud project. If omitted, the `OVH_CLOUD_PROJECT_SERVICE` environment variable is used.
 * `id` - (Required) IP address of the additional IP.
 
 ## Attributes Reference

--- a/docs/data-sources/cloud_additional_ips.md
+++ b/docs/data-sources/cloud_additional_ips.md
@@ -22,7 +22,7 @@ output "additional_ip_addresses" {
 
 The following arguments are supported:
 
-* `service_name` - (Required) Service name of the resource representing the id of the cloud project.
+* `service_name` - (Required) Service name of the resource representing the id of the cloud project. If omitted, the `OVH_CLOUD_PROJECT_SERVICE` environment variable is used.
 
 ## Attributes Reference
 

--- a/docs/data-sources/cloud_ext_net_ip.md
+++ b/docs/data-sources/cloud_ext_net_ip.md
@@ -23,7 +23,7 @@ output "ext_net_ip_status" {
 
 The following arguments are supported:
 
-* `service_name` - (Required) Service name of the resource representing the id of the cloud project.
+* `service_name` - (Required) Service name of the resource representing the id of the cloud project. If omitted, the `OVH_CLOUD_PROJECT_SERVICE` environment variable is used.
 * `id` - (Required) IP address of the external network IP.
 
 ## Attributes Reference

--- a/docs/data-sources/cloud_ext_net_ips.md
+++ b/docs/data-sources/cloud_ext_net_ips.md
@@ -22,7 +22,7 @@ output "ext_net_ip_addresses" {
 
 The following arguments are supported:
 
-* `service_name` - (Required) Service name of the resource representing the id of the cloud project.
+* `service_name` - (Required) Service name of the resource representing the id of the cloud project. If omitted, the `OVH_CLOUD_PROJECT_SERVICE` environment variable is used.
 
 ## Attributes Reference
 

--- a/docs/data-sources/cloud_floating_ip.md
+++ b/docs/data-sources/cloud_floating_ip.md
@@ -23,7 +23,7 @@ output "floating_ip_status" {
 
 The following arguments are supported:
 
-* `service_name` - (Required) Service name of the resource representing the id of the cloud project.
+* `service_name` - (Required) Service name of the resource representing the id of the cloud project. If omitted, the `OVH_CLOUD_PROJECT_SERVICE` environment variable is used.
 * `id` - (Required) IP address of the floating IP.
 
 ## Attributes Reference

--- a/docs/data-sources/cloud_floating_ips.md
+++ b/docs/data-sources/cloud_floating_ips.md
@@ -22,7 +22,7 @@ output "floating_ip_addresses" {
 
 The following arguments are supported:
 
-* `service_name` - (Required) Service name of the resource representing the id of the cloud project.
+* `service_name` - (Required) Service name of the resource representing the id of the cloud project. If omitted, the `OVH_CLOUD_PROJECT_SERVICE` environment variable is used.
 
 ## Attributes Reference
 

--- a/docs/data-sources/cloud_public_ips.md
+++ b/docs/data-sources/cloud_public_ips.md
@@ -22,7 +22,7 @@ output "public_ips" {
 
 The following arguments are supported:
 
-* `service_name` - (Required) Service name of the resource representing the id of the cloud project.
+* `service_name` - (Required) Service name of the resource representing the id of the cloud project. If omitted, the `OVH_CLOUD_PROJECT_SERVICE` environment variable is used.
 
 ## Attributes Reference
 

--- a/docs/resources/cloud_floating_ip.md
+++ b/docs/resources/cloud_floating_ip.md
@@ -20,7 +20,7 @@ resource "ovh_cloud_floating_ip" "ip" {
 
 The following arguments are supported:
 
-* `service_name` - (Required) Service name of the resource representing the id of the cloud project. **Changing this value recreates the resource.**
+* `service_name` - (Required) Service name of the resource representing the id of the cloud project. If omitted, the `OVH_CLOUD_PROJECT_SERVICE` environment variable is used. **Changing this value recreates the resource.**
 * `region` - (Required) Region where the floating IP will be created. **Changing this value recreates the resource.**
 * `availability_zone` - (Optional) Availability zone for the floating IP. **Changing this value recreates the resource.**
 * `description` - (Optional) Description of the floating IP. This is the only argument that can be updated in place.

--- a/ovh/data_cloud_additional_ip.go
+++ b/ovh/data_cloud_additional_ip.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net/url"
+	"os"
 
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
@@ -48,8 +49,9 @@ func (d *cloudAdditionalIPDataSource) Schema(ctx context.Context, req datasource
 		Attributes: map[string]schema.Attribute{
 			"service_name": schema.StringAttribute{
 				CustomType:  ovhtypes.TfStringType{},
-				Required:    true,
-				Description: "Service name of the resource representing the id of the cloud project",
+				Optional:    true,
+				Computed:    true,
+				Description: "Service name of the resource representing the id of the cloud project. If omitted, the `OVH_CLOUD_PROJECT_SERVICE` environment variable is used.",
 			},
 			"id": schema.StringAttribute{
 				CustomType:  ovhtypes.TfStringType{},
@@ -180,6 +182,19 @@ func (d *cloudAdditionalIPDataSource) Read(ctx context.Context, req datasource.R
 	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
 	if resp.Diagnostics.HasError() {
 		return
+	}
+
+	if data.ServiceName.IsNull() || data.ServiceName.ValueString() == "" {
+		envServiceName := os.Getenv("OVH_CLOUD_PROJECT_SERVICE")
+		if envServiceName == "" {
+			resp.Diagnostics.AddError(
+				"Missing service_name",
+				"The service_name attribute is required. Provide it in the data source "+
+					"configuration or set the OVH_CLOUD_PROJECT_SERVICE environment variable.",
+			)
+			return
+		}
+		data.ServiceName = ovhtypes.NewTfStringValue(envServiceName)
 	}
 
 	endpoint := "/v2/publicCloud/project/" + url.PathEscape(data.ServiceName.ValueString()) + "/publicIp/additional/" + url.PathEscape(data.Id.ValueString())

--- a/ovh/data_cloud_additional_ip_test.go
+++ b/ovh/data_cloud_additional_ip_test.go
@@ -44,3 +44,44 @@ data "ovh_cloud_additional_ip" "test" {
 		},
 	})
 }
+
+// TestAccDataSourceCloudAdditionalIP_serviceNameFromEnv mirrors the _basic test
+// but omits service_name from the data block: the data source must resolve the
+// project id from the OVH_CLOUD_PROJECT_SERVICE environment variable.
+func TestAccDataSourceCloudAdditionalIP_serviceNameFromEnv(t *testing.T) {
+	serviceName := os.Getenv("OVH_CLOUD_PROJECT_SERVICE_TEST")
+
+	// Additional IPs cannot be created from Terraform: the test requires an
+	// existing additional IP in the test project.
+	additionalIP := os.Getenv("OVH_CLOUD_PUBLIC_IP_ADDITIONAL_TEST")
+	if additionalIP == "" {
+		t.Skip("OVH_CLOUD_PUBLIC_IP_ADDITIONAL_TEST not set")
+	}
+
+	t.Setenv("OVH_CLOUD_PROJECT_SERVICE", serviceName)
+
+	config := fmt.Sprintf(`
+data "ovh_cloud_additional_ip" "test" {
+  id = "%s"
+}
+`, additionalIP)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheckCloudPublicIP(t)
+		},
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("data.ovh_cloud_additional_ip.test", "service_name", serviceName),
+					resource.TestCheckResourceAttr("data.ovh_cloud_additional_ip.test", "id", additionalIP),
+					resource.TestCheckResourceAttrSet("data.ovh_cloud_additional_ip.test", "current_state.id"),
+					resource.TestCheckResourceAttrSet("data.ovh_cloud_additional_ip.test", "resource_status"),
+					resource.TestCheckResourceAttrSet("data.ovh_cloud_additional_ip.test", "current_state.ip"),
+				),
+			},
+		},
+	})
+}

--- a/ovh/data_cloud_additional_ips.go
+++ b/ovh/data_cloud_additional_ips.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net/url"
+	"os"
 
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
@@ -56,8 +57,9 @@ func (d *cloudAdditionalIPsDataSource) Schema(ctx context.Context, req datasourc
 		Attributes: map[string]schema.Attribute{
 			"service_name": schema.StringAttribute{
 				CustomType:  ovhtypes.TfStringType{},
-				Required:    true,
-				Description: "Service name of the resource representing the id of the cloud project",
+				Optional:    true,
+				Computed:    true,
+				Description: "Service name of the resource representing the id of the cloud project. If omitted, the `OVH_CLOUD_PROJECT_SERVICE` environment variable is used.",
 			},
 			"additional_ips": schema.ListNestedAttribute{
 				Computed:    true,
@@ -186,6 +188,19 @@ func (d *cloudAdditionalIPsDataSource) Read(ctx context.Context, req datasource.
 	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
 	if resp.Diagnostics.HasError() {
 		return
+	}
+
+	if data.ServiceName.IsNull() || data.ServiceName.ValueString() == "" {
+		envServiceName := os.Getenv("OVH_CLOUD_PROJECT_SERVICE")
+		if envServiceName == "" {
+			resp.Diagnostics.AddError(
+				"Missing service_name",
+				"The service_name attribute is required. Provide it in the data source "+
+					"configuration or set the OVH_CLOUD_PROJECT_SERVICE environment variable.",
+			)
+			return
+		}
+		data.ServiceName = ovhtypes.NewTfStringValue(envServiceName)
 	}
 
 	endpoint := "/v2/publicCloud/project/" + url.PathEscape(data.ServiceName.ValueString()) + "/publicIp/additional"

--- a/ovh/data_cloud_additional_ips_test.go
+++ b/ovh/data_cloud_additional_ips_test.go
@@ -35,3 +35,35 @@ data "ovh_cloud_additional_ips" "test" {
 		},
 	})
 }
+
+// TestAccDataSourceCloudAdditionalIPs_serviceNameFromEnv mirrors the _basic test
+// but omits service_name from the data block: the data source must resolve the
+// project id from the OVH_CLOUD_PROJECT_SERVICE environment variable.
+func TestAccDataSourceCloudAdditionalIPs_serviceNameFromEnv(t *testing.T) {
+	serviceName := os.Getenv("OVH_CLOUD_PROJECT_SERVICE_TEST")
+
+	t.Setenv("OVH_CLOUD_PROJECT_SERVICE", serviceName)
+
+	// Additional IPs cannot be created from Terraform: this test only checks
+	// that the listing works, even when the project has no additional IP.
+	config := `
+data "ovh_cloud_additional_ips" "test" {
+}
+`
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheckCloudPublicIP(t)
+		},
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("data.ovh_cloud_additional_ips.test", "service_name", serviceName),
+					resource.TestCheckResourceAttrSet("data.ovh_cloud_additional_ips.test", "additional_ips.#"),
+				),
+			},
+		},
+	})
+}

--- a/ovh/data_cloud_ext_net_ip.go
+++ b/ovh/data_cloud_ext_net_ip.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net/url"
+	"os"
 
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
@@ -48,8 +49,9 @@ func (d *cloudExtNetIPDataSource) Schema(ctx context.Context, req datasource.Sch
 		Attributes: map[string]schema.Attribute{
 			"service_name": schema.StringAttribute{
 				CustomType:  ovhtypes.TfStringType{},
-				Required:    true,
-				Description: "Service name of the resource representing the id of the cloud project",
+				Optional:    true,
+				Computed:    true,
+				Description: "Service name of the resource representing the id of the cloud project. If omitted, the `OVH_CLOUD_PROJECT_SERVICE` environment variable is used.",
 			},
 			"id": schema.StringAttribute{
 				CustomType:  ovhtypes.TfStringType{},
@@ -187,6 +189,19 @@ func (d *cloudExtNetIPDataSource) Read(ctx context.Context, req datasource.ReadR
 	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
 	if resp.Diagnostics.HasError() {
 		return
+	}
+
+	if data.ServiceName.IsNull() || data.ServiceName.ValueString() == "" {
+		envServiceName := os.Getenv("OVH_CLOUD_PROJECT_SERVICE")
+		if envServiceName == "" {
+			resp.Diagnostics.AddError(
+				"Missing service_name",
+				"The service_name attribute is required. Provide it in the data source "+
+					"configuration or set the OVH_CLOUD_PROJECT_SERVICE environment variable.",
+			)
+			return
+		}
+		data.ServiceName = ovhtypes.NewTfStringValue(envServiceName)
 	}
 
 	endpoint := "/v2/publicCloud/project/" + url.PathEscape(data.ServiceName.ValueString()) + "/publicIp/extNet/" + url.PathEscape(data.Id.ValueString())

--- a/ovh/data_cloud_ext_net_ip_test.go
+++ b/ovh/data_cloud_ext_net_ip_test.go
@@ -84,3 +84,48 @@ data "ovh_cloud_ext_net_ip" "test" {
 		},
 	})
 }
+
+// TestAccDataSourceCloudExtNetIP_serviceNameFromEnv mirrors the _basic test but
+// omits service_name from the data block: the data source must resolve the
+// project id from the OVH_CLOUD_PROJECT_SERVICE environment variable.
+func TestAccDataSourceCloudExtNetIP_serviceNameFromEnv(t *testing.T) {
+	serviceName := os.Getenv("OVH_CLOUD_PROJECT_SERVICE_TEST")
+	region := os.Getenv("OVH_CLOUD_PROJECT_REGION_TEST")
+	flavor, image, err := getFlavorAndImage(serviceName, region)
+	if err != nil {
+		t.Skipf("failed to retrieve a flavor and an image: %s", err)
+	}
+
+	t.Setenv("OVH_CLOUD_PROJECT_SERVICE", serviceName)
+
+	// The instance keeps an explicit service_name so setup stays deterministic;
+	// only the data block relies on the environment fallback.
+	config := testAccCloudExtNetIPInstanceConfig(serviceName, region, image, flavor) + `
+data "ovh_cloud_ext_net_ip" "test" {
+  id = [for address in ovh_cloud_project_instance.instance.addresses : address.ip if address.version == 4][0]
+}
+`
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheckCloudExtNetIP(t)
+		},
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("data.ovh_cloud_ext_net_ip.test", "service_name", serviceName),
+					resource.TestCheckResourceAttrSet("data.ovh_cloud_ext_net_ip.test", "id"),
+					resource.TestCheckResourceAttrSet("data.ovh_cloud_ext_net_ip.test", "resource_status"),
+					resource.TestCheckResourceAttrSet("data.ovh_cloud_ext_net_ip.test", "current_state.ip"),
+					resource.TestCheckResourceAttrSet("data.ovh_cloud_ext_net_ip.test", "current_state.id"),
+					resource.TestCheckResourceAttrPair(
+						"data.ovh_cloud_ext_net_ip.test", "id",
+						"data.ovh_cloud_ext_net_ip.test", "current_state.ip",
+					),
+				),
+			},
+		},
+	})
+}

--- a/ovh/data_cloud_ext_net_ips.go
+++ b/ovh/data_cloud_ext_net_ips.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net/url"
+	"os"
 
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
@@ -56,8 +57,9 @@ func (d *cloudExtNetIPsDataSource) Schema(ctx context.Context, req datasource.Sc
 		Attributes: map[string]schema.Attribute{
 			"service_name": schema.StringAttribute{
 				CustomType:  ovhtypes.TfStringType{},
-				Required:    true,
-				Description: "Service name of the resource representing the id of the cloud project",
+				Optional:    true,
+				Computed:    true,
+				Description: "Service name of the resource representing the id of the cloud project. If omitted, the `OVH_CLOUD_PROJECT_SERVICE` environment variable is used.",
 			},
 			"ext_net_ips": schema.ListNestedAttribute{
 				Computed:    true,
@@ -191,6 +193,19 @@ func (d *cloudExtNetIPsDataSource) Read(ctx context.Context, req datasource.Read
 	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
 	if resp.Diagnostics.HasError() {
 		return
+	}
+
+	if data.ServiceName.IsNull() || data.ServiceName.ValueString() == "" {
+		envServiceName := os.Getenv("OVH_CLOUD_PROJECT_SERVICE")
+		if envServiceName == "" {
+			resp.Diagnostics.AddError(
+				"Missing service_name",
+				"The service_name attribute is required. Provide it in the data source "+
+					"configuration or set the OVH_CLOUD_PROJECT_SERVICE environment variable.",
+			)
+			return
+		}
+		data.ServiceName = ovhtypes.NewTfStringValue(envServiceName)
 	}
 
 	endpoint := "/v2/publicCloud/project/" + url.PathEscape(data.ServiceName.ValueString()) + "/publicIp/extNet"

--- a/ovh/data_cloud_ext_net_ips_test.go
+++ b/ovh/data_cloud_ext_net_ips_test.go
@@ -41,3 +41,42 @@ data "ovh_cloud_ext_net_ips" "test" {
 		},
 	})
 }
+
+// TestAccDataSourceCloudExtNetIPs_serviceNameFromEnv mirrors the _basic test but
+// omits service_name from the data block: the data source must resolve the
+// project id from the OVH_CLOUD_PROJECT_SERVICE environment variable.
+func TestAccDataSourceCloudExtNetIPs_serviceNameFromEnv(t *testing.T) {
+	serviceName := os.Getenv("OVH_CLOUD_PROJECT_SERVICE_TEST")
+	region := os.Getenv("OVH_CLOUD_PROJECT_REGION_TEST")
+	flavor, image, err := getFlavorAndImage(serviceName, region)
+	if err != nil {
+		t.Skipf("failed to retrieve a flavor and an image: %s", err)
+	}
+
+	t.Setenv("OVH_CLOUD_PROJECT_SERVICE", serviceName)
+
+	// The instance keeps an explicit service_name so setup stays deterministic;
+	// only the data block relies on the environment fallback.
+	config := testAccCloudExtNetIPInstanceConfig(serviceName, region, image, flavor) + `
+data "ovh_cloud_ext_net_ips" "test" {
+  depends_on = [ovh_cloud_project_instance.instance]
+}
+`
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheckCloudExtNetIP(t)
+		},
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("data.ovh_cloud_ext_net_ips.test", "service_name", serviceName),
+					resource.TestCheckResourceAttrSet("data.ovh_cloud_ext_net_ips.test", "ext_net_ips.#"),
+					resource.TestCheckResourceAttrWith("data.ovh_cloud_ext_net_ips.test", "ext_net_ips.#", testAccCheckCloudPublicIPListNotEmpty),
+				),
+			},
+		},
+	})
+}

--- a/ovh/data_cloud_floating_ip.go
+++ b/ovh/data_cloud_floating_ip.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net/url"
+	"os"
 
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
@@ -49,8 +50,9 @@ func (d *cloudFloatingIPDataSource) Schema(ctx context.Context, req datasource.S
 		Attributes: map[string]schema.Attribute{
 			"service_name": schema.StringAttribute{
 				CustomType:  ovhtypes.TfStringType{},
-				Required:    true,
-				Description: "Service name of the resource representing the id of the cloud project",
+				Optional:    true,
+				Computed:    true,
+				Description: "Service name of the resource representing the id of the cloud project. If omitted, the `OVH_CLOUD_PROJECT_SERVICE` environment variable is used.",
 			},
 			"id": schema.StringAttribute{
 				CustomType:  ovhtypes.TfStringType{},
@@ -235,6 +237,19 @@ func (d *cloudFloatingIPDataSource) Read(ctx context.Context, req datasource.Rea
 	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
 	if resp.Diagnostics.HasError() {
 		return
+	}
+
+	if data.ServiceName.IsNull() || data.ServiceName.ValueString() == "" {
+		envServiceName := os.Getenv("OVH_CLOUD_PROJECT_SERVICE")
+		if envServiceName == "" {
+			resp.Diagnostics.AddError(
+				"Missing service_name",
+				"The service_name attribute is required. Provide it in the data source "+
+					"configuration or set the OVH_CLOUD_PROJECT_SERVICE environment variable.",
+			)
+			return
+		}
+		data.ServiceName = ovhtypes.NewTfStringValue(envServiceName)
 	}
 
 	endpoint := "/v2/publicCloud/project/" + url.PathEscape(data.ServiceName.ValueString()) + "/publicIp/floating/" + url.PathEscape(data.Id.ValueString())

--- a/ovh/data_cloud_floating_ip_test.go
+++ b/ovh/data_cloud_floating_ip_test.go
@@ -3,6 +3,7 @@ package ovh
 import (
 	"fmt"
 	"os"
+	"regexp"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
@@ -44,6 +45,82 @@ data "ovh_cloud_floating_ip" "test" {
 					resource.TestCheckResourceAttrSet("data.ovh_cloud_floating_ip.test", "checksum"),
 					resource.TestCheckResourceAttrSet("data.ovh_cloud_floating_ip.test", "current_state.ip"),
 				),
+			},
+		},
+	})
+}
+
+// TestAccDataSourceCloudFloatingIP_serviceNameFromEnv mirrors the _basic test
+// but omits service_name from the data block: the data source must resolve the
+// project id from the OVH_CLOUD_PROJECT_SERVICE environment variable.
+func TestAccDataSourceCloudFloatingIP_serviceNameFromEnv(t *testing.T) {
+	serviceName := os.Getenv("OVH_CLOUD_PROJECT_SERVICE_TEST")
+	region := os.Getenv("OVH_CLOUD_PROJECT_REGION_TEST")
+
+	t.Setenv("OVH_CLOUD_PROJECT_SERVICE", serviceName)
+
+	description := acctest.RandomWithPrefix(testAccResourceCloudFloatingIPDescriptionPrefix)
+
+	// The resource keeps an explicit service_name so setup stays deterministic;
+	// only the data block relies on the environment fallback.
+	config := fmt.Sprintf(`
+resource "ovh_cloud_floating_ip" "test" {
+  service_name = "%s"
+  region       = "%s"
+  description  = "%s"
+}
+
+data "ovh_cloud_floating_ip" "test" {
+  id = ovh_cloud_floating_ip.test.id
+}
+`, serviceName, region, description)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheckCloudPublicIP(t)
+		},
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("data.ovh_cloud_floating_ip.test", "service_name", serviceName),
+					resource.TestCheckResourceAttr("data.ovh_cloud_floating_ip.test", "description", description),
+					resource.TestCheckResourceAttr("data.ovh_cloud_floating_ip.test", "location.region", region),
+					resource.TestCheckResourceAttrSet("data.ovh_cloud_floating_ip.test", "id"),
+					resource.TestCheckResourceAttrSet("data.ovh_cloud_floating_ip.test", "checksum"),
+					resource.TestCheckResourceAttrSet("data.ovh_cloud_floating_ip.test", "current_state.ip"),
+				),
+			},
+		},
+	})
+}
+
+// TestAccDataSourceCloudFloatingIP_missingServiceName asserts that the data
+// source errors clearly when neither the configuration nor the
+// OVH_CLOUD_PROJECT_SERVICE environment variable supplies service_name. The
+// error is raised before any API call, so no project/region is needed.
+func TestAccDataSourceCloudFloatingIP_missingServiceName(t *testing.T) {
+	// Force the env var empty so the inline fallback cannot resolve it.
+	t.Setenv("OVH_CLOUD_PROJECT_SERVICE", "")
+
+	// 203.0.113.1 is a documentation/test IP (RFC 5737); it is never queried
+	// because the missing service_name is rejected first.
+	config := `
+data "ovh_cloud_floating_ip" "test" {
+  id = "203.0.113.1"
+}
+`
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheckCredentials(t)
+		},
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config:      config,
+				ExpectError: regexp.MustCompile("Missing service_name"),
 			},
 		},
 	})

--- a/ovh/data_cloud_floating_ips.go
+++ b/ovh/data_cloud_floating_ips.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net/url"
+	"os"
 
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
@@ -56,8 +57,9 @@ func (d *cloudFloatingIPsDataSource) Schema(ctx context.Context, req datasource.
 		Attributes: map[string]schema.Attribute{
 			"service_name": schema.StringAttribute{
 				CustomType:  ovhtypes.TfStringType{},
-				Required:    true,
-				Description: "Service name of the resource representing the id of the cloud project",
+				Optional:    true,
+				Computed:    true,
+				Description: "Service name of the resource representing the id of the cloud project. If omitted, the `OVH_CLOUD_PROJECT_SERVICE` environment variable is used.",
 			},
 			"floating_ips": schema.ListNestedAttribute{
 				Computed:    true,
@@ -233,6 +235,19 @@ func (d *cloudFloatingIPsDataSource) Read(ctx context.Context, req datasource.Re
 	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
 	if resp.Diagnostics.HasError() {
 		return
+	}
+
+	if data.ServiceName.IsNull() || data.ServiceName.ValueString() == "" {
+		envServiceName := os.Getenv("OVH_CLOUD_PROJECT_SERVICE")
+		if envServiceName == "" {
+			resp.Diagnostics.AddError(
+				"Missing service_name",
+				"The service_name attribute is required. Provide it in the data source "+
+					"configuration or set the OVH_CLOUD_PROJECT_SERVICE environment variable.",
+			)
+			return
+		}
+		data.ServiceName = ovhtypes.NewTfStringValue(envServiceName)
 	}
 
 	endpoint := "/v2/publicCloud/project/" + url.PathEscape(data.ServiceName.ValueString()) + "/publicIp/floating"

--- a/ovh/data_cloud_floating_ips_test.go
+++ b/ovh/data_cloud_floating_ips_test.go
@@ -45,3 +45,45 @@ data "ovh_cloud_floating_ips" "test" {
 		},
 	})
 }
+
+// TestAccDataSourceCloudFloatingIPs_serviceNameFromEnv mirrors the _basic test
+// but omits service_name from the data block: the data source must resolve the
+// project id from the OVH_CLOUD_PROJECT_SERVICE environment variable.
+func TestAccDataSourceCloudFloatingIPs_serviceNameFromEnv(t *testing.T) {
+	serviceName := os.Getenv("OVH_CLOUD_PROJECT_SERVICE_TEST")
+	region := os.Getenv("OVH_CLOUD_PROJECT_REGION_TEST")
+
+	t.Setenv("OVH_CLOUD_PROJECT_SERVICE", serviceName)
+
+	description := acctest.RandomWithPrefix(testAccResourceCloudFloatingIPDescriptionPrefix)
+
+	// The resource keeps an explicit service_name so setup stays deterministic;
+	// only the data block relies on the environment fallback.
+	config := fmt.Sprintf(`
+resource "ovh_cloud_floating_ip" "test" {
+  service_name = "%s"
+  region       = "%s"
+  description  = "%s"
+}
+
+data "ovh_cloud_floating_ips" "test" {
+  depends_on = [ovh_cloud_floating_ip.test]
+}
+`, serviceName, region, description)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheckCloudPublicIP(t)
+		},
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("data.ovh_cloud_floating_ips.test", "service_name", serviceName),
+					resource.TestCheckResourceAttrWith("data.ovh_cloud_floating_ips.test", "floating_ips.#", testAccCheckCloudPublicIPListNotEmpty),
+				),
+			},
+		},
+	})
+}

--- a/ovh/data_cloud_public_ips.go
+++ b/ovh/data_cloud_public_ips.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net/url"
+	"os"
 
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
@@ -50,8 +51,9 @@ func (d *cloudPublicIPsDataSource) Schema(ctx context.Context, req datasource.Sc
 		Attributes: map[string]schema.Attribute{
 			"service_name": schema.StringAttribute{
 				CustomType:  ovhtypes.TfStringType{},
-				Required:    true,
-				Description: "Service name of the resource representing the id of the cloud project",
+				Optional:    true,
+				Computed:    true,
+				Description: "Service name of the resource representing the id of the cloud project. If omitted, the `OVH_CLOUD_PROJECT_SERVICE` environment variable is used.",
 			},
 			"public_ips": schema.ListNestedAttribute{
 				Computed:    true,
@@ -96,6 +98,19 @@ func (d *cloudPublicIPsDataSource) Read(ctx context.Context, req datasource.Read
 	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
 	if resp.Diagnostics.HasError() {
 		return
+	}
+
+	if data.ServiceName.IsNull() || data.ServiceName.ValueString() == "" {
+		envServiceName := os.Getenv("OVH_CLOUD_PROJECT_SERVICE")
+		if envServiceName == "" {
+			resp.Diagnostics.AddError(
+				"Missing service_name",
+				"The service_name attribute is required. Provide it in the data source "+
+					"configuration or set the OVH_CLOUD_PROJECT_SERVICE environment variable.",
+			)
+			return
+		}
+		data.ServiceName = ovhtypes.NewTfStringValue(envServiceName)
 	}
 
 	endpoint := "/v2/publicCloud/project/" + url.PathEscape(data.ServiceName.ValueString()) + "/publicIp"

--- a/ovh/data_cloud_public_ips_test.go
+++ b/ovh/data_cloud_public_ips_test.go
@@ -45,3 +45,45 @@ data "ovh_cloud_public_ips" "test" {
 		},
 	})
 }
+
+// TestAccDataSourceCloudPublicIPs_serviceNameFromEnv mirrors the _basic test but
+// omits service_name from the data block: the data source must resolve the
+// project id from the OVH_CLOUD_PROJECT_SERVICE environment variable.
+func TestAccDataSourceCloudPublicIPs_serviceNameFromEnv(t *testing.T) {
+	serviceName := os.Getenv("OVH_CLOUD_PROJECT_SERVICE_TEST")
+	region := os.Getenv("OVH_CLOUD_PROJECT_REGION_TEST")
+
+	t.Setenv("OVH_CLOUD_PROJECT_SERVICE", serviceName)
+
+	description := acctest.RandomWithPrefix(testAccResourceCloudFloatingIPDescriptionPrefix)
+
+	// The resource keeps an explicit service_name so setup stays deterministic;
+	// only the data block relies on the environment fallback.
+	config := fmt.Sprintf(`
+resource "ovh_cloud_floating_ip" "test" {
+  service_name = "%s"
+  region       = "%s"
+  description  = "%s"
+}
+
+data "ovh_cloud_public_ips" "test" {
+  depends_on = [ovh_cloud_floating_ip.test]
+}
+`, serviceName, region, description)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheckCloudPublicIP(t)
+		},
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("data.ovh_cloud_public_ips.test", "service_name", serviceName),
+					resource.TestCheckResourceAttrWith("data.ovh_cloud_public_ips.test", "public_ips.#", testAccCheckCloudPublicIPListNotEmpty),
+				),
+			},
+		},
+	})
+}

--- a/ovh/resource_cloud_floating_ip.go
+++ b/ovh/resource_cloud_floating_ip.go
@@ -63,10 +63,13 @@ func (r *cloudFloatingIPResource) Schema(ctx context.Context, req resource.Schem
 		Attributes: map[string]schema.Attribute{
 			"service_name": schema.StringAttribute{
 				CustomType:          ovhtypes.TfStringType{},
-				Required:            true,
-				Description:         "Service name of the resource representing the id of the cloud project",
-				MarkdownDescription: "Service name of the resource representing the id of the cloud project",
+				Optional:            true,
+				Computed:            true,
+				Description:         "Service name of the resource representing the id of the cloud project. If omitted, the `OVH_CLOUD_PROJECT_SERVICE` environment variable is used.",
+				MarkdownDescription: "Service name of the resource representing the id of the cloud project. If omitted, the `OVH_CLOUD_PROJECT_SERVICE` environment variable is used.",
 				PlanModifiers: []planmodifier.String{
+					EnvDefaultString("OVH_CLOUD_PROJECT_SERVICE", true),
+					stringplanmodifier.UseStateForUnknown(),
 					stringplanmodifier.RequiresReplace(),
 				},
 			},

--- a/ovh/resource_cloud_floating_ip_test.go
+++ b/ovh/resource_cloud_floating_ip_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 )
 
@@ -112,6 +113,63 @@ resource "ovh_cloud_floating_ip" "test" {
 						return nil
 					}),
 				),
+			},
+		},
+	})
+}
+
+// TestAccCloudFloatingIP_serviceNameFromEnv validates that when service_name is
+// omitted from the resource configuration, the provider falls back to the
+// OVH_CLOUD_PROJECT_SERVICE environment variable at plan time (via the
+// EnvDefaultString plan modifier) and that this does not produce a perpetual
+// diff / phantom replace on subsequent plans.
+func TestAccCloudFloatingIP_serviceNameFromEnv(t *testing.T) {
+	serviceName := os.Getenv("OVH_CLOUD_PROJECT_SERVICE_TEST")
+	region := os.Getenv("OVH_CLOUD_PROJECT_REGION_TEST")
+
+	// Make the project id resolvable from the environment so the resource can be
+	// configured without an explicit service_name.
+	t.Setenv("OVH_CLOUD_PROJECT_SERVICE", serviceName)
+
+	description := acctest.RandomWithPrefix(testAccResourceCloudFloatingIPDescriptionPrefix)
+
+	// service_name is intentionally omitted from the config: it must be resolved
+	// from OVH_CLOUD_PROJECT_SERVICE by the EnvDefaultString plan modifier.
+	config := fmt.Sprintf(`
+resource "ovh_cloud_floating_ip" "test" {
+  region      = "%s"
+  description = "%s"
+}
+`, region, description)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheckCloudPublicIP(t)
+		},
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					// The env default was applied even though service_name was
+					// absent from the config.
+					resource.TestCheckResourceAttr("ovh_cloud_floating_ip.test", "service_name", serviceName),
+					resource.TestCheckResourceAttr("ovh_cloud_floating_ip.test", "region", region),
+					resource.TestCheckResourceAttr("ovh_cloud_floating_ip.test", "description", description),
+					resource.TestCheckResourceAttr("ovh_cloud_floating_ip.test", "resource_status", "READY"),
+					resource.TestCheckResourceAttrSet("ovh_cloud_floating_ip.test", "id"),
+				),
+			},
+			{
+				// Re-planning with service_name still omitted must be a no-op:
+				// the EnvDefaultString modifier injects the env value so the plan
+				// matches state and RequiresReplace does not fire (regression guard).
+				Config: config,
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
 			},
 		},
 	})


### PR DESCRIPTION
# Description

Fix public IPs resources and datasources to accept `OVH_CLOUD_PROJECT_SERVICE` environment variable to define service name.

## Type of change

- [x] Improvement (improve existing resource(s) or datasource(s))

# How Has This Been Tested?

```
$ make testacc TESTARGS="-run 'CloudFloatingIP|DataSourceCloud(FloatingIPs|ExtNetIPs|AdditionalIPs|PublicIPs)_'"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -run 'CloudFloatingIP|DataSourceCloud(FloatingIPs|ExtNetIPs|AdditionalIPs|PublicIPs)_' -timeout 600m -p 10
?   	github.com/ovh/terraform-provider-ovh/v2	[no test files]
=== RUN   TestAccDataSourceCloudAdditionalIPs_basic
--- PASS: TestAccDataSourceCloudAdditionalIPs_basic (2.07s)
=== RUN   TestAccDataSourceCloudAdditionalIPs_serviceNameFromEnv
--- PASS: TestAccDataSourceCloudAdditionalIPs_serviceNameFromEnv (1.70s)
=== RUN   TestAccDataSourceCloudExtNetIPs_basic
--- PASS: TestAccDataSourceCloudExtNetIPs_basic (132.72s)
=== RUN   TestAccDataSourceCloudExtNetIPs_serviceNameFromEnv
--- PASS: TestAccDataSourceCloudExtNetIPs_serviceNameFromEnv (133.98s)
=== RUN   TestAccDataSourceCloudFloatingIP_basic
--- PASS: TestAccDataSourceCloudFloatingIP_basic (25.21s)
=== RUN   TestAccDataSourceCloudFloatingIP_serviceNameFromEnv
--- PASS: TestAccDataSourceCloudFloatingIP_serviceNameFromEnv (26.05s)
=== RUN   TestAccDataSourceCloudFloatingIP_missingServiceName
--- PASS: TestAccDataSourceCloudFloatingIP_missingServiceName (0.48s)
=== RUN   TestAccDataSourceCloudFloatingIPs_basic
--- PASS: TestAccDataSourceCloudFloatingIPs_basic (28.03s)
=== RUN   TestAccDataSourceCloudFloatingIPs_serviceNameFromEnv
--- PASS: TestAccDataSourceCloudFloatingIPs_serviceNameFromEnv (25.05s)
=== RUN   TestAccDataSourceCloudPublicIPs_basic
--- PASS: TestAccDataSourceCloudPublicIPs_basic (19.82s)
=== RUN   TestAccDataSourceCloudPublicIPs_serviceNameFromEnv
--- PASS: TestAccDataSourceCloudPublicIPs_serviceNameFromEnv (20.08s)
=== RUN   TestAccCloudFloatingIP_basic
--- PASS: TestAccCloudFloatingIP_basic (20.22s)
=== RUN   TestAccCloudFloatingIP_updateDescription
--- PASS: TestAccCloudFloatingIP_updateDescription (25.92s)
=== RUN   TestAccCloudFloatingIP_serviceNameFromEnv
--- PASS: TestAccCloudFloatingIP_serviceNameFromEnv (23.18s)
PASS
ok
```

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or issues
- [x] I have added acceptance tests that prove my fix is effective or that my feature works
- [x] New and existing acceptance tests pass locally with my changes
- [x] I ran successfully `go mod vendor` if I added or modify `go.mod` file 