### PR TITLE
feat(issues): fixed issues 1385

### DIFF
--- a/docs/resources/cloud_project_storage.md
+++ b/docs/resources/cloud_project_storage.md
@@ -149,7 +149,7 @@ Required:
 
 Optional:
 
-- `storage_class` (String) Destination storage class
+- `storage_class` (String) Destination storage class. Accepted values: `DEEP_ARCHIVE`, `GLACIER`, `GLACIER_IR`, `HIGH_PERF`, `INTELLIGENT_TIERING`, `ONEZONE_IA`, `STANDARD`, `STANDARD_IA`.
 - `remove_on_main_bucket_deletion` (Boolean) Whether to remove replicated bucket when the main bucket is deleted (make sure to apply your configuration when changing this value before deleting the main bucket)
 
 <a id="nestedatt--replication--rules--filter"></a>

--- a/docs/resources/cloud_project_storage_object_bucket_lifecycle_configuration.md
+++ b/docs/resources/cloud_project_storage_object_bucket_lifecycle_configuration.md
@@ -225,7 +225,7 @@ Optional:
 
 - `noncurrent_days` (Number) Number of days after an object becomes noncurrent before it is transitioned.
 - `newer_noncurrent_versions` (Number) Number of noncurrent versions to retain in the same storage class before transitioning.
-- `storage_class` (String) The storage class to transition noncurrent objects to.
+- `storage_class` (String) The storage class to transition noncurrent objects to. Accepted values: `STANDARD`, `STANDARD_IA`, `GLACIER_IR`, `DEEP_ARCHIVE`.
 
 ## Import
 

--- a/ovh/resource_cloud_project_storage_gen.go
+++ b/ovh/resource_cloud_project_storage_gen.go
@@ -229,7 +229,12 @@ func CloudProjectRegionStorageResourceSchema(ctx context.Context) schema.Schema 
 										MarkdownDescription: "Destination storage class",
 										Validators: []validator.String{
 											stringvalidator.OneOf(
+												"DEEP_ARCHIVE",
+												"GLACIER",
+												"GLACIER_IR",
 												"HIGH_PERF",
+												"INTELLIGENT_TIERING",
+												"ONEZONE_IA",
 												"STANDARD",
 												"STANDARD_IA",
 											),

--- a/ovh/resource_cloud_project_storage_object_bucket_lifecycle_configuration_gen.go
+++ b/ovh/resource_cloud_project_storage_object_bucket_lifecycle_configuration_gen.go
@@ -214,6 +214,8 @@ func CloudProjectStorageLifecycleConfigurationResourceSchema(ctx context.Context
 										MarkdownDescription: "The storage class to which you want the object to transition.",
 										Validators: []validator.String{
 											stringvalidator.OneOf(
+												"DEEP_ARCHIVE",
+												"GLACIER_IR",
 												"STANDARD",
 												"STANDARD_IA",
 											),

--- a/ovh/resource_cloud_project_storage_object_bucket_lifecycle_configuration_storageclass_test.go
+++ b/ovh/resource_cloud_project_storage_object_bucket_lifecycle_configuration_storageclass_test.go
@@ -1,0 +1,120 @@
+package ovh
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+// runStorageClassValidators runs every validator declared on a StringAttribute
+// against the given value and returns whether any error diagnostic was raised.
+func runStorageClassValidators(t *testing.T, attr schema.StringAttribute, value string) bool {
+	t.Helper()
+
+	req := validator.StringRequest{
+		ConfigValue: types.StringValue(value),
+	}
+
+	for _, v := range attr.Validators {
+		resp := &validator.StringResponse{}
+		v.ValidateString(context.Background(), req, resp)
+		if resp.Diagnostics.HasError() {
+			return true
+		}
+	}
+
+	return false
+}
+
+func mustStringAttribute(t *testing.T, attr schema.Attribute, name string) schema.StringAttribute {
+	t.Helper()
+	sa, ok := attr.(schema.StringAttribute)
+	if !ok {
+		t.Fatalf("attribute %q is not a StringAttribute (got %T)", name, attr)
+	}
+	return sa
+}
+
+func mustListNested(t *testing.T, attr schema.Attribute, name string) schema.ListNestedAttribute {
+	t.Helper()
+	la, ok := attr.(schema.ListNestedAttribute)
+	if !ok {
+		t.Fatalf("attribute %q is not a ListNestedAttribute (got %T)", name, attr)
+	}
+	return la
+}
+
+func mustSingleNested(t *testing.T, attr schema.Attribute, name string) schema.SingleNestedAttribute {
+	t.Helper()
+	sa, ok := attr.(schema.SingleNestedAttribute)
+	if !ok {
+		t.Fatalf("attribute %q is not a SingleNestedAttribute (got %T)", name, attr)
+	}
+	return sa
+}
+
+// TestStorageClassLifecycleTransitionValidator asserts that the lifecycle
+// transition storage_class validator accepts the full StorageClassLifecycleEnum
+// (regression test for issue #1385) and still rejects garbage.
+func TestStorageClassLifecycleTransitionValidator(t *testing.T) {
+	ctx := context.Background()
+
+	r := NewCloudProjectStorageLifecycleConfigurationResource()
+	resp := &resource.SchemaResponse{}
+	r.Schema(ctx, resource.SchemaRequest{}, resp)
+
+	rules := mustListNested(t, resp.Schema.Attributes["rules"], "rules")
+	transitions := mustListNested(t, rules.NestedObject.Attributes["transitions"], "transitions")
+	storageClass := mustStringAttribute(t, transitions.NestedObject.Attributes["storage_class"], "storage_class")
+
+	accepted := []string{"DEEP_ARCHIVE", "GLACIER_IR", "STANDARD", "STANDARD_IA"}
+	for _, value := range accepted {
+		if runStorageClassValidators(t, storageClass, value) {
+			t.Errorf("lifecycle transition storage_class rejected %q but it should be accepted", value)
+		}
+	}
+
+	if !runStorageClassValidators(t, storageClass, "NOPE") {
+		t.Errorf("lifecycle transition storage_class accepted bogus value %q but it should be rejected", "NOPE")
+	}
+}
+
+// TestStorageClassReplicationDestinationValidator asserts that the replication
+// destination storage_class validator accepts the full StorageClassReplicationEnum
+// (related drift from issue #1385) and still rejects garbage.
+func TestStorageClassReplicationDestinationValidator(t *testing.T) {
+	ctx := context.Background()
+
+	r := NewCloudProjectStorageResource()
+	resp := &resource.SchemaResponse{}
+	r.Schema(ctx, resource.SchemaRequest{}, resp)
+
+	replication := mustSingleNested(t, resp.Schema.Attributes["replication"], "replication")
+	rules := mustListNested(t, replication.Attributes["rules"], "rules")
+	destination := mustSingleNested(t, rules.NestedObject.Attributes["destination"], "destination")
+	storageClass := mustStringAttribute(t, destination.Attributes["storage_class"], "storage_class")
+
+	accepted := []string{
+		"DEEP_ARCHIVE",
+		"GLACIER",
+		"GLACIER_IR",
+		"HIGH_PERF",
+		"INTELLIGENT_TIERING",
+		"ONEZONE_IA",
+		"STANDARD",
+		"STANDARD_IA",
+	}
+	for _, value := range accepted {
+		if runStorageClassValidators(t, storageClass, value) {
+			t.Errorf("replication destination storage_class rejected %q but it should be accepted", value)
+		}
+	}
+
+	if !runStorageClassValidators(t, storageClass, "NOPE") {
+		t.Errorf("replication destination storage_class accepted bogus value %q but it should be rejected", "NOPE")
+	}
+}

--- a/templates/resources/cloud_project_storage.md.tmpl
+++ b/templates/resources/cloud_project_storage.md.tmpl
@@ -109,7 +109,7 @@ Required:
 
 Optional:
 
-- `storage_class` (String) Destination storage class
+- `storage_class` (String) Destination storage class. Accepted values: `DEEP_ARCHIVE`, `GLACIER`, `GLACIER_IR`, `HIGH_PERF`, `INTELLIGENT_TIERING`, `ONEZONE_IA`, `STANDARD`, `STANDARD_IA`.
 - `remove_on_main_bucket_deletion` (Boolean) Whether to remove replicated bucket when the main bucket is deleted (make sure to apply your configuration when changing this value before deleting the main bucket)
 
 <a id="nestedatt--replication--rules--filter"></a>


### PR DESCRIPTION
# Description

The storage_class validators were stricter than the API schema and rejected valid values.

Lifecycle transitions: now accept DEEP_ARCHIVE and GLACIER_IR (full StorageClassLifecycleEnum)

Fixes #1385

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (improve existing resource(s) or datasource(s))
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

# How Has This Been Tested?

Test Configuration:

Terraform version: Terraform v1.9.8
Existing HCL configuration you used:

resource "ovh_cloud_project_storage" "bucket" {
  service_name = var.service_name
  region_name  = "GRA"
  name         = "tf-test-1385-deeparchive"
}

resource "ovh_cloud_project_storage_object_bucket_lifecycle_configuration" "lifecycle" {
  service_name   = ovh_cloud_project_storage.bucket.service_name
  region_name    = ovh_cloud_project_storage.bucket.region_name
  container_name = ovh_cloud_project_storage.bucket.name

  rules = [
    {
      id     = "deep-archive-transition"
      status = "enabled"
      transitions = [
        {
          days          = 30
          storage_class = "DEEP_ARCHIVE"
        }
      ]
    }
  ]
}

# Checklist:

- [X] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings or issues
- [ ] I have added acceptance tests that prove my fix is effective or that my feature works
- [X] New and existing acceptance tests pass locally with my changes
- [X] I ran successfully `go mod vendor` if I added or modify `go.mod` file
