### PR TITLE
feat: addd instance backup feature

### DIFF
--- a/docs/data-sources/cloud_instance_backup.md
+++ b/docs/data-sources/cloud_instance_backup.md
@@ -1,0 +1,42 @@
+---
+subcategory: "Instances"
+---
+
+# ovh_cloud_instance_backup (Data Source)
+
+Use this data source to retrieve information about an instance backup in a public cloud project.
+
+## Example Usage
+
+```terraform
+data "ovh_cloud_instance_backup" "backup" {
+  service_name = "<Public cloud project id>"
+  id           = "<backup id>"
+}
+
+output "backup_status" {
+  value = data.ovh_cloud_instance_backup.backup.resource_status
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `service_name` - (Required) Service name of the resource representing the id of the cloud project.
+* `id` - (Required) Backup ID.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `name` - Backup name.
+* `location` - Location of the backup:
+  * `region` - Region.
+* `instance_id` - ID of the backed-up instance.
+* `min_disk` - Minimum disk size in GB required to boot.
+* `min_ram` - Minimum RAM in MB required to boot.
+* `size` - Image size in bytes.
+* `status` - Image status in the backend.
+* `visibility` - Image visibility.
+* `resource_status` - Backup readiness in the system (`CREATING`, `DELETING`, `ERROR`, `OUT_OF_SYNC`, `READY`).

--- a/docs/data-sources/cloud_instance_backups.md
+++ b/docs/data-sources/cloud_instance_backups.md
@@ -1,0 +1,44 @@
+---
+subcategory: "Instances"
+---
+
+# ovh_cloud_instance_backups (Data Source)
+
+Use this data source to list the backups of an instance in a public cloud project.
+
+## Example Usage
+
+```terraform
+data "ovh_cloud_instance_backups" "backups" {
+  service_name = "<Public cloud project id>"
+  region       = "GRA11"
+  instance_id  = "<instance id>"
+}
+
+output "backup_ids" {
+  value = [for backup in data.ovh_cloud_instance_backups.backups.backups : backup.id]
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `service_name` - (Required) Service name of the resource representing the id of the cloud project.
+* `region` - (Required) Region where the instance backups reside.
+* `instance_id` - (Required) ID of the instance whose backups to list.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `backups` - List of backups for the instance:
+  * `id` - Backup ID.
+  * `name` - Backup name.
+  * `location` - Location of the backup:
+    * `region` - Region.
+  * `instance_id` - ID of the backed-up instance.
+  * `size` - Image size in bytes.
+  * `status` - Image status in the backend.
+  * `visibility` - Image visibility.
+  * `resource_status` - Backup readiness in the system (`CREATING`, `DELETING`, `ERROR`, `OUT_OF_SYNC`, `READY`).

--- a/docs/resources/cloud_instance_backup.md
+++ b/docs/resources/cloud_instance_backup.md
@@ -1,0 +1,58 @@
+---
+subcategory: "Instances"
+---
+
+# ovh_cloud_instance_backup
+
+Creates an on-demand backup of an instance in a public cloud project.
+
+## Example Usage
+
+```terraform
+resource "ovh_cloud_instance_backup" "backup" {
+  service_name = "<Public cloud project id>"
+  region       = "GRA11"
+  instance_id  = "<instance id>"
+  name         = "my-instance-backup"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `service_name` - (Optional) Service name of the resource representing the id of the cloud project. If omitted, the `OVH_CLOUD_PROJECT_SERVICE` environment variable is used. Changing this value recreates the resource.
+* `region` - (Required) Region where the backup will be created. Changing this value recreates the resource.
+* `instance_id` - (Required) ID of the instance to back up. Changing this value recreates the resource.
+* `name` - (Required) Backup name. Changing this value recreates the resource.
+
+-> All attributes are immutable: the resource does not support in-place updates, any change requires replacement.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `id` - Backup ID.
+* `checksum` - Computed hash representing the current target specification value.
+* `created_at` - Creation date of the backup.
+* `updated_at` - Last update date of the backup.
+* `resource_status` - Backup readiness in the system (`CREATING`, `DELETING`, `ERROR`, `OUT_OF_SYNC`, `READY`).
+* `current_state` - Current state of the instance backup:
+  * `instance` - Source instance reference:
+    * `id` - Instance unique identifier.
+  * `location` - Current location:
+    * `region` - Region.
+  * `min_disk` - Minimum disk size in GB required to boot.
+  * `min_ram` - Minimum RAM in MB required to boot.
+  * `name` - Current backup name.
+  * `size` - Image size in bytes.
+  * `status` - Image status in the backend.
+  * `visibility` - Image visibility.
+
+## Import
+
+An instance backup can be imported using the `service_name` and the `id` of the backup, separated by "/":
+
+```bash
+terraform import ovh_cloud_instance_backup.backup service_name/backup_id
+```

--- a/ovh/data_cloud_instance_backup.go
+++ b/ovh/data_cloud_instance_backup.go
@@ -1,0 +1,207 @@
+package ovh
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	ovhtypes "github.com/ovh/terraform-provider-ovh/v2/ovh/types"
+)
+
+var _ datasource.DataSourceWithConfigure = (*cloudInstanceBackupDataSource)(nil)
+
+func NewCloudInstanceBackupDataSource() datasource.DataSource {
+	return &cloudInstanceBackupDataSource{}
+}
+
+type cloudInstanceBackupDataSource struct {
+	config *Config
+}
+
+func (d *cloudInstanceBackupDataSource) Metadata(ctx context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_cloud_instance_backup"
+}
+
+func (d *cloudInstanceBackupDataSource) Configure(_ context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+
+	config, ok := req.ProviderData.(*Config)
+	if !ok {
+		resp.Diagnostics.AddError(
+			"Unexpected Data Source Configure Type",
+			fmt.Sprintf("Expected *Config, got: %T. Please report this issue to the provider developers.", req.ProviderData),
+		)
+		return
+	}
+
+	d.config = config
+}
+
+func (d *cloudInstanceBackupDataSource) Schema(ctx context.Context, req datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Description:         "Get an instance backup in a public cloud project.",
+		MarkdownDescription: "Get an instance backup in a public cloud project.",
+		Attributes: map[string]schema.Attribute{
+			"service_name": schema.StringAttribute{
+				CustomType:          ovhtypes.TfStringType{},
+				Required:            true,
+				Description:         "Service name of the resource representing the id of the cloud project",
+				MarkdownDescription: "Service name of the resource representing the id of the cloud project",
+			},
+			"id": schema.StringAttribute{
+				CustomType:          ovhtypes.TfStringType{},
+				Required:            true,
+				Description:         "Backup ID",
+				MarkdownDescription: "Backup ID",
+			},
+			"name": schema.StringAttribute{
+				CustomType:  ovhtypes.TfStringType{},
+				Computed:    true,
+				Description: "Backup name",
+			},
+			"location": schema.SingleNestedAttribute{
+				Computed:    true,
+				Description: "Location of the backup",
+				Attributes: map[string]schema.Attribute{
+					"region": schema.StringAttribute{
+						CustomType:  ovhtypes.TfStringType{},
+						Computed:    true,
+						Description: "Region",
+					},
+				},
+			},
+			"instance_id": schema.StringAttribute{
+				CustomType:  ovhtypes.TfStringType{},
+				Computed:    true,
+				Description: "ID of the backed-up instance",
+			},
+			"min_disk": schema.Int64Attribute{
+				Computed:    true,
+				Description: "Minimum disk size in GB required to boot",
+			},
+			"min_ram": schema.Int64Attribute{
+				Computed:    true,
+				Description: "Minimum RAM in MB required to boot",
+			},
+			"size": schema.Int64Attribute{
+				Computed:    true,
+				Description: "Image size in bytes",
+			},
+			"status": schema.StringAttribute{
+				CustomType:  ovhtypes.TfStringType{},
+				Computed:    true,
+				Description: "Image status in the backend",
+			},
+			"visibility": schema.StringAttribute{
+				CustomType:  ovhtypes.TfStringType{},
+				Computed:    true,
+				Description: "Image visibility",
+			},
+			"resource_status": schema.StringAttribute{
+				CustomType:  ovhtypes.TfStringType{},
+				Computed:    true,
+				Description: "Backup readiness status",
+			},
+		},
+	}
+}
+
+type cloudInstanceBackupDataSourceModel struct {
+	ServiceName    ovhtypes.TfStringValue `tfsdk:"service_name"`
+	Id             ovhtypes.TfStringValue `tfsdk:"id"`
+	Name           ovhtypes.TfStringValue `tfsdk:"name"`
+	Location       types.Object           `tfsdk:"location"`
+	InstanceId     ovhtypes.TfStringValue `tfsdk:"instance_id"`
+	MinDisk        types.Int64            `tfsdk:"min_disk"`
+	MinRam         types.Int64            `tfsdk:"min_ram"`
+	Size           types.Int64            `tfsdk:"size"`
+	Status         ovhtypes.TfStringValue `tfsdk:"status"`
+	Visibility     ovhtypes.TfStringValue `tfsdk:"visibility"`
+	ResourceStatus ovhtypes.TfStringValue `tfsdk:"resource_status"`
+}
+
+func (d *cloudInstanceBackupDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+	var data cloudInstanceBackupDataSourceModel
+
+	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	endpoint := "/v2/publicCloud/project/" + url.PathEscape(data.ServiceName.ValueString()) +
+		"/compute/backup/" + url.PathEscape(data.Id.ValueString())
+
+	var b CloudInstanceBackupAPIResponse
+	if err := d.config.OVHClient.Get(endpoint, &b); err != nil {
+		resp.Diagnostics.AddError(
+			fmt.Sprintf("Error calling Get %s", endpoint),
+			err.Error(),
+		)
+		return
+	}
+
+	name := ""
+	instanceId := ""
+	region := ""
+	if b.TargetSpec != nil {
+		name = b.TargetSpec.Name
+		if b.TargetSpec.Instance != nil {
+			instanceId = b.TargetSpec.Instance.Id
+		}
+		if b.TargetSpec.Location != nil {
+			region = b.TargetSpec.Location.Region
+		}
+	}
+
+	minDisk := int64(0)
+	minRam := int64(0)
+	size := int64(0)
+	status := ""
+	visibility := ""
+	if b.CurrentState != nil {
+		minDisk = b.CurrentState.MinDisk
+		minRam = b.CurrentState.MinRam
+		size = b.CurrentState.Size
+		status = b.CurrentState.Status
+		visibility = b.CurrentState.Visibility
+		if b.CurrentState.Instance != nil && b.CurrentState.Instance.Id != "" {
+			instanceId = b.CurrentState.Instance.Id
+		}
+		if b.CurrentState.Name != "" {
+			name = b.CurrentState.Name
+		}
+		if b.CurrentState.Location != nil {
+			region = b.CurrentState.Location.Region
+		}
+	}
+
+	locObj, diags := types.ObjectValue(
+		map[string]attr.Type{"region": ovhtypes.TfStringType{}},
+		map[string]attr.Value{
+			"region": ovhtypes.TfStringValue{StringValue: types.StringValue(region)},
+		},
+	)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	data.Id = ovhtypes.TfStringValue{StringValue: types.StringValue(b.Id)}
+	data.Name = ovhtypes.TfStringValue{StringValue: types.StringValue(name)}
+	data.Location = locObj
+	data.InstanceId = ovhtypes.TfStringValue{StringValue: types.StringValue(instanceId)}
+	data.MinDisk = types.Int64Value(minDisk)
+	data.MinRam = types.Int64Value(minRam)
+	data.Size = types.Int64Value(size)
+	data.Status = ovhtypes.TfStringValue{StringValue: types.StringValue(status)}
+	data.Visibility = ovhtypes.TfStringValue{StringValue: types.StringValue(visibility)}
+	data.ResourceStatus = ovhtypes.TfStringValue{StringValue: types.StringValue(b.ResourceStatus)}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}

--- a/ovh/data_cloud_instance_backup_test.go
+++ b/ovh/data_cloud_instance_backup_test.go
@@ -1,0 +1,56 @@
+package ovh
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+func TestAccDataSourceCloudInstanceBackup_basic(t *testing.T) {
+	serviceName := os.Getenv("OVH_CLOUD_PROJECT_SERVICE_TEST")
+	region := os.Getenv("OVH_CLOUD_PROJECT_REGION_TEST")
+	flavorID := resolveInstanceFlavorID(t, serviceName, region, testAccInstanceFlavorName)
+	imageID := resolveInstanceImageID(t, serviceName, region, testAccInstanceImageName)
+	instanceName := acctest.RandomWithPrefix(test_prefix)
+	backupName := acctest.RandomWithPrefix(test_prefix)
+
+	config := testAccCloudInstanceBackupConfig(serviceName, region, flavorID, imageID, instanceName, backupName) + fmt.Sprintf(`
+data "ovh_cloud_instance_backup" "backup" {
+  service_name = "%s"
+  id           = ovh_cloud_instance_backup.backup.id
+}
+`, serviceName)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheckCloudInstanceV2(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("data.ovh_cloud_instance_backup.backup", "service_name", serviceName),
+					resource.TestCheckResourceAttrPair(
+						"data.ovh_cloud_instance_backup.backup", "id",
+						"ovh_cloud_instance_backup.backup", "id",
+					),
+					resource.TestCheckResourceAttrPair(
+						"data.ovh_cloud_instance_backup.backup", "instance_id",
+						"ovh_cloud_instance.instance", "id",
+					),
+					resource.TestCheckResourceAttr("data.ovh_cloud_instance_backup.backup", "name", backupName),
+					resource.TestCheckResourceAttr("data.ovh_cloud_instance_backup.backup", "location.region", region),
+					resource.TestCheckResourceAttr("data.ovh_cloud_instance_backup.backup", "resource_status", "READY"),
+					resource.TestCheckResourceAttrSet("data.ovh_cloud_instance_backup.backup", "status"),
+					resource.TestCheckResourceAttrSet("data.ovh_cloud_instance_backup.backup", "visibility"),
+					resource.TestCheckResourceAttrPair(
+						"data.ovh_cloud_instance_backup.backup", "instance_id",
+						"ovh_cloud_instance_backup.backup", "current_state.instance.id",
+					),
+				),
+			},
+		},
+	})
+}

--- a/ovh/data_cloud_instance_backups.go
+++ b/ovh/data_cloud_instance_backups.go
@@ -1,0 +1,248 @@
+package ovh
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	ovhtypes "github.com/ovh/terraform-provider-ovh/v2/ovh/types"
+)
+
+var _ datasource.DataSourceWithConfigure = (*cloudInstanceBackupsDataSource)(nil)
+
+func NewCloudInstanceBackupsDataSource() datasource.DataSource {
+	return &cloudInstanceBackupsDataSource{}
+}
+
+type cloudInstanceBackupsDataSource struct {
+	config *Config
+}
+
+func (d *cloudInstanceBackupsDataSource) Metadata(ctx context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_cloud_instance_backups"
+}
+
+func (d *cloudInstanceBackupsDataSource) Configure(_ context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+
+	config, ok := req.ProviderData.(*Config)
+	if !ok {
+		resp.Diagnostics.AddError(
+			"Unexpected Data Source Configure Type",
+			fmt.Sprintf("Expected *Config, got: %T. Please report this issue to the provider developers.", req.ProviderData),
+		)
+		return
+	}
+
+	d.config = config
+}
+
+func (d *cloudInstanceBackupsDataSource) Schema(ctx context.Context, req datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Description:         "List instance backups for a given instance in a public cloud project.",
+		MarkdownDescription: "List instance backups for a given instance in a public cloud project.",
+		Attributes: map[string]schema.Attribute{
+			"service_name": schema.StringAttribute{
+				CustomType:          ovhtypes.TfStringType{},
+				Required:            true,
+				Description:         "Service name of the resource representing the id of the cloud project",
+				MarkdownDescription: "Service name of the resource representing the id of the cloud project",
+			},
+			"region": schema.StringAttribute{
+				CustomType:          ovhtypes.TfStringType{},
+				Required:            true,
+				Description:         "Region where the instance backups reside",
+				MarkdownDescription: "Region where the instance backups reside",
+			},
+			"instance_id": schema.StringAttribute{
+				CustomType:          ovhtypes.TfStringType{},
+				Required:            true,
+				Description:         "ID of the instance whose backups to list",
+				MarkdownDescription: "ID of the instance whose backups to list",
+			},
+			"backups": schema.ListNestedAttribute{
+				Computed:            true,
+				Description:         "List of backups for the instance",
+				MarkdownDescription: "List of backups for the instance",
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]schema.Attribute{
+						"id": schema.StringAttribute{
+							CustomType:  ovhtypes.TfStringType{},
+							Computed:    true,
+							Description: "Backup ID",
+						},
+						"name": schema.StringAttribute{
+							CustomType:  ovhtypes.TfStringType{},
+							Computed:    true,
+							Description: "Backup name",
+						},
+						"location": schema.SingleNestedAttribute{
+							Computed:    true,
+							Description: "Location of the backup",
+							Attributes: map[string]schema.Attribute{
+								"region": schema.StringAttribute{
+									CustomType:  ovhtypes.TfStringType{},
+									Computed:    true,
+									Description: "Region",
+								},
+							},
+						},
+						"instance_id": schema.StringAttribute{
+							CustomType:  ovhtypes.TfStringType{},
+							Computed:    true,
+							Description: "ID of the backed-up instance",
+						},
+						"size": schema.Int64Attribute{
+							Computed:    true,
+							Description: "Image size in bytes",
+						},
+						"status": schema.StringAttribute{
+							CustomType:  ovhtypes.TfStringType{},
+							Computed:    true,
+							Description: "Image status in the backend",
+						},
+						"visibility": schema.StringAttribute{
+							CustomType:  ovhtypes.TfStringType{},
+							Computed:    true,
+							Description: "Image visibility",
+						},
+						"resource_status": schema.StringAttribute{
+							CustomType:  ovhtypes.TfStringType{},
+							Computed:    true,
+							Description: "Backup readiness status",
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+type cloudInstanceBackupsDataSourceModel struct {
+	ServiceName ovhtypes.TfStringValue `tfsdk:"service_name"`
+	Region      ovhtypes.TfStringValue `tfsdk:"region"`
+	InstanceId  ovhtypes.TfStringValue `tfsdk:"instance_id"`
+	Backups     types.List             `tfsdk:"backups"`
+}
+
+func instanceBackupListItemAttrTypes() map[string]attr.Type {
+	return map[string]attr.Type{
+		"id":   ovhtypes.TfStringType{},
+		"name": ovhtypes.TfStringType{},
+		"location": types.ObjectType{AttrTypes: map[string]attr.Type{
+			"region": ovhtypes.TfStringType{},
+		}},
+		"instance_id":     ovhtypes.TfStringType{},
+		"size":            types.Int64Type,
+		"status":          ovhtypes.TfStringType{},
+		"visibility":      ovhtypes.TfStringType{},
+		"resource_status": ovhtypes.TfStringType{},
+	}
+}
+
+func (d *cloudInstanceBackupsDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+	var data cloudInstanceBackupsDataSourceModel
+
+	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	endpoint := "/v2/publicCloud/project/" + url.PathEscape(data.ServiceName.ValueString()) +
+		"/compute/backup?instanceId=" + url.QueryEscape(data.InstanceId.ValueString())
+
+	var apiBackups []CloudInstanceBackupAPIResponse
+	if err := d.config.OVHClient.Get(endpoint, &apiBackups); err != nil {
+		resp.Diagnostics.AddError(
+			fmt.Sprintf("Error calling Get %s", endpoint),
+			err.Error(),
+		)
+		return
+	}
+
+	backupObjs := make([]attr.Value, 0, len(apiBackups))
+	for _, b := range apiBackups {
+		if b.CurrentState != nil && b.CurrentState.Location != nil &&
+			b.CurrentState.Location.Region != data.Region.ValueString() {
+			continue
+		}
+
+		name := ""
+		instanceId := ""
+		if b.TargetSpec != nil {
+			name = b.TargetSpec.Name
+			if b.TargetSpec.Instance != nil {
+				instanceId = b.TargetSpec.Instance.Id
+			}
+		}
+
+		size := int64(0)
+		status := ""
+		visibility := ""
+		region := data.Region.ValueString()
+		if b.CurrentState != nil {
+			size = b.CurrentState.Size
+			status = b.CurrentState.Status
+			visibility = b.CurrentState.Visibility
+			if b.CurrentState.Instance != nil && b.CurrentState.Instance.Id != "" {
+				instanceId = b.CurrentState.Instance.Id
+			}
+			if b.CurrentState.Name != "" {
+				name = b.CurrentState.Name
+			}
+			if b.CurrentState.Location != nil {
+				region = b.CurrentState.Location.Region
+			}
+		}
+
+		locObj, diags := types.ObjectValue(
+			map[string]attr.Type{"region": ovhtypes.TfStringType{}},
+			map[string]attr.Value{
+				"region": ovhtypes.TfStringValue{StringValue: types.StringValue(region)},
+			},
+		)
+		resp.Diagnostics.Append(diags...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+
+		itemObj, diags := types.ObjectValue(
+			instanceBackupListItemAttrTypes(),
+			map[string]attr.Value{
+				"id":              ovhtypes.TfStringValue{StringValue: types.StringValue(b.Id)},
+				"name":            ovhtypes.TfStringValue{StringValue: types.StringValue(name)},
+				"location":        locObj,
+				"instance_id":     ovhtypes.TfStringValue{StringValue: types.StringValue(instanceId)},
+				"size":            types.Int64Value(size),
+				"status":          ovhtypes.TfStringValue{StringValue: types.StringValue(status)},
+				"visibility":      ovhtypes.TfStringValue{StringValue: types.StringValue(visibility)},
+				"resource_status": ovhtypes.TfStringValue{StringValue: types.StringValue(b.ResourceStatus)},
+			},
+		)
+		resp.Diagnostics.Append(diags...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+
+		backupObjs = append(backupObjs, itemObj)
+	}
+
+	backupsList, diags := types.ListValue(
+		types.ObjectType{AttrTypes: instanceBackupListItemAttrTypes()},
+		backupObjs,
+	)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	data.Backups = backupsList
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}

--- a/ovh/data_cloud_instance_backups_test.go
+++ b/ovh/data_cloud_instance_backups_test.go
@@ -1,0 +1,76 @@
+package ovh
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+func TestAccDataSourceCloudInstanceBackups_basic(t *testing.T) {
+	serviceName := os.Getenv("OVH_CLOUD_PROJECT_SERVICE_TEST")
+	region := os.Getenv("OVH_CLOUD_PROJECT_REGION_TEST")
+	flavorID := resolveInstanceFlavorID(t, serviceName, region, testAccInstanceFlavorName)
+	imageID := resolveInstanceImageID(t, serviceName, region, testAccInstanceImageName)
+	instanceName := acctest.RandomWithPrefix(test_prefix)
+	backupName := acctest.RandomWithPrefix(test_prefix)
+
+	config := testAccCloudInstanceBackupConfig(serviceName, region, flavorID, imageID, instanceName, backupName) + fmt.Sprintf(`
+data "ovh_cloud_instance_backups" "backups" {
+  service_name = "%s"
+  region       = "%s"
+  instance_id  = ovh_cloud_instance.instance.id
+
+  depends_on = [ovh_cloud_instance_backup.backup]
+}
+`, serviceName, region)
+
+	configNoMatch := testAccCloudInstanceBackupConfig(serviceName, region, flavorID, imageID, instanceName, backupName) + fmt.Sprintf(`
+data "ovh_cloud_instance_backups" "empty" {
+  service_name = "%s"
+  region       = "%s"
+  instance_id  = "00000000-0000-0000-0000-000000000000"
+
+  depends_on = [ovh_cloud_instance_backup.backup]
+}
+`, serviceName, region)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheckCloudInstanceV2(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("data.ovh_cloud_instance_backups.backups", "service_name", serviceName),
+					resource.TestCheckResourceAttr("data.ovh_cloud_instance_backups.backups", "region", region),
+					resource.TestCheckResourceAttrPair(
+						"data.ovh_cloud_instance_backups.backups", "instance_id",
+						"ovh_cloud_instance.instance", "id",
+					),
+					resource.TestCheckResourceAttrPair(
+						"data.ovh_cloud_instance_backups.backups", "backups.0.id",
+						"ovh_cloud_instance_backup.backup", "id",
+					),
+					resource.TestCheckResourceAttr("data.ovh_cloud_instance_backups.backups", "backups.0.name", backupName),
+					resource.TestCheckResourceAttr("data.ovh_cloud_instance_backups.backups", "backups.0.location.region", region),
+					resource.TestCheckResourceAttr("data.ovh_cloud_instance_backups.backups", "backups.0.resource_status", "READY"),
+					resource.TestCheckResourceAttrSet("data.ovh_cloud_instance_backups.backups", "backups.0.status"),
+					resource.TestCheckResourceAttrSet("data.ovh_cloud_instance_backups.backups", "backups.0.visibility"),
+					resource.TestCheckResourceAttrPair(
+						"data.ovh_cloud_instance_backups.backups", "backups.0.instance_id",
+						"ovh_cloud_instance.instance", "id",
+					),
+				),
+			},
+			{
+				Config: configNoMatch,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("data.ovh_cloud_instance_backups.empty", "backups.#", "0"),
+				),
+			},
+		},
+	})
+}

--- a/ovh/provider_new.go
+++ b/ovh/provider_new.go
@@ -235,6 +235,8 @@ func (p *OvhProvider) DataSources(_ context.Context) []func() datasource.DataSou
 		NewCloudFloatingIPsDataSource,
 		NewCloudGatewayDataSource,
 		NewCloudGatewaysDataSource,
+		NewCloudInstanceBackupDataSource,
+		NewCloudInstanceBackupsDataSource,
 		NewCloudInstanceDataSource,
 		NewCloudInstanceFlavorDataSource,
 		NewCloudInstanceFlavorsDataSource,
@@ -351,6 +353,7 @@ func (p *OvhProvider) Resources(_ context.Context) []func() resource.Resource {
 	return []func() resource.Resource{
 		NewCloudFloatingIPResource,
 		NewCloudGatewayResource,
+		NewCloudInstanceBackupResource,
 		NewCloudInstanceGroupResource,
 		NewCloudInstanceResource,
 		NewCloudNetworkPrivateVrackResource,

--- a/ovh/resource_cloud_instance_backup.go
+++ b/ovh/resource_cloud_instance_backup.go
@@ -1,0 +1,358 @@
+package ovh
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
+	"github.com/ovh/go-ovh/ovh"
+	ovhtypes "github.com/ovh/terraform-provider-ovh/v2/ovh/types"
+)
+
+var (
+	_ resource.Resource                = (*cloudInstanceBackupResource)(nil)
+	_ resource.ResourceWithConfigure   = (*cloudInstanceBackupResource)(nil)
+	_ resource.ResourceWithImportState = (*cloudInstanceBackupResource)(nil)
+)
+
+func NewCloudInstanceBackupResource() resource.Resource {
+	return &cloudInstanceBackupResource{}
+}
+
+type cloudInstanceBackupResource struct {
+	config *Config
+}
+
+func (r *cloudInstanceBackupResource) Metadata(ctx context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_cloud_instance_backup"
+}
+
+func (r *cloudInstanceBackupResource) Configure(ctx context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+
+	config, ok := req.ProviderData.(*Config)
+	if !ok {
+		resp.Diagnostics.AddError(
+			"Unexpected Resource Configure Type",
+			fmt.Sprintf("Expected *Config, got: %T. Please report this issue to the provider developers.", req.ProviderData),
+		)
+		return
+	}
+
+	r.config = config
+}
+
+func (r *cloudInstanceBackupResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Description: "Creates an on-demand instance backup in a public cloud project using the publicCloud API.",
+		Attributes: map[string]schema.Attribute{
+			"service_name": schema.StringAttribute{
+				CustomType:          ovhtypes.TfStringType{},
+				Optional:            true,
+				Computed:            true,
+				Description:         "Service name of the resource representing the id of the cloud project. If omitted, the OVH_CLOUD_PROJECT_SERVICE environment variable is used.",
+				MarkdownDescription: "Service name of the resource representing the id of the cloud project. If omitted, the `OVH_CLOUD_PROJECT_SERVICE` environment variable is used.",
+				PlanModifiers: []planmodifier.String{
+					EnvDefaultString("OVH_CLOUD_PROJECT_SERVICE", true),
+					stringplanmodifier.UseStateForUnknown(),
+					stringplanmodifier.RequiresReplace(),
+				},
+			},
+			"name": schema.StringAttribute{
+				CustomType:          ovhtypes.TfStringType{},
+				Required:            true,
+				Description:         "Backup name",
+				MarkdownDescription: "Backup name",
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+			},
+			"region": schema.StringAttribute{
+				CustomType:          ovhtypes.TfStringType{},
+				Required:            true,
+				Description:         "Region where the backup will be created",
+				MarkdownDescription: "Region where the backup will be created",
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+			},
+			"instance_id": schema.StringAttribute{
+				CustomType:          ovhtypes.TfStringType{},
+				Required:            true,
+				Description:         "ID of the instance to back up",
+				MarkdownDescription: "ID of the instance to back up",
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+			},
+			"id": schema.StringAttribute{
+				CustomType:          ovhtypes.TfStringType{},
+				Computed:            true,
+				Description:         "Backup ID",
+				MarkdownDescription: "Backup ID",
+			},
+			"checksum": schema.StringAttribute{
+				CustomType:          ovhtypes.TfStringType{},
+				Computed:            true,
+				Description:         "Computed hash representing the current target specification value",
+				MarkdownDescription: "Computed hash representing the current target specification value",
+			},
+			"created_at": schema.StringAttribute{
+				CustomType:          ovhtypes.TfStringType{},
+				Computed:            true,
+				Description:         "Creation date of the backup",
+				MarkdownDescription: "Creation date of the backup",
+			},
+			"updated_at": schema.StringAttribute{
+				CustomType:          ovhtypes.TfStringType{},
+				Computed:            true,
+				Description:         "Last update date of the backup",
+				MarkdownDescription: "Last update date of the backup",
+			},
+			"resource_status": schema.StringAttribute{
+				CustomType:          ovhtypes.TfStringType{},
+				Computed:            true,
+				Description:         "Backup readiness in the system (CREATING, DELETING, ERROR, OUT_OF_SYNC, READY)",
+				MarkdownDescription: "Backup readiness in the system (CREATING, DELETING, ERROR, OUT_OF_SYNC, READY)",
+			},
+			"current_state": schema.SingleNestedAttribute{
+				Computed:    true,
+				Description: "Current state of the instance backup",
+				Attributes: map[string]schema.Attribute{
+					"instance": schema.SingleNestedAttribute{
+						Computed:    true,
+						Description: "Source instance reference",
+						Attributes: map[string]schema.Attribute{
+							"id": schema.StringAttribute{
+								CustomType:          ovhtypes.TfStringType{},
+								Computed:            true,
+								Description:         "Instance unique identifier",
+								MarkdownDescription: "Instance unique identifier",
+							},
+						},
+					},
+					"location": schema.SingleNestedAttribute{
+						Computed:    true,
+						Description: "Current location",
+						Attributes: map[string]schema.Attribute{
+							"region": schema.StringAttribute{
+								CustomType:          ovhtypes.TfStringType{},
+								Computed:            true,
+								Description:         "Region",
+								MarkdownDescription: "Region",
+							},
+						},
+					},
+					"min_disk": schema.Int64Attribute{
+						Computed:            true,
+						Description:         "Minimum disk size in GB required to boot",
+						MarkdownDescription: "Minimum disk size in GB required to boot",
+					},
+					"min_ram": schema.Int64Attribute{
+						Computed:            true,
+						Description:         "Minimum RAM in MB required to boot",
+						MarkdownDescription: "Minimum RAM in MB required to boot",
+					},
+					"name": schema.StringAttribute{
+						CustomType:          ovhtypes.TfStringType{},
+						Computed:            true,
+						Description:         "Current backup name",
+						MarkdownDescription: "Current backup name",
+					},
+					"size": schema.Int64Attribute{
+						Computed:            true,
+						Description:         "Image size in bytes",
+						MarkdownDescription: "Image size in bytes",
+					},
+					"status": schema.StringAttribute{
+						CustomType:          ovhtypes.TfStringType{},
+						Computed:            true,
+						Description:         "Image status in the backend",
+						MarkdownDescription: "Image status in the backend",
+					},
+					"visibility": schema.StringAttribute{
+						CustomType:          ovhtypes.TfStringType{},
+						Computed:            true,
+						Description:         "Image visibility",
+						MarkdownDescription: "Image visibility",
+					},
+				},
+			},
+		},
+	}
+}
+
+func (r *cloudInstanceBackupResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	splits := strings.Split(req.ID, "/")
+	if len(splits) != 2 {
+		resp.Diagnostics.AddError("Given ID is malformed", "ID must be formatted like the following: <service_name>/<backup_id>")
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("service_name"), splits[0])...)
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("id"), splits[1])...)
+}
+
+func (r *cloudInstanceBackupResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	var data CloudInstanceBackupModel
+
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	createPayload := data.ToCreate()
+
+	endpoint := "/v2/publicCloud/project/" + url.PathEscape(data.ServiceName.ValueString()) + "/compute/backup"
+
+	var responseData CloudInstanceBackupAPIResponse
+	if err := r.config.OVHClient.Post(endpoint, createPayload, &responseData); err != nil {
+		resp.Diagnostics.AddError(
+			fmt.Sprintf("Error calling Post %s", endpoint),
+			err.Error(),
+		)
+		return
+	}
+
+	// Save state immediately so the resource ID is tracked even if the workflow fails
+	data.MergeWith(ctx, &responseData)
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+
+	_, err := r.waitForInstanceBackupReady(ctx, data.ServiceName.ValueString(), responseData.Id)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Error waiting for instance backup to be ready",
+			err.Error(),
+		)
+		return
+	}
+
+	endpoint = "/v2/publicCloud/project/" + url.PathEscape(data.ServiceName.ValueString()) + "/compute/backup/" + url.PathEscape(responseData.Id)
+	if err := r.config.OVHClient.Get(endpoint, &responseData); err != nil {
+		resp.Diagnostics.AddError(
+			fmt.Sprintf("Error calling Get %s", endpoint),
+			err.Error(),
+		)
+		return
+	}
+
+	data.MergeWith(ctx, &responseData)
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+func (r *cloudInstanceBackupResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	var data CloudInstanceBackupModel
+
+	resp.Diagnostics.Append(req.State.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	endpoint := "/v2/publicCloud/project/" + url.PathEscape(data.ServiceName.ValueString()) + "/compute/backup/" + url.PathEscape(data.Id.ValueString())
+
+	var responseData CloudInstanceBackupAPIResponse
+	if err := r.config.OVHClient.Get(endpoint, &responseData); err != nil {
+		if errOvh, ok := err.(*ovh.APIError); ok && errOvh.Code == 404 {
+			resp.State.RemoveResource(ctx)
+			return
+		}
+		resp.Diagnostics.AddError(
+			fmt.Sprintf("Error calling Get %s", endpoint),
+			err.Error(),
+		)
+		return
+	}
+
+	data.MergeWith(ctx, &responseData)
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+func (r *cloudInstanceBackupResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	// All attributes are immutable (RequiresReplace); the API exposes no update endpoint.
+	resp.Diagnostics.AddError(
+		"Update not supported",
+		"ovh_cloud_instance_backup does not support in-place updates; all attributes require replacement.",
+	)
+}
+
+func (r *cloudInstanceBackupResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	var data CloudInstanceBackupModel
+
+	resp.Diagnostics.Append(req.State.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	endpoint := "/v2/publicCloud/project/" + url.PathEscape(data.ServiceName.ValueString()) + "/compute/backup/" + url.PathEscape(data.Id.ValueString())
+
+	if err := r.config.OVHClient.Delete(endpoint, nil); err != nil {
+		if errOvh, ok := err.(*ovh.APIError); ok && errOvh.Code == 404 {
+			return
+		}
+		resp.Diagnostics.AddError(
+			fmt.Sprintf("Error calling Delete %s", endpoint),
+			err.Error(),
+		)
+		return
+	}
+
+	stateConf := &retry.StateChangeConf{
+		Pending: []string{"DELETING"},
+		Target:  []string{"DELETED"},
+		Refresh: func() (interface{}, string, error) {
+			res := &CloudInstanceBackupAPIResponse{}
+			endpoint := "/v2/publicCloud/project/" + url.PathEscape(data.ServiceName.ValueString()) + "/compute/backup/" + url.PathEscape(data.Id.ValueString())
+			err := r.config.OVHClient.GetWithContext(ctx, endpoint, res)
+			if err != nil {
+				if errOvh, ok := err.(*ovh.APIError); ok && errOvh.Code == 404 {
+					return res, "DELETED", nil
+				}
+				return res, "", err
+			}
+			return res, res.ResourceStatus, nil
+		},
+		Timeout:    20 * time.Minute,
+		Delay:      10 * time.Second,
+		MinTimeout: 5 * time.Second,
+	}
+
+	if _, err := stateConf.WaitForStateContext(ctx); err != nil {
+		resp.Diagnostics.AddError(
+			"Error waiting for instance backup to be deleted",
+			err.Error(),
+		)
+	}
+}
+
+func (r *cloudInstanceBackupResource) waitForInstanceBackupReady(ctx context.Context, serviceName, backupId string) (interface{}, error) {
+	stateConf := &retry.StateChangeConf{
+		Pending: []string{"CREATING", "UPDATING", "PENDING", "OUT_OF_SYNC"},
+		Target:  []string{"READY"},
+		Refresh: func() (interface{}, string, error) {
+			res := &CloudInstanceBackupAPIResponse{}
+			endpoint := "/v2/publicCloud/project/" + url.PathEscape(serviceName) + "/compute/backup/" + url.PathEscape(backupId)
+			err := r.config.OVHClient.GetWithContext(ctx, endpoint, res)
+			if err != nil {
+				return res, "", err
+			}
+			return res, res.ResourceStatus, nil
+		},
+		Timeout:    20 * time.Minute,
+		Delay:      10 * time.Second,
+		MinTimeout: 5 * time.Second,
+	}
+
+	return stateConf.WaitForStateContext(ctx)
+}

--- a/ovh/resource_cloud_instance_backup_test.go
+++ b/ovh/resource_cloud_instance_backup_test.go
@@ -1,0 +1,96 @@
+package ovh
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+)
+
+func testAccCloudInstanceBackupConfig(serviceName, region, flavorID, imageID, instanceName, backupName string) string {
+	return fmt.Sprintf(`
+resource "ovh_cloud_instance" "instance" {
+  service_name = "%s"
+  region       = "%s"
+  name         = "%s"
+  flavor_id    = "%s"
+  image_id     = "%s"
+
+  networks = [
+    { auto_assign_public_ip = true },
+  ]
+}
+
+resource "ovh_cloud_instance_backup" "backup" {
+  service_name = "%s"
+  name         = "%s"
+  region       = "%s"
+  instance_id  = ovh_cloud_instance.instance.id
+}
+`, serviceName, region, instanceName, flavorID, imageID, serviceName, backupName, region)
+}
+
+func TestAccCloudInstanceBackup_basic(t *testing.T) {
+	serviceName := os.Getenv("OVH_CLOUD_PROJECT_SERVICE_TEST")
+	region := os.Getenv("OVH_CLOUD_PROJECT_REGION_TEST")
+	flavorID := resolveInstanceFlavorID(t, serviceName, region, testAccInstanceFlavorName)
+	imageID := resolveInstanceImageID(t, serviceName, region, testAccInstanceImageName)
+	instanceName := acctest.RandomWithPrefix(test_prefix)
+	backupName := acctest.RandomWithPrefix(test_prefix)
+	backupNameUpdated := acctest.RandomWithPrefix(test_prefix)
+
+	config := testAccCloudInstanceBackupConfig(serviceName, region, flavorID, imageID, instanceName, backupName)
+	configUpdated := testAccCloudInstanceBackupConfig(serviceName, region, flavorID, imageID, instanceName, backupNameUpdated)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheckCloudInstanceV2(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("ovh_cloud_instance_backup.backup", "service_name", serviceName),
+					resource.TestCheckResourceAttr("ovh_cloud_instance_backup.backup", "name", backupName),
+					resource.TestCheckResourceAttr("ovh_cloud_instance_backup.backup", "region", region),
+					resource.TestCheckResourceAttr("ovh_cloud_instance_backup.backup", "resource_status", "READY"),
+					resource.TestCheckResourceAttrSet("ovh_cloud_instance_backup.backup", "id"),
+					resource.TestCheckResourceAttrSet("ovh_cloud_instance_backup.backup", "checksum"),
+					resource.TestCheckResourceAttrSet("ovh_cloud_instance_backup.backup", "created_at"),
+					resource.TestCheckResourceAttrSet("ovh_cloud_instance_backup.backup", "instance_id"),
+					resource.TestCheckResourceAttrSet("ovh_cloud_instance_backup.backup", "current_state.name"),
+					resource.TestCheckResourceAttrSet("ovh_cloud_instance_backup.backup", "current_state.instance.id"),
+				),
+			},
+			{
+				Config: configUpdated,
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction("ovh_cloud_instance_backup.backup", plancheck.ResourceActionReplace),
+					},
+				},
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("ovh_cloud_instance_backup.backup", "name", backupNameUpdated),
+					resource.TestCheckResourceAttr("ovh_cloud_instance_backup.backup", "resource_status", "READY"),
+					resource.TestCheckResourceAttrSet("ovh_cloud_instance_backup.backup", "id"),
+					resource.TestCheckResourceAttrSet("ovh_cloud_instance_backup.backup", "checksum"),
+				),
+			},
+			{
+				ResourceName:      "ovh_cloud_instance_backup.backup",
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: func(state *terraform.State) (string, error) {
+					return fmt.Sprintf(
+						"%s/%s",
+						state.RootModule().Resources["ovh_cloud_instance_backup.backup"].Primary.Attributes["service_name"],
+						state.RootModule().Resources["ovh_cloud_instance_backup.backup"].Primary.Attributes["id"],
+					), nil
+				},
+			},
+		},
+	})
+}

--- a/ovh/types_cloud_instance_backup.go
+++ b/ovh/types_cloud_instance_backup.go
@@ -1,0 +1,145 @@
+package ovh
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	ovhtypes "github.com/ovh/terraform-provider-ovh/v2/ovh/types"
+)
+
+type CloudInstanceBackupModel struct {
+	ServiceName ovhtypes.TfStringValue `tfsdk:"service_name"`
+	Region      ovhtypes.TfStringValue `tfsdk:"region"`
+	InstanceId  ovhtypes.TfStringValue `tfsdk:"instance_id"`
+	Name        ovhtypes.TfStringValue `tfsdk:"name"`
+
+	Id             ovhtypes.TfStringValue `tfsdk:"id"`
+	Checksum       ovhtypes.TfStringValue `tfsdk:"checksum"`
+	CreatedAt      ovhtypes.TfStringValue `tfsdk:"created_at"`
+	UpdatedAt      ovhtypes.TfStringValue `tfsdk:"updated_at"`
+	ResourceStatus ovhtypes.TfStringValue `tfsdk:"resource_status"`
+	CurrentState   types.Object           `tfsdk:"current_state"`
+}
+
+type CloudInstanceBackupAPIResponse struct {
+	Id             string                           `json:"id"`
+	Checksum       string                           `json:"checksum"`
+	CreatedAt      string                           `json:"createdAt"`
+	UpdatedAt      string                           `json:"updatedAt"`
+	ResourceStatus string                           `json:"resourceStatus"`
+	CurrentState   *CloudInstanceBackupCurrentState `json:"currentState,omitempty"`
+	TargetSpec     *CloudInstanceBackupTargetSpec   `json:"targetSpec,omitempty"`
+}
+
+type CloudInstanceBackupCurrentState struct {
+	Instance   *CloudInstanceBackupInstanceRef `json:"instance,omitempty"`
+	Location   *CloudInstanceBackupLocation    `json:"location,omitempty"`
+	MinDisk    int64                           `json:"minDisk,omitempty"`
+	MinRam     int64                           `json:"minRam,omitempty"`
+	Name       string                          `json:"name,omitempty"`
+	Size       int64                           `json:"size,omitempty"`
+	Status     string                          `json:"status,omitempty"`
+	Visibility string                          `json:"visibility,omitempty"`
+}
+
+type CloudInstanceBackupTargetSpec struct {
+	Instance *CloudInstanceBackupInstanceRef `json:"instance,omitempty"`
+	Location *CloudInstanceBackupLocation    `json:"location,omitempty"`
+	Name     string                          `json:"name,omitempty"`
+}
+
+type CloudInstanceBackupInstanceRef struct {
+	Id string `json:"id,omitempty"`
+}
+
+type CloudInstanceBackupLocation struct {
+	Region string `json:"region,omitempty"`
+}
+
+type CloudInstanceBackupCreatePayload struct {
+	TargetSpec *CloudInstanceBackupTargetSpec `json:"targetSpec"`
+}
+
+func (m *CloudInstanceBackupModel) ToCreate() *CloudInstanceBackupCreatePayload {
+	return &CloudInstanceBackupCreatePayload{
+		TargetSpec: &CloudInstanceBackupTargetSpec{
+			Instance: &CloudInstanceBackupInstanceRef{Id: m.InstanceId.ValueString()},
+			Location: &CloudInstanceBackupLocation{Region: m.Region.ValueString()},
+			Name:     m.Name.ValueString(),
+		},
+	}
+}
+
+func InstanceBackupCurrentStateAttrTypes() map[string]attr.Type {
+	return map[string]attr.Type{
+		"instance":   types.ObjectType{AttrTypes: map[string]attr.Type{"id": ovhtypes.TfStringType{}}},
+		"location":   types.ObjectType{AttrTypes: map[string]attr.Type{"region": ovhtypes.TfStringType{}}},
+		"min_disk":   types.Int64Type,
+		"min_ram":    types.Int64Type,
+		"name":       ovhtypes.TfStringType{},
+		"size":       types.Int64Type,
+		"status":     ovhtypes.TfStringType{},
+		"visibility": ovhtypes.TfStringType{},
+	}
+}
+
+func (m *CloudInstanceBackupModel) MergeWith(ctx context.Context, response *CloudInstanceBackupAPIResponse) {
+	m.Id = ovhtypes.TfStringValue{StringValue: types.StringValue(response.Id)}
+	m.Checksum = ovhtypes.TfStringValue{StringValue: types.StringValue(response.Checksum)}
+	m.CreatedAt = ovhtypes.TfStringValue{StringValue: types.StringValue(response.CreatedAt)}
+	m.UpdatedAt = ovhtypes.TfStringValue{StringValue: types.StringValue(response.UpdatedAt)}
+	m.ResourceStatus = ovhtypes.TfStringValue{StringValue: types.StringValue(response.ResourceStatus)}
+
+	if response.CurrentState != nil {
+		instanceAttrTypes := map[string]attr.Type{"id": ovhtypes.TfStringType{}}
+		var instanceObj types.Object
+		if response.CurrentState.Instance != nil {
+			instanceObj, _ = types.ObjectValue(
+				instanceAttrTypes,
+				map[string]attr.Value{"id": ovhtypes.TfStringValue{StringValue: types.StringValue(response.CurrentState.Instance.Id)}},
+			)
+		} else {
+			instanceObj = types.ObjectNull(instanceAttrTypes)
+		}
+
+		locationAttrTypes := map[string]attr.Type{"region": ovhtypes.TfStringType{}}
+		var locObj types.Object
+		if response.CurrentState.Location != nil {
+			locObj, _ = types.ObjectValue(
+				locationAttrTypes,
+				map[string]attr.Value{"region": ovhtypes.TfStringValue{StringValue: types.StringValue(response.CurrentState.Location.Region)}},
+			)
+		} else {
+			locObj = types.ObjectNull(locationAttrTypes)
+		}
+
+		currentStateObj, _ := types.ObjectValue(
+			InstanceBackupCurrentStateAttrTypes(),
+			map[string]attr.Value{
+				"instance":   instanceObj,
+				"location":   locObj,
+				"min_disk":   types.Int64Value(response.CurrentState.MinDisk),
+				"min_ram":    types.Int64Value(response.CurrentState.MinRam),
+				"name":       ovhtypes.TfStringValue{StringValue: types.StringValue(response.CurrentState.Name)},
+				"size":       types.Int64Value(response.CurrentState.Size),
+				"status":     ovhtypes.TfStringValue{StringValue: types.StringValue(response.CurrentState.Status)},
+				"visibility": ovhtypes.TfStringValue{StringValue: types.StringValue(response.CurrentState.Visibility)},
+			},
+		)
+
+		m.CurrentState = currentStateObj
+	} else {
+		m.CurrentState = types.ObjectNull(InstanceBackupCurrentStateAttrTypes())
+	}
+
+	if response.TargetSpec != nil {
+		if response.TargetSpec.Location != nil {
+			m.Region = ovhtypes.TfStringValue{StringValue: types.StringValue(response.TargetSpec.Location.Region)}
+		}
+		if response.TargetSpec.Instance != nil {
+			m.InstanceId = ovhtypes.TfStringValue{StringValue: types.StringValue(response.TargetSpec.Instance.Id)}
+		}
+		m.Name = ovhtypes.TfStringValue{StringValue: types.StringValue(response.TargetSpec.Name)}
+	}
+}


### PR DESCRIPTION
Description

Added resource:
- ovh_cloud_instance_backup

Added datasources:
- ovh_cloud_instance_backup
- ovh_cloud_instance_backups 


Type of change

- New feature (non-breaking change which adds functionality)

How Has This Been Tested?

```sh
$ make testacc TEST=./ovh TESTARGS='-run "TestAccCloudInstanceBackup|TestAccDataSourceCloudInstanceBackup"'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./ovh -v -run "TestAccCloudInstanceBackup|TestAccDataSourceCloudInstanceBackup" -timeout 600m -p 10
--- PASS: TestAccDataSourceCloudInstanceBackup_basic (232.25s)
=== RUN   TestAccDataSourceCloudInstanceBackups_basic
--- PASS: TestAccDataSourceCloudInstanceBackups_basic (221.70s)
=== RUN   TestAccCloudInstanceBackup_basic
--- PASS: TestAccCloudInstanceBackup_basic (288.87s)
PASS
ok      github.com/ovh/terraform-provider-ovh/v2/ovh    742.845s
```


Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or issues
- [x] I have added acceptance tests that prove my fix is effective or that my feature works
- [x] New and existing acceptance tests pass locally with my changes
- [x] I ran successfully go mod vendor if I added or modify go.mod file
