### PR TITLE
feat: Add missing cloud_storage_file_share_acl(s) datasources + fix i…

### DIFF
--- a/docs/data-sources/cloud_storage_file_share.md
+++ b/docs/data-sources/cloud_storage_file_share.md
@@ -1,5 +1,5 @@
 ---
-subcategory: "Cloud Storage"
+subcategory: "File Storage"
 ---
 
 # ovh_cloud_storage_file_share (Data Source)

--- a/docs/data-sources/cloud_storage_file_share_acl.md
+++ b/docs/data-sources/cloud_storage_file_share_acl.md
@@ -1,0 +1,37 @@
+---
+subcategory: "File Storage"
+---
+
+# ovh_cloud_storage_file_share_acl (Data Source)
+
+Get an access rule (ACL) of a public cloud file storage share.
+
+## Example Usage
+
+```hcl
+data "ovh_cloud_storage_file_share_acl" "acl" {
+  service_name = "<public cloud project ID>"
+  share_id     = "00000000-0000-0000-0000-000000000000"
+  id           = "00000000-0000-0000-0000-000000000000"
+}
+```
+
+## Argument Reference
+
+* `service_name` - (Required) The id of the public cloud project.
+* `share_id` - (Required) The ID of the file storage share the access rule applies to.
+* `id` - (Required) The ID of the access rule.
+
+## Attributes Reference
+
+* `access_to` - IP address or CIDR allowed to access the file storage share.
+* `access_level` - Access level granted (`READ_WRITE`, `READ_ONLY`).
+* `checksum` - Computed hash representing the current target specification value.
+* `created_at` - Creation date of the access rule.
+* `updated_at` - Last update date of the access rule.
+* `resource_status` - Access rule readiness in the system (`CREATING`, `DELETING`, `ERROR`, `OUT_OF_SYNC`, `READY`, `UPDATING`).
+* `current_state` - Current observed state of the access rule from the infrastructure:
+  * `access_to` - IP address or CIDR allowed to access the file storage share.
+  * `access_level` - Access level granted.
+  * `state` - Current state of the access rule (`ACTIVE`, `APPLYING`, `DENYING`, `ERROR`).
+  * `created_at` - Creation date of the access rule.

--- a/docs/data-sources/cloud_storage_file_share_acls.md
+++ b/docs/data-sources/cloud_storage_file_share_acls.md
@@ -1,0 +1,37 @@
+---
+subcategory: "File Storage"
+---
+
+# ovh_cloud_storage_file_share_acls (Data Source)
+
+List the access rules (ACLs) of a public cloud file storage share.
+
+## Example Usage
+
+```hcl
+data "ovh_cloud_storage_file_share_acls" "acls" {
+  service_name = "<public cloud project ID>"
+  share_id     = "00000000-0000-0000-0000-000000000000"
+}
+```
+
+## Argument Reference
+
+* `service_name` - (Required) The id of the public cloud project.
+* `share_id` - (Required) The ID of the file storage share the access rules apply to.
+
+## Attributes Reference
+
+* `share_acls` - List of access rules:
+  * `id` - Access rule ID.
+  * `access_to` - IP address or CIDR allowed to access the file storage share.
+  * `access_level` - Access level granted (`READ_WRITE`, `READ_ONLY`).
+  * `checksum` - Computed hash representing the current target specification value.
+  * `created_at` - Creation date of the access rule.
+  * `updated_at` - Last update date of the access rule.
+  * `resource_status` - Access rule readiness in the system (`CREATING`, `DELETING`, `ERROR`, `OUT_OF_SYNC`, `READY`, `UPDATING`).
+  * `current_state` - Current observed state of the access rule from the infrastructure:
+    * `access_to` - IP address or CIDR allowed to access the file storage share.
+    * `access_level` - Access level granted.
+    * `state` - Current state of the access rule (`ACTIVE`, `APPLYING`, `DENYING`, `ERROR`).
+    * `created_at` - Creation date of the access rule.

--- a/docs/data-sources/cloud_storage_file_share_network.md
+++ b/docs/data-sources/cloud_storage_file_share_network.md
@@ -1,5 +1,5 @@
 ---
-subcategory: "Cloud Storage"
+subcategory: "File Storage"
 ---
 
 # ovh_cloud_storage_file_share_network (Data Source)

--- a/docs/data-sources/cloud_storage_file_share_networks.md
+++ b/docs/data-sources/cloud_storage_file_share_networks.md
@@ -1,5 +1,5 @@
 ---
-subcategory: "Cloud Storage"
+subcategory: "File Storage"
 ---
 
 # ovh_cloud_storage_file_share_networks (Data Source)

--- a/docs/data-sources/cloud_storage_file_share_snapshot.md
+++ b/docs/data-sources/cloud_storage_file_share_snapshot.md
@@ -1,5 +1,5 @@
 ---
-subcategory: "Cloud Storage"
+subcategory: "File Storage"
 ---
 
 # ovh_cloud_storage_file_share_snapshot (Data Source)

--- a/docs/data-sources/cloud_storage_file_share_snapshots.md
+++ b/docs/data-sources/cloud_storage_file_share_snapshots.md
@@ -1,5 +1,5 @@
 ---
-subcategory: "Cloud Storage"
+subcategory: "File Storage"
 ---
 
 # ovh_cloud_storage_file_share_snapshots (Data Source)

--- a/docs/data-sources/cloud_storage_file_shares.md
+++ b/docs/data-sources/cloud_storage_file_shares.md
@@ -1,5 +1,5 @@
 ---
-subcategory: "Cloud Storage"
+subcategory: "File Storage"
 ---
 
 # ovh_cloud_storage_file_shares (Data Source)

--- a/docs/resources/cloud_storage_file_share.md
+++ b/docs/resources/cloud_storage_file_share.md
@@ -1,5 +1,5 @@
 ---
-subcategory : "Cloud Storage"
+subcategory : "File Storage"
 ---
 
 # ovh_cloud_storage_file_share

--- a/docs/resources/cloud_storage_file_share_acl.md
+++ b/docs/resources/cloud_storage_file_share_acl.md
@@ -1,5 +1,5 @@
 ---
-subcategory : "Cloud Storage"
+subcategory : "File Storage"
 ---
 
 # ovh_cloud_storage_file_share_acl

--- a/docs/resources/cloud_storage_file_share_network.md
+++ b/docs/resources/cloud_storage_file_share_network.md
@@ -1,5 +1,5 @@
 ---
-subcategory : "Cloud Storage"
+subcategory : "File Storage"
 ---
 
 # ovh_cloud_storage_file_share_network

--- a/docs/resources/cloud_storage_file_share_snapshot.md
+++ b/docs/resources/cloud_storage_file_share_snapshot.md
@@ -1,5 +1,5 @@
 ---
-subcategory : "Cloud Storage"
+subcategory : "File Storage"
 ---
 
 # ovh_cloud_storage_file_share_snapshot

--- a/ovh/data_cloud_storage_file_share_acl.go
+++ b/ovh/data_cloud_storage_file_share_acl.go
@@ -1,0 +1,207 @@
+package ovh
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	ovhtypes "github.com/ovh/terraform-provider-ovh/v2/ovh/types"
+)
+
+var _ datasource.DataSourceWithConfigure = (*cloudStorageFileShareAclDataSource)(nil)
+
+func NewCloudStorageFileShareAclDataSource() datasource.DataSource {
+	return &cloudStorageFileShareAclDataSource{}
+}
+
+type cloudStorageFileShareAclDataSource struct {
+	config *Config
+}
+
+func (d *cloudStorageFileShareAclDataSource) Metadata(ctx context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_cloud_storage_file_share_acl"
+}
+
+func (d *cloudStorageFileShareAclDataSource) Configure(_ context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+
+	config, ok := req.ProviderData.(*Config)
+	if !ok {
+		resp.Diagnostics.AddError(
+			"Unexpected Data Source Configure Type",
+			fmt.Sprintf("Expected *Config, got: %T. Please report this issue to the provider developers.", req.ProviderData),
+		)
+		return
+	}
+
+	d.config = config
+}
+
+// fileShareAclDataSourceAttributes returns the computed attributes describing a
+// file storage share access rule (ACL), shared between the singular and plural data sources.
+func fileShareAclDataSourceAttributes() map[string]schema.Attribute {
+	return map[string]schema.Attribute{
+		"id": schema.StringAttribute{
+			CustomType:  ovhtypes.TfStringType{},
+			Computed:    true,
+			Description: "Access rule ID",
+		},
+		"access_to": schema.StringAttribute{
+			CustomType:  ovhtypes.TfStringType{},
+			Computed:    true,
+			Description: "IP address or CIDR allowed to access the file storage share",
+		},
+		"access_level": schema.StringAttribute{
+			CustomType:  ovhtypes.TfStringType{},
+			Computed:    true,
+			Description: "Access level granted (READ_WRITE, READ_ONLY)",
+		},
+		"checksum": schema.StringAttribute{
+			CustomType:  ovhtypes.TfStringType{},
+			Computed:    true,
+			Description: "Computed hash representing the current target specification value",
+		},
+		"created_at": schema.StringAttribute{
+			CustomType:  ovhtypes.TfStringType{},
+			Computed:    true,
+			Description: "Creation date of the access rule",
+		},
+		"updated_at": schema.StringAttribute{
+			CustomType:  ovhtypes.TfStringType{},
+			Computed:    true,
+			Description: "Last update date of the access rule",
+		},
+		"resource_status": schema.StringAttribute{
+			CustomType:  ovhtypes.TfStringType{},
+			Computed:    true,
+			Description: "Access rule readiness in the system (CREATING, DELETING, ERROR, OUT_OF_SYNC, READY, UPDATING)",
+		},
+		"current_state": schema.SingleNestedAttribute{
+			Computed:    true,
+			Description: "Current observed state of the access rule from the infrastructure",
+			Attributes: map[string]schema.Attribute{
+				"access_to": schema.StringAttribute{
+					CustomType:  ovhtypes.TfStringType{},
+					Computed:    true,
+					Description: "IP address or CIDR allowed to access the file storage share",
+				},
+				"access_level": schema.StringAttribute{
+					CustomType:  ovhtypes.TfStringType{},
+					Computed:    true,
+					Description: "Access level granted",
+				},
+				"state": schema.StringAttribute{
+					CustomType:  ovhtypes.TfStringType{},
+					Computed:    true,
+					Description: "Current state of the access rule (ACTIVE, APPLYING, DENYING, ERROR)",
+				},
+				"created_at": schema.StringAttribute{
+					CustomType:  ovhtypes.TfStringType{},
+					Computed:    true,
+					Description: "Creation date of the access rule",
+				},
+			},
+		},
+	}
+}
+
+func (d *cloudStorageFileShareAclDataSource) Schema(ctx context.Context, req datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	attrs := map[string]schema.Attribute{
+		"service_name": schema.StringAttribute{
+			CustomType:          ovhtypes.TfStringType{},
+			Required:            true,
+			Description:         "Service name of the resource representing the id of the cloud project",
+			MarkdownDescription: "Service name of the resource representing the id of the cloud project",
+		},
+		"share_id": schema.StringAttribute{
+			CustomType:          ovhtypes.TfStringType{},
+			Required:            true,
+			Description:         "ID of the file storage share the access rule applies to",
+			MarkdownDescription: "ID of the file storage share the access rule applies to",
+		},
+		"id": schema.StringAttribute{
+			CustomType:          ovhtypes.TfStringType{},
+			Required:            true,
+			Description:         "Access rule ID",
+			MarkdownDescription: "Access rule ID",
+		},
+	}
+
+	for name, attribute := range fileShareAclDataSourceAttributes() {
+		if name == "id" {
+			continue
+		}
+		attrs[name] = attribute
+	}
+
+	resp.Schema = schema.Schema{
+		Description:         "Get an access rule (ACL) of a public cloud file storage share.",
+		MarkdownDescription: "Get an access rule (ACL) of a public cloud file storage share.",
+		Attributes:          attrs,
+	}
+}
+
+// cloudStorageFileShareAclDataSourceModel is the Terraform state model for this data source.
+type cloudStorageFileShareAclDataSourceModel struct {
+	ServiceName    ovhtypes.TfStringValue `tfsdk:"service_name"`
+	ShareId        ovhtypes.TfStringValue `tfsdk:"share_id"`
+	Id             ovhtypes.TfStringValue `tfsdk:"id"`
+	AccessTo       ovhtypes.TfStringValue `tfsdk:"access_to"`
+	AccessLevel    ovhtypes.TfStringValue `tfsdk:"access_level"`
+	Checksum       ovhtypes.TfStringValue `tfsdk:"checksum"`
+	CreatedAt      ovhtypes.TfStringValue `tfsdk:"created_at"`
+	UpdatedAt      ovhtypes.TfStringValue `tfsdk:"updated_at"`
+	ResourceStatus ovhtypes.TfStringValue `tfsdk:"resource_status"`
+	CurrentState   types.Object           `tfsdk:"current_state"`
+}
+
+func (d *cloudStorageFileShareAclDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+	var data cloudStorageFileShareAclDataSourceModel
+
+	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	endpoint := fileStorageAclBaseEndpoint(data.ServiceName.ValueString(), data.ShareId.ValueString()) +
+		"/" + url.PathEscape(data.Id.ValueString())
+
+	var v CloudStorageFileShareAclAPIResponse
+	if err := d.config.OVHClient.Get(endpoint, &v); err != nil {
+		resp.Diagnostics.AddError(
+			fmt.Sprintf("Error calling Get %s", endpoint),
+			err.Error(),
+		)
+		return
+	}
+
+	mapFileShareAclToDataSourceModel(&v, &data)
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+// mapFileShareAclToDataSourceModel populates the data source model from the API response.
+// ServiceName and ShareId come from the configuration and are never touched here.
+func mapFileShareAclToDataSourceModel(v *CloudStorageFileShareAclAPIResponse, data *cloudStorageFileShareAclDataSourceModel) {
+	data.Id = ovhtypes.TfStringValue{StringValue: types.StringValue(v.Id)}
+	data.Checksum = ovhtypes.TfStringValue{StringValue: types.StringValue(v.Checksum)}
+	data.CreatedAt = ovhtypes.TfStringValue{StringValue: types.StringValue(v.CreatedAt)}
+	data.UpdatedAt = ovhtypes.TfStringValue{StringValue: types.StringValue(v.UpdatedAt)}
+	data.ResourceStatus = ovhtypes.TfStringValue{StringValue: types.StringValue(v.ResourceStatus)}
+
+	if v.TargetSpec != nil {
+		data.AccessTo = ovhtypes.TfStringValue{StringValue: types.StringValue(v.TargetSpec.AccessTo)}
+		data.AccessLevel = ovhtypes.TfStringValue{StringValue: types.StringValue(v.TargetSpec.AccessLevel)}
+	}
+
+	if v.CurrentState != nil {
+		data.CurrentState = buildStorageFileShareAclCurrentStateObject(v.CurrentState)
+	} else {
+		data.CurrentState = types.ObjectNull(StorageFileShareAclCurrentStateAttrTypes())
+	}
+}

--- a/ovh/data_cloud_storage_file_share_acl_test.go
+++ b/ovh/data_cloud_storage_file_share_acl_test.go
@@ -1,0 +1,64 @@
+package ovh
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+func TestAccDataSourceCloudStorageFileShareAcl_basic(t *testing.T) {
+	serviceName := os.Getenv("OVH_CLOUD_PROJECT_SERVICE_TEST")
+	region := os.Getenv("OVH_CLOUD_PROJECT_REGION_TEST")
+
+	vrackNetName := acctest.RandomWithPrefix(testAccResourceCloudStorageFileShareVrackSubnetNamePrefix)
+	vrackSubnetName := acctest.RandomWithPrefix(testAccResourceCloudStorageFileShareVrackSubnetNamePrefix)
+	networkName := acctest.RandomWithPrefix(testAccResourceCloudStorageFileShareNetworkNamePrefix)
+	shareName := acctest.RandomWithPrefix(testAccResourceCloudStorageFileShareNamePrefix)
+
+	config := testAccCloudStorageFileShareAclShareConfig(serviceName, region, vrackNetName, vrackSubnetName, networkName, shareName) + fmt.Sprintf(`
+resource "ovh_cloud_storage_file_share_acl" "acl" {
+  service_name = "%s"
+  share_id     = ovh_cloud_storage_file_share.share.id
+  access_to    = "10.0.0.0/24"
+  access_level = "READ_ONLY"
+}
+
+data "ovh_cloud_storage_file_share_acl" "acl" {
+  service_name = "%s"
+  share_id     = ovh_cloud_storage_file_share.share.id
+  id           = ovh_cloud_storage_file_share_acl.acl.id
+
+  depends_on = [ovh_cloud_storage_file_share_acl.acl]
+}
+`, serviceName, serviceName)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheckCloud(t)
+			testAccCheckCloudProjectExists(t)
+			testAccPreCheckVRack(t)
+		},
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("data.ovh_cloud_storage_file_share_acl.acl", "service_name", serviceName),
+					resource.TestCheckResourceAttrPair(
+						"data.ovh_cloud_storage_file_share_acl.acl", "id",
+						"ovh_cloud_storage_file_share_acl.acl", "id",
+					),
+					resource.TestCheckResourceAttr("data.ovh_cloud_storage_file_share_acl.acl", "access_to", "10.0.0.0/24"),
+					resource.TestCheckResourceAttr("data.ovh_cloud_storage_file_share_acl.acl", "access_level", "READ_ONLY"),
+					resource.TestCheckResourceAttrSet("data.ovh_cloud_storage_file_share_acl.acl", "id"),
+					resource.TestCheckResourceAttrSet("data.ovh_cloud_storage_file_share_acl.acl", "checksum"),
+					resource.TestCheckResourceAttrSet("data.ovh_cloud_storage_file_share_acl.acl", "resource_status"),
+					resource.TestCheckResourceAttrSet("data.ovh_cloud_storage_file_share_acl.acl", "current_state.state"),
+				),
+			},
+		},
+	})
+}

--- a/ovh/data_cloud_storage_file_share_acls.go
+++ b/ovh/data_cloud_storage_file_share_acls.go
@@ -1,0 +1,154 @@
+package ovh
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	ovhtypes "github.com/ovh/terraform-provider-ovh/v2/ovh/types"
+)
+
+var _ datasource.DataSourceWithConfigure = (*cloudStorageFileShareAclsDataSource)(nil)
+
+func NewCloudStorageFileShareAclsDataSource() datasource.DataSource {
+	return &cloudStorageFileShareAclsDataSource{}
+}
+
+type cloudStorageFileShareAclsDataSource struct {
+	config *Config
+}
+
+func (d *cloudStorageFileShareAclsDataSource) Metadata(ctx context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_cloud_storage_file_share_acls"
+}
+
+func (d *cloudStorageFileShareAclsDataSource) Configure(_ context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+
+	config, ok := req.ProviderData.(*Config)
+	if !ok {
+		resp.Diagnostics.AddError(
+			"Unexpected Data Source Configure Type",
+			fmt.Sprintf("Expected *Config, got: %T. Please report this issue to the provider developers.", req.ProviderData),
+		)
+		return
+	}
+
+	d.config = config
+}
+
+func (d *cloudStorageFileShareAclsDataSource) Schema(ctx context.Context, req datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Description:         "List the access rules (ACLs) of a public cloud file storage share.",
+		MarkdownDescription: "List the access rules (ACLs) of a public cloud file storage share.",
+		Attributes: map[string]schema.Attribute{
+			"service_name": schema.StringAttribute{
+				CustomType:          ovhtypes.TfStringType{},
+				Required:            true,
+				Description:         "Service name of the resource representing the id of the cloud project",
+				MarkdownDescription: "Service name of the resource representing the id of the cloud project",
+			},
+			"share_id": schema.StringAttribute{
+				CustomType:          ovhtypes.TfStringType{},
+				Required:            true,
+				Description:         "ID of the file storage share the access rules apply to",
+				MarkdownDescription: "ID of the file storage share the access rules apply to",
+			},
+			"share_acls": schema.ListNestedAttribute{
+				Computed:            true,
+				Description:         "List of access rules of the file storage share",
+				MarkdownDescription: "List of access rules of the file storage share",
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: fileShareAclDataSourceAttributes(),
+				},
+			},
+		},
+	}
+}
+
+// cloudStorageFileShareAclsDataSourceModel is the Terraform state model for this data source.
+type cloudStorageFileShareAclsDataSourceModel struct {
+	ServiceName ovhtypes.TfStringValue `tfsdk:"service_name"`
+	ShareId     ovhtypes.TfStringValue `tfsdk:"share_id"`
+	ShareAcls   types.List             `tfsdk:"share_acls"`
+}
+
+// fileShareAclListItemAttrTypes returns the attribute types for a single access rule item in the list.
+func fileShareAclListItemAttrTypes() map[string]attr.Type {
+	return map[string]attr.Type{
+		"id":              ovhtypes.TfStringType{},
+		"access_to":       ovhtypes.TfStringType{},
+		"access_level":    ovhtypes.TfStringType{},
+		"checksum":        ovhtypes.TfStringType{},
+		"created_at":      ovhtypes.TfStringType{},
+		"updated_at":      ovhtypes.TfStringType{},
+		"resource_status": ovhtypes.TfStringType{},
+		"current_state":   types.ObjectType{AttrTypes: StorageFileShareAclCurrentStateAttrTypes()},
+	}
+}
+
+func (d *cloudStorageFileShareAclsDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+	var data cloudStorageFileShareAclsDataSourceModel
+
+	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	endpoint := fileStorageAclBaseEndpoint(data.ServiceName.ValueString(), data.ShareId.ValueString())
+
+	var apiAcls []CloudStorageFileShareAclAPIResponse
+	if err := d.config.OVHClient.Get(endpoint, &apiAcls); err != nil {
+		resp.Diagnostics.AddError(
+			fmt.Sprintf("Error calling Get %s", endpoint),
+			err.Error(),
+		)
+		return
+	}
+
+	aclObjs := make([]attr.Value, 0, len(apiAcls))
+	for i := range apiAcls {
+		v := apiAcls[i]
+
+		var item cloudStorageFileShareAclDataSourceModel
+		mapFileShareAclToDataSourceModel(&v, &item)
+
+		obj, diags := types.ObjectValue(
+			fileShareAclListItemAttrTypes(),
+			map[string]attr.Value{
+				"id":              item.Id,
+				"access_to":       item.AccessTo,
+				"access_level":    item.AccessLevel,
+				"checksum":        item.Checksum,
+				"created_at":      item.CreatedAt,
+				"updated_at":      item.UpdatedAt,
+				"resource_status": item.ResourceStatus,
+				"current_state":   item.CurrentState,
+			},
+		)
+		resp.Diagnostics.Append(diags...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+
+		aclObjs = append(aclObjs, obj)
+	}
+
+	aclsList, diags := types.ListValue(
+		types.ObjectType{AttrTypes: fileShareAclListItemAttrTypes()},
+		aclObjs,
+	)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	data.ShareAcls = aclsList
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}

--- a/ovh/data_cloud_storage_file_share_acls_test.go
+++ b/ovh/data_cloud_storage_file_share_acls_test.go
@@ -1,0 +1,62 @@
+package ovh
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+func TestAccDataSourceCloudStorageFileShareAcls_basic(t *testing.T) {
+	serviceName := os.Getenv("OVH_CLOUD_PROJECT_SERVICE_TEST")
+	region := os.Getenv("OVH_CLOUD_PROJECT_REGION_TEST")
+
+	vrackNetName := acctest.RandomWithPrefix(testAccResourceCloudStorageFileShareVrackSubnetNamePrefix)
+	vrackSubnetName := acctest.RandomWithPrefix(testAccResourceCloudStorageFileShareVrackSubnetNamePrefix)
+	networkName := acctest.RandomWithPrefix(testAccResourceCloudStorageFileShareNetworkNamePrefix)
+	shareName := acctest.RandomWithPrefix(testAccResourceCloudStorageFileShareNamePrefix)
+
+	config := testAccCloudStorageFileShareAclShareConfig(serviceName, region, vrackNetName, vrackSubnetName, networkName, shareName) + fmt.Sprintf(`
+resource "ovh_cloud_storage_file_share_acl" "acl" {
+  service_name = "%s"
+  share_id     = ovh_cloud_storage_file_share.share.id
+  access_to    = "10.0.0.0/24"
+  access_level = "READ_ONLY"
+}
+
+data "ovh_cloud_storage_file_share_acls" "acls" {
+  service_name = "%s"
+  share_id     = ovh_cloud_storage_file_share.share.id
+
+  depends_on = [ovh_cloud_storage_file_share_acl.acl]
+}
+`, serviceName, serviceName)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheckCloud(t)
+			testAccCheckCloudProjectExists(t)
+			testAccPreCheckVRack(t)
+		},
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("data.ovh_cloud_storage_file_share_acls.acls", "service_name", serviceName),
+					resource.TestCheckResourceAttrPair(
+						"data.ovh_cloud_storage_file_share_acls.acls", "share_id",
+						"ovh_cloud_storage_file_share_acl.acl", "share_id",
+					),
+					resource.TestCheckResourceAttrSet("data.ovh_cloud_storage_file_share_acls.acls", "share_acls.0.id"),
+					resource.TestCheckResourceAttrSet("data.ovh_cloud_storage_file_share_acls.acls", "share_acls.0.access_to"),
+					resource.TestCheckResourceAttrSet("data.ovh_cloud_storage_file_share_acls.acls", "share_acls.0.access_level"),
+					resource.TestCheckResourceAttrSet("data.ovh_cloud_storage_file_share_acls.acls", "share_acls.0.checksum"),
+					resource.TestCheckResourceAttrSet("data.ovh_cloud_storage_file_share_acls.acls", "share_acls.0.resource_status"),
+				),
+			},
+		},
+	})
+}

--- a/ovh/provider_new.go
+++ b/ovh/provider_new.go
@@ -317,6 +317,8 @@ func (p *OvhProvider) DataSources(_ context.Context) []func() datasource.DataSou
 		NewCloudStorageFileShareNetworksDataSource,
 		NewCloudStorageFileShareSnapshotDataSource,
 		NewCloudStorageFileShareSnapshotsDataSource,
+		NewCloudStorageFileShareAclDataSource,
+		NewCloudStorageFileShareAclsDataSource,
 		NewCloudRegionDataSource,
 		NewCloudRegionsDataSource,
 		NewOvhcloudConnectDatacentersDataSource,


### PR DESCRIPTION
# Description

- Add `ovh_cloud_storage_file_share_acl` and `ovh_cloud_storage_file_share_acls` datasources
- Fix the documentation catagories for File Storage resources and datasources

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] Documentation update

# How Has This Been Tested?

```
$ make testacc TESTARGS="-run 'DataSourceCloudStorageFileShareAcl'"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -run 'DataSourceCloudStorageFileShareAcl' -timeout 600m -p 10
?   	github.com/ovh/terraform-provider-ovh/v2	[no test files]
=== RUN   TestAccDataSourceCloudStorageFileShareAcl_basic
--- PASS: TestAccDataSourceCloudStorageFileShareAcl_basic (307.43s)
=== RUN   TestAccDataSourceCloudStorageFileShareAcls_basic
--- PASS: TestAccDataSourceCloudStorageFileShareAcls_basic (253.52s)
PASS
ok
```

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or issues
- [x] I have added acceptance tests that prove my fix is effective or that my feature works
- [x] New and existing acceptance tests pass locally with my changes
- [x] I ran successfully `go mod vendor` if I added or modify `go.mod` file 