### PR TITLE
feat(vps): support 2027v1 plan type

### DIFF
--- a/ovh/resource_vps_gen.go
+++ b/ovh/resource_vps_gen.go
@@ -167,6 +167,7 @@ func VpsResourceSchema(ctx context.Context) schema.Schema {
 							"2018v2",
 							"2019v1",
 							"2025v1",
+							"2027v1",
 						),
 					},
 				},

--- a/ovh/resource_vps_test.go
+++ b/ovh/resource_vps_test.go
@@ -1,13 +1,64 @@
 package ovh
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"testing"
 
+	resourceschema "github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 )
+
+func TestVpsResourceSchemaModelVersionValidation(t *testing.T) {
+	ctx := context.Background()
+	schema := VpsResourceSchema(ctx)
+	model := schema.Attributes["model"].(resourceschema.SingleNestedAttribute)
+	version := model.Attributes["version"].(resourceschema.StringAttribute)
+	versionValidator := version.Validators[0]
+	expectedDescription := `value must be one of: ["2013v1" "2014v1" "2015v1" "2017v1" "2017v2" "2017v3" "2018v1" "2018v2" "2019v1" "2025v1" "2027v1"]`
+
+	if got := versionValidator.Description(ctx); got != expectedDescription {
+		t.Fatalf("expected plan type validator description %q, got %q", expectedDescription, got)
+	}
+
+	for _, planType := range []string{
+		"2013v1",
+		"2014v1",
+		"2015v1",
+		"2017v1",
+		"2017v2",
+		"2017v3",
+		"2018v1",
+		"2018v2",
+		"2019v1",
+		"2025v1",
+		"2027v1",
+	} {
+		t.Run(planType, func(t *testing.T) {
+			var response validator.StringResponse
+
+			versionValidator.ValidateString(ctx, validator.StringRequest{
+				ConfigValue: types.StringValue(planType),
+			}, &response)
+
+			if response.Diagnostics.HasError() {
+				t.Fatalf("expected plan type %q to be accepted, got diagnostics: %#v", planType, response.Diagnostics)
+			}
+		})
+	}
+
+	var response validator.StringResponse
+	versionValidator.ValidateString(ctx, validator.StringRequest{
+		ConfigValue: types.StringValue("unsupported-vps-plan"),
+	}, &response)
+	if !response.Diagnostics.HasError() {
+		t.Fatal("expected an unsupported plan type to be rejected")
+	}
+}
 
 const testAccVpsBasic = `
 data "ovh_me" "myaccount" {}


### PR DESCRIPTION
# Description

OVH VPS catalog entries now expose plans using the `2027v1` plan type. The `ovh_vps` resource currently rejects this value during local schema validation, before an OVH API request can be made.

This change adds `2027v1` to the accepted VPS plan types and includes validation coverage. It does not change ordering behavior or alter existing plan types.

No related issue or additional dependency.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (improve existing resource(s) or datasource(s))
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

# How Has This Been Tested?

- [x] `go test ./ovh -run '^TestVpsResourceSchemaModelVersionValidation$' -count=1 -v`
- [x] `go vet ./ovh`

**Test Configuration**:
- Terraform version: not applicable; the test invokes the local resource schema validation directly.
- Existing HCL configuration: not applicable; no OVH API request or account configuration is required.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (not applicable; the resource documentation does not enumerate this validation set)
- [x] My changes generate no new warnings or issues
- [ ] I have added acceptance tests that prove my fix is effective or that my feature works (not applicable; this change is covered by a unit test of local schema validation and must not require an OVH account)
- [x] New and existing relevant tests pass locally with my changes
- [x] I ran successfully `go mod vendor` if I added or modified `go.mod` (not applicable; `go.mod` was not changed)