### PR TITLE
fix(ip_firewall_rule): omit tcpOption for non-TCP rules

### DIFF
--- a/ovh/resource_ip_firewall_rule_gen.go
+++ b/ovh/resource_ip_firewall_rule_gen.go
@@ -413,7 +413,7 @@ func (v IpFirewallRuleModel) ToCreate() *IpFirewallRuleWritableModel {
 		res.SourcePort = &v.SourcePort
 	}
 
-	if !v.TcpOption.IsUnknown() || !v.Fragments.IsUnknown() {
+	if v.Protocol.ValueString() == "tcp" && (!v.TcpOption.IsUnknown() || !v.Fragments.IsUnknown()) {
 		option := TcpOptionWritableValue{}
 
 		if !v.TcpOption.IsUnknown() {

--- a/ovh/resource_ip_firewall_rule_model_test.go
+++ b/ovh/resource_ip_firewall_rule_model_test.go
@@ -1,0 +1,70 @@
+package ovh
+
+import (
+	"encoding/json"
+	"testing"
+
+	ovhtypes "github.com/ovh/terraform-provider-ovh/v2/ovh/types"
+)
+
+func TestIpFirewallRuleModelToCreateTcpOptionByProtocol(t *testing.T) {
+	testCases := []struct {
+		name          string
+		protocol      string
+		tcpOption     string
+		wantTcpOption bool
+	}{
+		{
+			name:          "udp omits tcpOption when computed fields are populated",
+			protocol:      "udp",
+			tcpOption:     "established",
+			wantTcpOption: false,
+		},
+		{
+			name:          "icmp omits tcpOption when computed fields are populated",
+			protocol:      "icmp",
+			tcpOption:     "established",
+			wantTcpOption: false,
+		},
+		{
+			name:          "tcp preserves established tcpOption and fragments",
+			protocol:      "tcp",
+			tcpOption:     "established",
+			wantTcpOption: true,
+		},
+		{
+			name:          "tcp preserves syn tcpOption and fragments",
+			protocol:      "tcp",
+			tcpOption:     "syn",
+			wantTcpOption: true,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			model := IpFirewallRuleModel{
+				Protocol:  ovhtypes.NewTfStringValue(testCase.protocol),
+				TcpOption: ovhtypes.NewTfStringValue(testCase.tcpOption),
+				Fragments: ovhtypes.NewTfBoolValue(false),
+			}
+
+			payload, err := json.Marshal(model.ToCreate())
+			if err != nil {
+				t.Fatalf("marshal create payload: %v", err)
+			}
+
+			var fields map[string]json.RawMessage
+			if err := json.Unmarshal(payload, &fields); err != nil {
+				t.Fatalf("unmarshal create payload: %v", err)
+			}
+
+			_, hasTcpOption := fields["tcpOption"]
+			if hasTcpOption != testCase.wantTcpOption {
+				t.Errorf("tcpOption present = %t, want %t; payload: %s", hasTcpOption, testCase.wantTcpOption, payload)
+			}
+			if testCase.wantTcpOption && string(fields["tcpOption"]) != `{"fragments":false,"option":"`+testCase.tcpOption+`"}` {
+				t.Errorf("unexpected tcpOption payload: %s", fields["tcpOption"])
+			}
+		})
+	}
+}


### PR DESCRIPTION
# Description

tcpOption is valid only for TCP firewall rules. The provider previously serialized it for non-TCP rules when optional/computed fields were populated, causing the OVH API to reject valid UDP or ICMP rules with `Invalid usage of TcpOption - only for tcp`.

This change serializes tcpOption only when the requested protocol is `tcp`, while preserving the existing TCP behavior.

No additional dependencies are required.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (improve existing resource(s) or datasource(s))
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

# How Has This Been Tested?

- [x] Unit test: `go test ./ovh -run TestIpFirewallRuleModelToCreateTcpOptionByProtocol -count=1`
- [x] Static analysis: `go vet ./ovh`

The unit test serializes the real create payload and verifies that `tcpOption` is omitted for UDP and ICMP, while TCP retains both `established` and `syn` options with `fragments`.

Acceptance tests were not run because they require OVH credentials; the unfiltered package test invokes an existing acceptance test that fails without authentication.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or issues
- [ ] I have added acceptance tests that prove my fix is effective or that my feature works
- [ ] New and existing acceptance tests pass locally with my changes
- [x] I ran successfully `go mod vendor` if I added or modify `go.mod` file