### PR TITLE
fix(cloud): keep service_name from state when omitted (Optional+Computed)

### DIFF
--- a/ovh/resource_cloud_project_alerting_gen.go
+++ b/ovh/resource_cloud_project_alerting_gen.go
@@ -94,6 +94,7 @@ func CloudProjectAlertingResourceSchema(ctx context.Context) schema.Schema {
 			"service_name": schema.StringAttribute{
 				CustomType: ovhtypes.TfStringType{},
 				Optional:   true,
+				Computed:   true,
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.RequiresReplace(),
 				},

--- a/ovh/resource_cloud_project_gateway_interface_gen.go
+++ b/ovh/resource_cloud_project_gateway_interface_gen.go
@@ -48,6 +48,7 @@ func CloudProjectGatewayInterfaceResourceSchema(ctx context.Context) schema.Sche
 		"service_name": schema.StringAttribute{
 			CustomType: ovhtypes.TfStringType{},
 			Optional:   true,
+			Computed:   true,
 			PlanModifiers: []planmodifier.String{
 				stringplanmodifier.RequiresReplace(),
 			},

--- a/ovh/resource_cloud_project_instance_snapshot_gen.go
+++ b/ovh/resource_cloud_project_instance_snapshot_gen.go
@@ -77,6 +77,7 @@ func CloudProjectInstanceSnapshotResourceSchema(ctx context.Context) schema.Sche
 		"service_name": schema.StringAttribute{
 			CustomType:          ovhtypes.TfStringType{},
 			Optional:            true,
+			Computed:            true,
 			Description:         "Service name. If omitted, the `OVH_CLOUD_PROJECT_SERVICE` environment variable is used.",
 			MarkdownDescription: "Service name. If omitted, the `OVH_CLOUD_PROJECT_SERVICE` environment variable is used.",
 			PlanModifiers: []planmodifier.String{

--- a/ovh/resource_cloud_project_loadbalancer_gen.go
+++ b/ovh/resource_cloud_project_loadbalancer_gen.go
@@ -731,6 +731,7 @@ func CloudProjectLoadbalancerResourceSchema(ctx context.Context) schema.Schema {
 		"service_name": schema.StringAttribute{
 			CustomType:          ovhtypes.TfStringType{},
 			Optional:            true,
+			Computed:            true,
 			Description:         "Service name. If omitted, the `OVH_CLOUD_PROJECT_SERVICE` environment variable is used.",
 			MarkdownDescription: "Service name. If omitted, the `OVH_CLOUD_PROJECT_SERVICE` environment variable is used.",
 			PlanModifiers: []planmodifier.String{

--- a/ovh/resource_cloud_project_region_gen.go
+++ b/ovh/resource_cloud_project_region_gen.go
@@ -81,6 +81,7 @@ func CloudProjectRegionResourceSchema(ctx context.Context) schema.Schema {
 		"service_name": schema.StringAttribute{
 			CustomType:          ovhtypes.TfStringType{},
 			Optional:            true,
+			Computed:            true,
 			Description:         "Service name. If omitted, the `OVH_CLOUD_PROJECT_SERVICE` environment variable is used.",
 			MarkdownDescription: "Service name. If omitted, the `OVH_CLOUD_PROJECT_SERVICE` environment variable is used.",
 			PlanModifiers: []planmodifier.String{

--- a/ovh/resource_cloud_project_region_network_gen.go
+++ b/ovh/resource_cloud_project_region_network_gen.go
@@ -59,6 +59,7 @@ func CloudProjectRegionNetworkResourceSchema(ctx context.Context) schema.Schema 
 		"service_name": schema.StringAttribute{
 			CustomType: ovhtypes.TfStringType{},
 			Optional:   true,
+			Computed:   true,
 			PlanModifiers: []planmodifier.String{
 				stringplanmodifier.RequiresReplace(),
 			},

--- a/ovh/resource_cloud_project_ssh_key_gen.go
+++ b/ovh/resource_cloud_project_ssh_key_gen.go
@@ -64,6 +64,7 @@ func CloudProjectSshKeyResourceSchema(ctx context.Context) schema.Schema {
 		"service_name": schema.StringAttribute{
 			CustomType: ovhtypes.TfStringType{},
 			Optional:   true,
+			Computed:   true,
 			PlanModifiers: []planmodifier.String{
 				stringplanmodifier.RequiresReplace(),
 			},

--- a/ovh/resource_cloud_project_storage_gen.go
+++ b/ovh/resource_cloud_project_storage_gen.go
@@ -337,6 +337,7 @@ func CloudProjectRegionStorageResourceSchema(ctx context.Context) schema.Schema 
 		"service_name": schema.StringAttribute{
 			CustomType:          ovhtypes.TfStringType{},
 			Optional:            true,
+			Computed:            true,
 			Description:         "Service name. If omitted, the `OVH_CLOUD_PROJECT_SERVICE` environment variable is used.",
 			MarkdownDescription: "Service name. If omitted, the `OVH_CLOUD_PROJECT_SERVICE` environment variable is used.",
 		},

--- a/ovh/resource_cloud_project_storage_replication_job.go
+++ b/ovh/resource_cloud_project_storage_replication_job.go
@@ -125,6 +125,7 @@ func CloudProjectStorageReplicationJobResourceSchema(ctx context.Context) schema
 			"service_name": schema.StringAttribute{
 				CustomType:          ovhtypes.TfStringType{},
 				Optional:            true,
+				Computed:            true,
 				Description:         "The ID of the public cloud project. If omitted, the `OVH_CLOUD_PROJECT_SERVICE` environment variable is used.",
 				MarkdownDescription: "The ID of the public cloud project. If omitted, the `OVH_CLOUD_PROJECT_SERVICE` environment variable is used.",
 				PlanModifiers: []planmodifier.String{

--- a/ovh/resource_cloud_project_volume_backup_gen.go
+++ b/ovh/resource_cloud_project_volume_backup_gen.go
@@ -54,6 +54,7 @@ func CloudProjectVolumeBackupResourceSchema(ctx context.Context) schema.Schema {
 		"service_name": schema.StringAttribute{
 			CustomType:          ovhtypes.TfStringType{},
 			Optional:            true,
+			Computed:            true,
 			Description:         "Service name. If omitted, the `OVH_CLOUD_PROJECT_SERVICE` environment variable is used.",
 			MarkdownDescription: "Service name. If omitted, the `OVH_CLOUD_PROJECT_SERVICE` environment variable is used.",
 			PlanModifiers: []planmodifier.String{

--- a/ovh/resource_cloud_project_volume_gen.go
+++ b/ovh/resource_cloud_project_volume_gen.go
@@ -173,6 +173,7 @@ func CloudProjectVolumeResourceSchema(ctx context.Context) schema.Schema {
 		"service_name": schema.StringAttribute{
 			CustomType:          ovhtypes.TfStringType{},
 			Optional:            true,
+			Computed:            true,
 			Description:         "Service name. If omitted, the `OVH_CLOUD_PROJECT_SERVICE` environment variable is used.",
 			MarkdownDescription: "Service name. If omitted, the `OVH_CLOUD_PROJECT_SERVICE` environment variable is used.",
 			PlanModifiers: []planmodifier.String{


### PR DESCRIPTION
# Description

Since https://github.com/ovh/terraform-provider-ovh/pull/1233, `service_name` is optional on a bunch of cloud resources and falls back to the `OVH_CLOUD_PROJECT_SERVICE` env variable. The fallback only happens in `Create()` though: once the resource exists, the state holds the actual project id while the config holds nothing, and every subsequent plan tries to "fix" it:

```
~ resource "ovh_cloud_project_storage" "this" {
    - service_name = "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx" -> null
    ...
  }
```

On `ovh_cloud_project_storage` this is a harmless but noisy in-place update that comes back on every plan. It's worse on the other resources touched by https://github.com/ovh/terraform-provider-ovh/pull/1233, since they carry `RequiresReplace()` on `service_name`: omitting it there plans a full destroy/recreate.

Fix: also declare the attribute as `Computed`, so Terraform keeps the prior state value when the config doesn't set one. This is already how `ovh_cloud_floating_ip`, `ovh_cloud_project_storage_object_bucket_lifecycle_configuration`, `ovh_dedicated_server` or `ovh_vps` declare it.

Affected resources:

- `ovh_cloud_project_alerting`
- `ovh_cloud_project_gateway_interface`
- `ovh_cloud_project_instance_snapshot`
- `ovh_cloud_project_loadbalancer`
- `ovh_cloud_project_region`
- `ovh_cloud_project_region_network`
- `ovh_cloud_project_ssh_key`
- `ovh_cloud_project_storage`
- `ovh_cloud_project_storage_replication_job`
- `ovh_cloud_project_volume`
- `ovh_cloud_project_volume_backup`

Nothing changes when `service_name` is set explicitly, and changing its value still triggers a replacement where `RequiresReplace` is present.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or issues
- [ ] I have added acceptance tests that prove my fix is effective or that my feature works
- [ ] New and existing acceptance tests pass locally with my changes
- [ ] I ran successfully `go mod vendor` if I added or modify `go.mod` file
