### PR TITLE
fix: update Kafka topic properties in place instead of recreating

### DIFF
--- a/docs/resources/cloud_project_database_kafka_topic.md
+++ b/docs/resources/cloud_project_database_kafka_topic.md
@@ -37,15 +37,15 @@ The following arguments are supported:
 
 * `name` - (Required, Forces new resource) Name of the topic. No spaces allowed.
 
-* `min_insync_replicas` - (Optional, Forces new resource) Minimum insync replica accepted for this topic. Should be superior to 0
+* `min_insync_replicas` - (Optional) Minimum insync replica accepted for this topic. Should be superior to 0
 
-* `partitions` - (Optional, Forces new resource) Number of partitions for this topic. Should be superior to 0
+* `partitions` - (Optional) Number of partitions for this topic. Should be superior to 0. Can only be increased: lowering it forces a new resource
 
-* `replication` - (Optional, Forces new resource) Number of replication for this topic. Should be superior to 1
+* `replication` - (Optional) Number of replication for this topic. Should be superior to 1
 
-* `retention_bytes` - (Optional, Forces new resource) Number of bytes for the retention of the data for this topic. Inferior to 0 means unlimited
+* `retention_bytes` - (Optional) Number of bytes for the retention of the data for this topic. Inferior to 0 means unlimited
 
-* `retention_hours` - (Optional, Forces new resource) Number of hours for the retention of the data for this topic. Should be superior to -2. Inferior to 0 means unlimited
+* `retention_hours` - (Optional) Number of hours for the retention of the data for this topic. Should be superior to -2. Inferior to 0 means unlimited
 
 ## Attributes Reference
 
@@ -69,11 +69,13 @@ resource "ovh_cloud_project_database_kafka_topic" "topic" {
 
   timeouts {
     create = "1h"
+    update = "45m"
     delete = "45m"
   }
 }
 ```
 * `create` - (Default 20m)
+* `update` - (Default 20m)
 * `delete` - (Default 20m)
 
 ## Import

--- a/examples/resources/cloud_project_database_kafka_topic/example_2.tf
+++ b/examples/resources/cloud_project_database_kafka_topic/example_2.tf
@@ -3,6 +3,7 @@ resource "ovh_cloud_project_database_kafka_topic" "topic" {
 
   timeouts {
     create = "1h"
+    update = "45m"
     delete = "45m"
   }
 }

--- a/ovh/resource_cloud_project_database_kafka_topic.go
+++ b/ovh/resource_cloud_project_database_kafka_topic.go
@@ -202,13 +202,27 @@ func resourceCloudProjectDatabaseKafkaTopicUpdate(ctx context.Context, d *schema
 	)
 	params := (&CloudProjectDatabaseKafkaTopicUpdateOpts{}).FromResource(d)
 
-	log.Printf("[DEBUG] Will update topic %s from cluster %s from project %s", id, clusterID, serviceName)
-	err := config.OVHClient.PutWithContext(ctx, endpoint, params, nil)
-	if err != nil {
-		return diag.Errorf("calling Put %s with params %+v:\n\t %q", endpoint, params, err)
-	}
+	return diag.FromErr(
+		retry.RetryContext(ctx, d.Timeout(schema.TimeoutUpdate),
+			func() *retry.RetryError {
+				log.Printf("[DEBUG] Will update topic %s from cluster %s from project %s", id, clusterID, serviceName)
+				err := config.OVHClient.PutWithContext(ctx, endpoint, params, nil)
+				if err != nil {
+					// The cluster rejects concurrent operations while it converges
+					if errOvh, ok := err.(*ovh.APIError); ok && (errOvh.Code == 409) {
+						return retry.RetryableError(err)
+					}
+					return retry.NonRetryableError(fmt.Errorf("calling Put %s with params %+v:\n\t %q", endpoint, params, err))
+				}
 
-	return resourceCloudProjectDatabaseKafkaTopicRead(ctx, d, meta)
+				readDiags := resourceCloudProjectDatabaseKafkaTopicRead(ctx, d, meta)
+				if err := diagnosticsToError(readDiags); err != nil {
+					return retry.NonRetryableError(err)
+				}
+				return nil
+			},
+		),
+	)
 }
 
 func resourceCloudProjectDatabaseKafkaTopicDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {

--- a/ovh/resource_cloud_project_database_kafka_topic.go
+++ b/ovh/resource_cloud_project_database_kafka_topic.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/ovh/go-ovh/ovh"
@@ -20,6 +21,7 @@ func resourceCloudProjectDatabaseKafkaTopic() *schema.Resource {
 		CreateContext: resourceCloudProjectDatabaseKafkaTopicCreate,
 		ReadContext:   resourceCloudProjectDatabaseKafkaTopicRead,
 		DeleteContext: resourceCloudProjectDatabaseKafkaTopicDelete,
+		UpdateContext: resourceCloudProjectDatabaseKafkaTopicUpdate,
 
 		Importer: &schema.ResourceImporter{
 			State: resourceCloudProjectDatabaseKafkaTopicImportState,
@@ -27,6 +29,7 @@ func resourceCloudProjectDatabaseKafkaTopic() *schema.Resource {
 
 		Timeouts: &schema.ResourceTimeout{
 			Create: schema.DefaultTimeout(20 * time.Minute),
+			Update: schema.DefaultTimeout(20 * time.Minute),
 			Delete: schema.DefaultTimeout(20 * time.Minute),
 		},
 
@@ -54,7 +57,6 @@ func resourceCloudProjectDatabaseKafkaTopic() *schema.Resource {
 			"min_insync_replicas": {
 				Type:             schema.TypeInt,
 				Description:      "Minimum insync replica accepted for this topic",
-				ForceNew:         true,
 				Optional:         true,
 				Computed:         true,
 				ValidateDiagFunc: validateCloudProjectDatabaseKafkaTopicMinInsyncReplicasFunc,
@@ -62,7 +64,6 @@ func resourceCloudProjectDatabaseKafkaTopic() *schema.Resource {
 			"partitions": {
 				Type:             schema.TypeInt,
 				Description:      "Number of partitions for this topic",
-				ForceNew:         true,
 				Optional:         true,
 				Computed:         true,
 				ValidateDiagFunc: validateCloudProjectDatabaseKafkaTopicPartitionsFunc,
@@ -70,7 +71,6 @@ func resourceCloudProjectDatabaseKafkaTopic() *schema.Resource {
 			"replication": {
 				Type:             schema.TypeInt,
 				Description:      "Number of replication for this topic",
-				ForceNew:         true,
 				Optional:         true,
 				Computed:         true,
 				ValidateDiagFunc: validateCloudProjectDatabaseKafkaTopicReplicationFunc,
@@ -78,19 +78,22 @@ func resourceCloudProjectDatabaseKafkaTopic() *schema.Resource {
 			"retention_bytes": {
 				Type:        schema.TypeInt,
 				Description: "Number of bytes for the retention of the data for this topic",
-				ForceNew:    true,
 				Optional:    true,
 				Computed:    true,
 			},
 			"retention_hours": {
 				Type:             schema.TypeInt,
 				Description:      "Number of hours for the retention of the data for this topic",
-				ForceNew:         true,
 				Optional:         true,
 				Computed:         true,
 				ValidateDiagFunc: validateCloudProjectDatabaseKafkaTopicRetentionHoursFunc,
 			},
 		},
+
+		// Partitions can only be increased
+		CustomizeDiff: customdiff.ForceNewIfChange("partitions", func(ctx context.Context, old, new, meta interface{}) bool {
+			return new.(int) < old.(int)
+		}),
 	}
 }
 
@@ -184,6 +187,28 @@ func resourceCloudProjectDatabaseKafkaTopicRead(ctx context.Context, d *schema.R
 	}
 
 	return nil
+}
+
+func resourceCloudProjectDatabaseKafkaTopicUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	config := meta.(*Config)
+	serviceName := d.Get("service_name").(string)
+	clusterID := d.Get("cluster_id").(string)
+	id := d.Id()
+
+	endpoint := fmt.Sprintf("/cloud/project/%s/database/kafka/%s/topic/%s",
+		url.PathEscape(serviceName),
+		url.PathEscape(clusterID),
+		url.PathEscape(id),
+	)
+	params := (&CloudProjectDatabaseKafkaTopicUpdateOpts{}).FromResource(d)
+
+	log.Printf("[DEBUG] Will update topic %s from cluster %s from project %s", id, clusterID, serviceName)
+	err := config.OVHClient.PutWithContext(ctx, endpoint, params, nil)
+	if err != nil {
+		return diag.Errorf("calling Put %s with params %+v:\n\t %q", endpoint, params, err)
+	}
+
+	return resourceCloudProjectDatabaseKafkaTopicRead(ctx, d, meta)
 }
 
 func resourceCloudProjectDatabaseKafkaTopicDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {

--- a/ovh/resource_cloud_project_database_kafka_topic_test.go
+++ b/ovh/resource_cloud_project_database_kafka_topic_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 )
 
 const testAccCloudProjectDatabaseKafkaTopicConfig = `
@@ -104,6 +105,150 @@ func TestAccCloudProjectDatabaseKafkaTopic_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"ovh_cloud_project_database_kafka_topic.topic2", "retention_hours", strconv.Itoa(5)),
 				),
+			},
+		},
+	})
+}
+
+const testAccCloudProjectDatabaseKafkaTopicUpdateConfig = `
+resource "ovh_cloud_project_database" "db" {
+	service_name = "%s"
+	description  = "%s"
+	engine       = "kafka"
+	version      = "%s"
+	plan         = "business"
+	nodes {
+		region     = "%s"
+	}
+	nodes {
+		region     = "%s"
+	}
+	nodes {
+		region     = "%s"
+	}
+	flavor = "%s"
+}
+
+resource "ovh_cloud_project_database_kafka_topic" "topic" {
+	service_name = ovh_cloud_project_database.db.service_name
+	cluster_id   = ovh_cloud_project_database.db.id
+	name = "%s"
+	min_insync_replicas = %d
+	partitions = %d
+	replication = %d
+	retention_bytes = %d
+	retention_hours = %d
+}
+`
+
+// captureKafkaTopicID stores the topic id on first call, then fails on any
+// later call where it changed, proving the topic was updated and not recreated.
+func captureKafkaTopicID(rn string, store *string) resource.TestCheckFunc {
+	return resource.TestCheckResourceAttrWith(rn, "id", func(v string) error {
+		if v == "" {
+			return fmt.Errorf("expected topic id to be set")
+		}
+		if *store == "" {
+			*store = v
+			return nil
+		}
+		if v != *store {
+			return fmt.Errorf("topic was replaced: id changed from %q to %q", *store, v)
+		}
+		return nil
+	})
+}
+
+func TestAccCloudProjectDatabaseKafkaTopic_update(t *testing.T) {
+	serviceName := os.Getenv("OVH_CLOUD_PROJECT_SERVICE_TEST")
+	version := os.Getenv("OVH_CLOUD_PROJECT_DATABASE_KAFKA_VERSION_TEST")
+	if version == "" {
+		version = os.Getenv("OVH_CLOUD_PROJECT_DATABASE_VERSION_TEST")
+	}
+	region := os.Getenv("OVH_CLOUD_PROJECT_DATABASE_REGION_TEST")
+	flavor := os.Getenv("OVH_CLOUD_PROJECT_DATABASE_FLAVOR_TEST")
+	description := acctest.RandomWithPrefix(test_prefix)
+	name := "myTopic"
+	rn := "ovh_cloud_project_database_kafka_topic.topic"
+
+	config := func(minInsyncReplicas, partitions, replication, retentionBytes, retentionHours int) string {
+		return fmt.Sprintf(
+			testAccCloudProjectDatabaseKafkaTopicUpdateConfig,
+			serviceName,
+			description,
+			version,
+			region,
+			region,
+			region,
+			flavor,
+			name,
+			minInsyncReplicas,
+			partitions,
+			replication,
+			retentionBytes,
+			retentionHours,
+		)
+	}
+
+	checkAttrs := func(minInsyncReplicas, partitions, replication, retentionBytes, retentionHours int) resource.TestCheckFunc {
+		return resource.ComposeTestCheckFunc(
+			resource.TestCheckResourceAttr(rn, "name", name),
+			resource.TestCheckResourceAttr(rn, "min_insync_replicas", strconv.Itoa(minInsyncReplicas)),
+			resource.TestCheckResourceAttr(rn, "partitions", strconv.Itoa(partitions)),
+			resource.TestCheckResourceAttr(rn, "replication", strconv.Itoa(replication)),
+			resource.TestCheckResourceAttr(rn, "retention_bytes", strconv.Itoa(retentionBytes)),
+			resource.TestCheckResourceAttr(rn, "retention_hours", strconv.Itoa(retentionHours)),
+		)
+	}
+
+	var topicID string
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheckCloudDatabaseNoEngine(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: config(1, 3, 2, 4, 5),
+				Check: resource.ComposeTestCheckFunc(
+					checkAttrs(1, 3, 2, 4, 5),
+					captureKafkaTopicID(rn, &topicID),
+				),
+			},
+			{
+				// min_insync_replicas, replication and both retentions update in place.
+				Config: config(2, 3, 3, 8, 10),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(rn, plancheck.ResourceActionUpdate),
+					},
+				},
+				Check: resource.ComposeTestCheckFunc(
+					checkAttrs(2, 3, 3, 8, 10),
+					captureKafkaTopicID(rn, &topicID),
+				),
+			},
+			{
+				// Partitions can be increased in place.
+				Config: config(2, 6, 3, 8, 10),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(rn, plancheck.ResourceActionUpdate),
+					},
+				},
+				Check: resource.ComposeTestCheckFunc(
+					checkAttrs(2, 6, 3, 8, 10),
+					captureKafkaTopicID(rn, &topicID),
+				),
+			},
+			{
+				// The API rejects a partition decrease, so it must force a new resource.
+				Config: config(2, 3, 3, 8, 10),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(rn, plancheck.ResourceActionReplace),
+					},
+				},
+				Check: checkAttrs(2, 3, 3, 8, 10),
 			},
 		},
 	})

--- a/ovh/types_cloud_project_database.go
+++ b/ovh/types_cloud_project_database.go
@@ -1658,6 +1658,24 @@ func (opts *CloudProjectDatabaseKafkaTopicCreateOpts) FromResource(d *schema.Res
 	return opts
 }
 
+type CloudProjectDatabaseKafkaTopicUpdateOpts struct {
+	MinInsyncReplicas int `json:"minInsyncReplicas"`
+	Partitions        int `json:"partitions"`
+	Replication       int `json:"replication"`
+	RetentionBytes    int `json:"retentionBytes"`
+	RetentionHours    int `json:"retentionHours"`
+}
+
+func (opts *CloudProjectDatabaseKafkaTopicUpdateOpts) FromResource(d *schema.ResourceData) *CloudProjectDatabaseKafkaTopicUpdateOpts {
+	opts.MinInsyncReplicas = d.Get("min_insync_replicas").(int)
+	opts.Partitions = d.Get("partitions").(int)
+	opts.Replication = d.Get("replication").(int)
+	opts.RetentionBytes = d.Get("retention_bytes").(int)
+	opts.RetentionHours = d.Get("retention_hours").(int)
+
+	return opts
+}
+
 func validateIsSupEqual(v, min int) (diags diag.Diagnostics) {
 	if v < min {
 		diags = append(diags, diag.Diagnostic{

--- a/templates/resources/cloud_project_database_kafka_topic.md.tmpl
+++ b/templates/resources/cloud_project_database_kafka_topic.md.tmpl
@@ -24,15 +24,15 @@ The following arguments are supported:
 
 * `name` - (Required, Forces new resource) Name of the topic. No spaces allowed.
 
-* `min_insync_replicas` - (Optional, Forces new resource) Minimum insync replica accepted for this topic. Should be superior to 0
+* `min_insync_replicas` - (Optional) Minimum insync replica accepted for this topic. Should be superior to 0
 
-* `partitions` - (Optional, Forces new resource) Number of partitions for this topic. Should be superior to 0
+* `partitions` - (Optional) Number of partitions for this topic. Should be superior to 0. Can only be increased: lowering it forces a new resource
 
-* `replication` - (Optional, Forces new resource) Number of replication for this topic. Should be superior to 1
+* `replication` - (Optional) Number of replication for this topic. Should be superior to 1
 
-* `retention_bytes` - (Optional, Forces new resource) Number of bytes for the retention of the data for this topic. Inferior to 0 means unlimited
+* `retention_bytes` - (Optional) Number of bytes for the retention of the data for this topic. Inferior to 0 means unlimited
 
-* `retention_hours` - (Optional, Forces new resource) Number of hours for the retention of the data for this topic. Should be superior to -2. Inferior to 0 means unlimited
+* `retention_hours` - (Optional) Number of hours for the retention of the data for this topic. Should be superior to -2. Inferior to 0 means unlimited
 
 ## Attributes Reference
 
@@ -52,6 +52,7 @@ The following attributes are exported:
 
 {{tffile "examples/resources/cloud_project_database_kafka_topic/example_2.tf"}}
 * `create` - (Default 20m)
+* `update` - (Default 20m)
 * `delete` - (Default 20m)
 
 ## Import


### PR DESCRIPTION
# Description

`ovh_cloud_project_database_kafka_topic` marks every attribute `ForceNew` and implements no `Update`, so changing any topic property destroys and recreates the topic, dropping its data.

The API supports updating them: `PUT /cloud/project/{serviceName}/database/kafka/{clusterId}/topic/{topicId}` exists, and in the `cloud.project.database.kafka.Topic` model only `id` and `name` are `readOnly`.

This adds `UpdateContext` backed by that PUT and drops `ForceNew` from the five mutable attributes.

`partitions` is the exception: Kafka only allows partition counts to grow, and the API returns 400 on a decrease, so it is wrapped in `customdiff.ForceNewIfChange` and forces replacement only when the value goes down.

Verified against a live cluster before writing the code:

| change | result |
| --- | --- |
| `retention_hours` 48 -> 72 | 200 |
| `retention_bytes` -1 -> 1 GiB | 200 |
| `min_insync_replicas` 1 -> 2 | 200 |
| `partitions` 1 -> 2 | 200 |
| `partitions` 2 -> 1 | 400 Bad Request |
| `replication` 2 -> 3 | 200 |
| `replication` 3 -> 2 | 200 |

Fixes #1359

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Documentation update

# How Has This Been Tested?

- [x] Test A: `make testacc TESTARGS="-run TestAccCloudProjectDatabaseKafkaTopic_update"` - PASS (703s)
- [x] Test B: `make testacc TESTARGS="-run TestAccCloudProjectDatabaseKafkaTopic"` - PASS

`TestAccCloudProjectDatabaseKafkaTopic_update` is new.

It creates a topic, then asserts via `plancheck` that changing `min_insync_replicas`, `replication`, `retention_bytes` and `retention_hours` plans as an in-place update, that raising `partitions` plans as an in-place update, and that lowering `partitions` plans as a replacement.

The first three steps also assert the topic id is unchanged, so an update that silently recreated the topic would fail.

**Test Configuration**:
* Terraform version: `Terraform v1.15.1` (the acceptance test harness resolves `terraform` from `PATH`; the provider is served in-process from this branch). Issue #1359 was reported against OpenTofu v1.12.3.
* Existing HCL configuration you used:
```hcl
resource "ovh_cloud_project_database_kafka_topic" "topic" {
  service_name        = ovh_cloud_project_database.db.service_name
  cluster_id          = ovh_cloud_project_database.db.id
  name                = "myTopic"
  min_insync_replicas = 1
  partitions          = 3
  replication         = 2
  retention_bytes     = 4
  retention_hours     = 5
}
```

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or issues
- [x] I have added acceptance tests that prove my fix is effective or that my feature works
- [x] New and existing acceptance tests pass locally with my changes
- [x] I ran successfully `go mod vendor` if I added or modify `go.mod` file
