### PR TITLE
fix: Add missing field availability_zone on block storage volume + fix bug on encryption

### DIFF
--- a/ovh/resource_cloud_storage_block_volume.go
+++ b/ovh/resource_cloud_storage_block_volume.go
@@ -95,6 +95,17 @@ func (r *cloudStorageBlockVolumeResource) Schema(ctx context.Context, req resour
 					stringplanmodifier.RequiresReplace(),
 				},
 			},
+			"availability_zone": schema.StringAttribute{
+				CustomType:          ovhtypes.TfStringType{},
+				Optional:            true,
+				Computed:            true,
+				Description:         "Availability zone where the volume will be created",
+				MarkdownDescription: "Availability zone where the volume will be created",
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+					stringplanmodifier.RequiresReplace(),
+				},
+			},
 			"volume_type": schema.StringAttribute{
 				CustomType:          ovhtypes.TfStringType{},
 				Optional:            true,
@@ -111,6 +122,7 @@ func (r *cloudStorageBlockVolumeResource) Schema(ctx context.Context, req resour
 				Description:         "Encryption configuration for the volume. Changing this value recreates the resource.",
 				MarkdownDescription: "Encryption configuration for the volume. **Changing this value recreates the resource.**",
 				PlanModifiers: []planmodifier.Object{
+					objectplanmodifier.UseStateForUnknown(),
 					objectplanmodifier.RequiresReplace(),
 				},
 				Attributes: map[string]schema.Attribute{
@@ -120,6 +132,7 @@ func (r *cloudStorageBlockVolumeResource) Schema(ctx context.Context, req resour
 						Description:         "Whether the volume is encrypted at rest with LUKS",
 						MarkdownDescription: "Whether the volume is encrypted at rest with LUKS",
 						PlanModifiers: []planmodifier.Bool{
+							boolplanmodifier.UseStateForUnknown(),
 							boolplanmodifier.RequiresReplace(),
 						},
 					},
@@ -209,6 +222,12 @@ func (r *cloudStorageBlockVolumeResource) Schema(ctx context.Context, req resour
 								Computed:            true,
 								Description:         "Region",
 								MarkdownDescription: "Region",
+							},
+							"availability_zone": schema.StringAttribute{
+								CustomType:          ovhtypes.TfStringType{},
+								Computed:            true,
+								Description:         "Availability zone",
+								MarkdownDescription: "Availability zone",
 							},
 						},
 					},

--- a/ovh/resource_cloud_storage_block_volume_test.go
+++ b/ovh/resource_cloud_storage_block_volume_test.go
@@ -439,6 +439,66 @@ resource "ovh_cloud_storage_block_volume" "volume" {
 	})
 }
 
+// TestAccCloudStorageBlockVolume_availabilityZone verifies that a volume can be
+// created pinned to a specific availability zone via the root-level
+// `availability_zone` attribute, and that the AZ is reflected both at the root
+// and inside current_state.location.
+func TestAccCloudStorageBlockVolume_availabilityZone(t *testing.T) {
+	serviceName := os.Getenv("OVH_CLOUD_PROJECT_SERVICE_TEST")
+
+	// Per explicit instruction, these values are hardcoded for this test.
+	const (
+		region           = "EU-WEST-PAR"
+		availabilityZone = "eu-west-par-a"
+	)
+
+	volumeName := acctest.RandomWithPrefix(testAccResourceCloudStorageBlockVolumeNamePrefix)
+
+	config := fmt.Sprintf(`
+resource "ovh_cloud_storage_block_volume" "volume" {
+  service_name      = "%s"
+  name              = "%s"
+  size              = 10
+  region            = "%s"
+  availability_zone = "%s"
+  volume_type       = "HIGH_SPEED_GEN2"
+
+  encryption = {
+    enabled = false
+  }
+}
+`, serviceName, volumeName, region, availabilityZone)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheckCloud(t)
+			testAccCheckCloudProjectExists(t)
+		},
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("ovh_cloud_storage_block_volume.volume", "service_name", serviceName),
+					resource.TestCheckResourceAttr("ovh_cloud_storage_block_volume.volume", "name", volumeName),
+					resource.TestCheckResourceAttr("ovh_cloud_storage_block_volume.volume", "region", region),
+					resource.TestCheckResourceAttr("ovh_cloud_storage_block_volume.volume", "availability_zone", availabilityZone),
+					resource.TestCheckResourceAttr("ovh_cloud_storage_block_volume.volume", "current_state.location.availability_zone", availabilityZone),
+					resource.TestCheckResourceAttrSet("ovh_cloud_storage_block_volume.volume", "id"),
+					resource.TestCheckResourceAttrSet("ovh_cloud_storage_block_volume.volume", "checksum"),
+					resource.TestCheckResourceAttr("ovh_cloud_storage_block_volume.volume", "resource_status", "READY"),
+				),
+			},
+			{
+				ResourceName:      "ovh_cloud_storage_block_volume.volume",
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testAccCloudStorageBlockVolumeImportStateIdFunc("ovh_cloud_storage_block_volume.volume"),
+			},
+		},
+	})
+}
+
 const testAccResourceCloudStorageBlockVolumeNamePrefix = "tf-test-volume-v2-"
 
 func testAccCloudStorageBlockVolumeImportStateIdFunc(resourceName string) resource.ImportStateIdFunc {

--- a/ovh/types_cloud_storage_block_volume.go
+++ b/ovh/types_cloud_storage_block_volume.go
@@ -10,13 +10,14 @@ import (
 
 // CloudStorageBlockVolumeModel represents the Terraform model for the block storage resource
 type CloudStorageBlockVolumeModel struct {
-	ServiceName ovhtypes.TfStringValue `tfsdk:"service_name"`
-	Name        ovhtypes.TfStringValue `tfsdk:"name"`
-	Size        types.Int64            `tfsdk:"size"`
-	Region      ovhtypes.TfStringValue `tfsdk:"region"`
-	VolumeType  ovhtypes.TfStringValue `tfsdk:"volume_type"`
-	Encryption  types.Object           `tfsdk:"encryption"`
-	CreateFrom  types.Object           `tfsdk:"create_from"`
+	ServiceName      ovhtypes.TfStringValue `tfsdk:"service_name"`
+	Name             ovhtypes.TfStringValue `tfsdk:"name"`
+	Size             types.Int64            `tfsdk:"size"`
+	Region           ovhtypes.TfStringValue `tfsdk:"region"`
+	AvailabilityZone ovhtypes.TfStringValue `tfsdk:"availability_zone"`
+	VolumeType       ovhtypes.TfStringValue `tfsdk:"volume_type"`
+	Encryption       types.Object           `tfsdk:"encryption"`
+	CreateFrom       types.Object           `tfsdk:"create_from"`
 
 	Id             ovhtypes.TfStringValue `tfsdk:"id"`
 	Checksum       ovhtypes.TfStringValue `tfsdk:"checksum"`
@@ -72,7 +73,8 @@ type CloudStorageBlockVolumeTarget struct {
 }
 
 type CloudStorageBlockVolumeLocation struct {
-	Region string `json:"region,omitempty"`
+	Region           string `json:"region,omitempty"`
+	AvailabilityZone string `json:"availabilityZone,omitempty"`
 }
 
 // Create payload
@@ -109,6 +111,10 @@ func (m *CloudStorageBlockVolumeModel) ToCreate() *CloudStorageBlockVolumeCreate
 		Name:       m.Name.ValueString(),
 		Size:       m.Size.ValueInt64(),
 		VolumeType: m.VolumeType.ValueString(),
+	}
+
+	if !m.AvailabilityZone.IsNull() && !m.AvailabilityZone.IsUnknown() {
+		target.Location.AvailabilityZone = m.AvailabilityZone.ValueString()
 	}
 
 	if !m.Encryption.IsNull() && !m.Encryption.IsUnknown() {
@@ -177,7 +183,7 @@ func BlockVolumeAttachedInstanceAttrTypes() map[string]attr.Type {
 // BlockVolumeCurrentStateAttrTypes returns the attribute types for the current_state object
 func BlockVolumeCurrentStateAttrTypes() map[string]attr.Type {
 	return map[string]attr.Type{
-		"location":           types.ObjectType{AttrTypes: map[string]attr.Type{"region": ovhtypes.TfStringType{}}},
+		"location":           types.ObjectType{AttrTypes: map[string]attr.Type{"region": ovhtypes.TfStringType{}, "availability_zone": ovhtypes.TfStringType{}}},
 		"name":               ovhtypes.TfStringType{},
 		"size":               types.Int64Type,
 		"volume_type":        ovhtypes.TfStringType{},
@@ -199,8 +205,11 @@ func (m *CloudStorageBlockVolumeModel) MergeWith(ctx context.Context, response *
 	// Build current_state from API currentState
 	if response.CurrentState != nil {
 		locObj, _ := types.ObjectValue(
-			map[string]attr.Type{"region": ovhtypes.TfStringType{}},
-			map[string]attr.Value{"region": ovhtypes.TfStringValue{StringValue: types.StringValue(response.CurrentState.Location.Region)}},
+			map[string]attr.Type{"region": ovhtypes.TfStringType{}, "availability_zone": ovhtypes.TfStringType{}},
+			map[string]attr.Value{
+				"region":            ovhtypes.TfStringValue{StringValue: types.StringValue(response.CurrentState.Location.Region)},
+				"availability_zone": ovhtypes.TfStringValue{StringValue: types.StringValue(response.CurrentState.Location.AvailabilityZone)},
+			},
 		)
 
 		bootableVal := types.BoolValue(false)
@@ -261,6 +270,7 @@ func (m *CloudStorageBlockVolumeModel) MergeWith(ctx context.Context, response *
 	if response.TargetSpec != nil {
 		if response.TargetSpec.Location != nil {
 			m.Region = ovhtypes.TfStringValue{StringValue: types.StringValue(response.TargetSpec.Location.Region)}
+			m.AvailabilityZone = ovhtypes.TfStringValue{StringValue: types.StringValue(response.TargetSpec.Location.AvailabilityZone)}
 		}
 		m.Name = ovhtypes.TfStringValue{StringValue: types.StringValue(response.TargetSpec.Name)}
 		m.Size = types.Int64Value(response.TargetSpec.Size)


### PR DESCRIPTION
# Description

Improvement and bug fix on resource `ovh_cloud_storage_block_volume`:
- Avoid re-creation of the resource when omitting `encryption` field
- Add missing `availability_zone` field in resource

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Improvement (improve existing resource(s) or datasource(s))

# How Has This Been Tested?

All tests matching `CloudStorageBlock` are ok.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or issues
- [x] I have added acceptance tests that prove my fix is effective or that my feature works
- [x] New and existing acceptance tests pass locally with my changes
- [x] I ran successfully `go mod vendor` if I added or modify `go.mod` file
