### PR TITLE
feat(hosting_privatedatabase): add webhosting network resource

### DIFF
--- a/docs/resources/hosting_privatedatabase_webhosting_network.md
+++ b/docs/resources/hosting_privatedatabase_webhosting_network.md
@@ -1,0 +1,41 @@
+---
+subcategory : "Web Cloud Private SQL"
+---
+
+# ovh_hosting_privatedatabase_webhosting_network
+
+Allow or deny the OVHcloud webhosting network to connect to your private database.
+
+A private database has this access enabled, so `enabled = true` matches the state of a brand new
+instance and does nothing. Destroying the resource restores that default rather than leaving the
+access closed.
+
+## Example Usage
+
+```terraform
+resource "ovh_hosting_privatedatabase_webhosting_network" "network" {
+  service_name = "XXXXXX"
+  enabled      = false
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `service_name` - (Required) The internal name of your private database.
+* `enabled` - (Required) Allow the OVHcloud webhosting network to connect to the private database. Values can be `true` or `false`
+
+## Attributes Reference
+
+* `status` - Webhosting network status (`disabled`, `disabling`, `enabled` or `enabling`)
+
+The id is set to the value of `service_name`.
+
+## Import
+
+The webhosting network access can be imported using the `service_name`. E.g.,
+
+```
+$ terraform import ovh_hosting_privatedatabase_webhosting_network.network service_name
+```

--- a/examples/resources/hosting_privatedatabase_webhosting_network/example_1.tf
+++ b/examples/resources/hosting_privatedatabase_webhosting_network/example_1.tf
@@ -1,0 +1,4 @@
+resource "ovh_hosting_privatedatabase_webhosting_network" "network" {
+  service_name = "XXXXXX"
+  enabled      = false
+}

--- a/ovh/provider_new.go
+++ b/ovh/provider_new.go
@@ -393,6 +393,7 @@ func (p *OvhProvider) Resources(_ context.Context) []func() resource.Resource {
 		NewEmailDomainAccountResource,
 		NewDomainZoneDynhostLoginResource,
 		NewDomainZoneDynhostRecordResource,
+		NewHostingPrivateDatabaseWebhostingNetworkResource,
 		NewIpFirewallResource,
 		NewIpFirewallRuleResource,
 		NewIploadbalancingSslResource,

--- a/ovh/provider_test.go
+++ b/ovh/provider_test.go
@@ -202,6 +202,13 @@ func testAccPreCheckHostingPrivateDatabaseWhitelist(t *testing.T) {
 	checkEnvOrSkip(t, "OVH_HOSTING_PRIVATEDATABASE_WHITELIST_SFTP_TEST")
 }
 
+// Checks that the environment variables needed for the /hosting/privatedatabase acceptance tests
+// are set.
+func testAccPreCheckHostingPrivateDatabaseWebhostingNetwork(t *testing.T) {
+	testAccPreCheckCredentials(t)
+	checkEnvOrSkip(t, "OVH_HOSTING_PRIVATEDATABASE_SERVICE_TEST")
+}
+
 // Checks that the environment variables needed for the /dbaas acceptance tests
 // are set.
 func testAccPreCheckDbaasLogs(t *testing.T) {

--- a/ovh/resource_hosting_privatedatabase_webhosting_network.go
+++ b/ovh/resource_hosting_privatedatabase_webhosting_network.go
@@ -1,0 +1,314 @@
+package ovh
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/url"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
+	"github.com/ovh/go-ovh/ovh"
+	ovhtypes "github.com/ovh/terraform-provider-ovh/v2/ovh/types"
+)
+
+const (
+	hostingPrivateDatabaseWebhostingNetworkEnabled   = "enabled"
+	hostingPrivateDatabaseWebhostingNetworkEnabling  = "enabling"
+	hostingPrivateDatabaseWebhostingNetworkDisabled  = "disabled"
+	hostingPrivateDatabaseWebhostingNetworkDisabling = "disabling"
+
+	hostingPrivateDatabaseWebhostingNetworkTimeout = 2 * time.Minute
+)
+
+var (
+	_ resource.Resource                = (*hostingPrivateDatabaseWebhostingNetworkResource)(nil)
+	_ resource.ResourceWithConfigure   = (*hostingPrivateDatabaseWebhostingNetworkResource)(nil)
+	_ resource.ResourceWithImportState = (*hostingPrivateDatabaseWebhostingNetworkResource)(nil)
+)
+
+func NewHostingPrivateDatabaseWebhostingNetworkResource() resource.Resource {
+	return &hostingPrivateDatabaseWebhostingNetworkResource{}
+}
+
+type hostingPrivateDatabaseWebhostingNetworkResource struct {
+	config *Config
+}
+
+// HostingPrivateDatabaseWebhostingNetwork is the API representation of
+// /hosting/privateDatabase/{serviceName}/webhostingNetwork. The GET returns the status of the
+// access, while the POST and the DELETE return the task in charge of the change.
+type HostingPrivateDatabaseWebhostingNetwork struct {
+	Status string `json:"status,omitempty"`
+	TaskId int    `json:"id,omitempty"`
+}
+
+type HostingPrivateDatabaseWebhostingNetworkModel struct {
+	ID          ovhtypes.TfStringValue `tfsdk:"id"`
+	ServiceName ovhtypes.TfStringValue `tfsdk:"service_name"`
+	Enabled     ovhtypes.TfBoolValue   `tfsdk:"enabled"`
+	Status      ovhtypes.TfStringValue `tfsdk:"status"`
+}
+
+func (r *hostingPrivateDatabaseWebhostingNetworkResource) Metadata(ctx context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_hosting_privatedatabase_webhosting_network"
+}
+
+func (r *hostingPrivateDatabaseWebhostingNetworkResource) Configure(ctx context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+
+	config, ok := req.ProviderData.(*Config)
+	if !ok {
+		resp.Diagnostics.AddError(
+			"Unexpected Resource Configure Type",
+			fmt.Sprintf("Expected *Config, got: %T. Please report this issue to the provider developers.", req.ProviderData),
+		)
+		return
+	}
+
+	r.config = config
+}
+
+func (r *hostingPrivateDatabaseWebhostingNetworkResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Description: "Allow or deny the OVHcloud webhosting network to reach a private database.",
+		Attributes: map[string]schema.Attribute{
+			"service_name": schema.StringAttribute{
+				CustomType:          ovhtypes.TfStringType{},
+				Required:            true,
+				Description:         "The internal name of your private database",
+				MarkdownDescription: "The internal name of your private database",
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+			},
+			"enabled": schema.BoolAttribute{
+				CustomType:          ovhtypes.TfBoolType{},
+				Required:            true,
+				Description:         "Allow the OVHcloud webhosting network to connect to the private database. A new private database has it enabled",
+				MarkdownDescription: "Allow the OVHcloud webhosting network to connect to the private database. A new private database has it enabled",
+			},
+			"status": schema.StringAttribute{
+				CustomType:          ovhtypes.TfStringType{},
+				Computed:            true,
+				Description:         "Webhosting network status",
+				MarkdownDescription: "Webhosting network status",
+			},
+			"id": schema.StringAttribute{
+				CustomType:          ovhtypes.TfStringType{},
+				Computed:            true,
+				Description:         "Unique identifier for the resource",
+				MarkdownDescription: "Unique identifier for the resource",
+			},
+		},
+	}
+}
+
+func hostingPrivateDatabaseWebhostingNetworkEndpoint(serviceName string) string {
+	return "/hosting/privateDatabase/" + url.PathEscape(serviceName) + "/webhostingNetwork"
+}
+
+// hostingPrivateDatabaseWebhostingNetworkIsEnabled maps an API status to the enabled flag, a
+// transient status being reported as the state it is heading to.
+func hostingPrivateDatabaseWebhostingNetworkIsEnabled(status string) bool {
+	return status == hostingPrivateDatabaseWebhostingNetworkEnabled ||
+		status == hostingPrivateDatabaseWebhostingNetworkEnabling
+}
+
+func (r *hostingPrivateDatabaseWebhostingNetworkResource) getStatus(serviceName string) (string, error) {
+	var res HostingPrivateDatabaseWebhostingNetwork
+
+	endpoint := hostingPrivateDatabaseWebhostingNetworkEndpoint(serviceName)
+	if err := r.config.OVHClient.Get(endpoint, &res); err != nil {
+		return "", fmt.Errorf("error calling Get %s: %w", endpoint, err)
+	}
+
+	return res.Status, nil
+}
+
+// waitForStableStatus waits for the API to leave the enabling and disabling transient statuses.
+func (r *hostingPrivateDatabaseWebhostingNetworkResource) waitForStableStatus(ctx context.Context, serviceName string) (string, error) {
+	var status string
+
+	err := retry.RetryContext(ctx, hostingPrivateDatabaseWebhostingNetworkTimeout, func() *retry.RetryError {
+		var err error
+
+		status, err = r.getStatus(serviceName)
+		if err != nil {
+			return retry.NonRetryableError(err)
+		}
+
+		switch status {
+		case hostingPrivateDatabaseWebhostingNetworkEnabled, hostingPrivateDatabaseWebhostingNetworkDisabled:
+			return nil
+		default:
+			return retry.RetryableError(fmt.Errorf("webhosting network of %s is %s", serviceName, status))
+		}
+	})
+
+	return status, err
+}
+
+// apply brings the webhosting network access to the wanted state and returns the reached status.
+// Nothing is sent to the API when the wanted state is already the current one, so that a resource
+// created on a brand new private database, where the access is enabled by default, is a no-op.
+func (r *hostingPrivateDatabaseWebhostingNetworkResource) apply(ctx context.Context, serviceName string, enabled bool) (string, error) {
+	status, err := r.waitForStableStatus(ctx, serviceName)
+	if err != nil {
+		return "", err
+	}
+
+	wanted := hostingPrivateDatabaseWebhostingNetworkDisabled
+	if enabled {
+		wanted = hostingPrivateDatabaseWebhostingNetworkEnabled
+	}
+
+	if status == wanted {
+		return status, nil
+	}
+
+	var task HostingPrivateDatabaseWebhostingNetwork
+	endpoint := hostingPrivateDatabaseWebhostingNetworkEndpoint(serviceName)
+
+	if enabled {
+		err = r.config.OVHClient.Post(endpoint, nil, &task)
+	} else {
+		err = r.config.OVHClient.Delete(endpoint, &task)
+	}
+	if err != nil {
+		return "", fmt.Errorf("error calling %s: %w", endpoint, err)
+	}
+
+	taskEndpoint := fmt.Sprintf("/hosting/privateDatabase/%s/tasks/%d", url.PathEscape(serviceName), task.TaskId)
+	if err := WaitArchivedHostingPrivateDabaseTask(r.config.OVHClient, taskEndpoint, hostingPrivateDatabaseWebhostingNetworkTimeout); err != nil {
+		return "", fmt.Errorf("error waiting for task %s: %w", taskEndpoint, err)
+	}
+
+	return r.waitForStableStatus(ctx, serviceName)
+}
+
+func (r *hostingPrivateDatabaseWebhostingNetworkResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	var data HostingPrivateDatabaseWebhostingNetworkModel
+
+	// Read Terraform plan data into the model
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	serviceName := data.ServiceName.ValueString()
+
+	status, err := r.apply(ctx, serviceName, data.Enabled.ValueBool())
+	if err != nil {
+		resp.Diagnostics.AddError(
+			fmt.Sprintf("Error setting the webhosting network access of %s", serviceName),
+			err.Error(),
+		)
+		return
+	}
+
+	data.ID = data.ServiceName
+	data.Status = ovhtypes.NewTfStringValue(status)
+
+	// Save data into Terraform state
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+func (r *hostingPrivateDatabaseWebhostingNetworkResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	var data HostingPrivateDatabaseWebhostingNetworkModel
+
+	// Read Terraform prior state data into the model
+	resp.Diagnostics.Append(req.State.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	serviceName := data.ServiceName.ValueString()
+
+	status, err := r.getStatus(serviceName)
+	if err != nil {
+		// getStatus and apply wrap the client error, so unwrap it to reach the API error.
+		var errOvh *ovh.APIError
+		if errors.As(err, &errOvh) && errOvh.Code == 404 {
+			resp.State.RemoveResource(ctx)
+			return
+		}
+		resp.Diagnostics.AddError(
+			fmt.Sprintf("Error reading the webhosting network access of %s", serviceName),
+			err.Error(),
+		)
+		return
+	}
+
+	data.ID = data.ServiceName
+	data.Status = ovhtypes.NewTfStringValue(status)
+	data.Enabled = ovhtypes.NewTfBoolValue(hostingPrivateDatabaseWebhostingNetworkIsEnabled(status))
+
+	// Save updated data into Terraform state
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+func (r *hostingPrivateDatabaseWebhostingNetworkResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	var data HostingPrivateDatabaseWebhostingNetworkModel
+
+	// Read Terraform plan data into the model
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	serviceName := data.ServiceName.ValueString()
+
+	status, err := r.apply(ctx, serviceName, data.Enabled.ValueBool())
+	if err != nil {
+		resp.Diagnostics.AddError(
+			fmt.Sprintf("Error setting the webhosting network access of %s", serviceName),
+			err.Error(),
+		)
+		return
+	}
+
+	data.ID = data.ServiceName
+	data.Status = ovhtypes.NewTfStringValue(status)
+
+	// Save updated data into Terraform state
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+func (r *hostingPrivateDatabaseWebhostingNetworkResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	var data HostingPrivateDatabaseWebhostingNetworkModel
+
+	// Read Terraform prior state data into the model
+	resp.Diagnostics.Append(req.State.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	serviceName := data.ServiceName.ValueString()
+
+	// The webhosting network access is enabled by default on a private database, restore that
+	// default instead of leaving behind an access closed by a resource that no longer exists.
+	if _, err := r.apply(ctx, serviceName, true); err != nil {
+		// getStatus and apply wrap the client error, so unwrap it to reach the API error.
+		var errOvh *ovh.APIError
+		if errors.As(err, &errOvh) && errOvh.Code == 404 {
+			return
+		}
+		resp.Diagnostics.AddError(
+			fmt.Sprintf("Error restoring the webhosting network access of %s", serviceName),
+			err.Error(),
+		)
+	}
+}
+
+func (r *hostingPrivateDatabaseWebhostingNetworkResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("service_name"), req.ID)...)
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("id"), req.ID)...)
+}

--- a/ovh/resource_hosting_privatedatabase_webhosting_network_test.go
+++ b/ovh/resource_hosting_privatedatabase_webhosting_network_test.go
@@ -1,0 +1,49 @@
+package ovh
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+const testAccHostingPrivateDatabaseWebhostingNetworkBasic = `
+resource "ovh_hosting_privatedatabase_webhosting_network" "network" {
+    service_name = "%s"
+    enabled      = %t
+}
+`
+
+func TestAccHostingPrivateDatabaseWebhostingNetwork_basic(t *testing.T) {
+	serviceName := os.Getenv("OVH_HOSTING_PRIVATEDATABASE_SERVICE_TEST")
+	resourceName := "ovh_hosting_privatedatabase_webhosting_network.network"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheckHostingPrivateDatabaseWebhostingNetwork(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(testAccHostingPrivateDatabaseWebhostingNetworkBasic, serviceName, false),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "service_name", serviceName),
+					resource.TestCheckResourceAttr(resourceName, "enabled", "false"),
+					resource.TestCheckResourceAttr(resourceName, "status", "disabled"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateId:     serviceName,
+				ImportStateVerify: true,
+			},
+			{
+				Config: fmt.Sprintf(testAccHostingPrivateDatabaseWebhostingNetworkBasic, serviceName, true),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "enabled", "true"),
+					resource.TestCheckResourceAttr(resourceName, "status", "enabled"),
+				),
+			},
+		},
+	})
+}

--- a/templates/resources/hosting_privatedatabase_webhosting_network.md.tmpl
+++ b/templates/resources/hosting_privatedatabase_webhosting_network.md.tmpl
@@ -1,0 +1,40 @@
+---
+subcategory : "Web Cloud Private SQL"
+---
+
+{{/* This template serves as a starting point for documentation generation, and can be customized with hardcoded values and/or doc gen templates.
+
+For example, the {{ .SchemaMarkdown }} template can be used to replace manual schema documentation if descriptions of schema attributes are added in the provider source code. */ -}}
+
+# ovh_hosting_privatedatabase_webhosting_network
+
+Allow or deny the OVHcloud webhosting network to connect to your private database.
+
+A private database has this access enabled, so `enabled = true` matches the state of a brand new
+instance and does nothing. Destroying the resource restores that default rather than leaving the
+access closed.
+
+## Example Usage
+
+{{tffile "examples/resources/hosting_privatedatabase_webhosting_network/example_1.tf"}}
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `service_name` - (Required) The internal name of your private database.
+* `enabled` - (Required) Allow the OVHcloud webhosting network to connect to the private database. Values can be `true` or `false`
+
+## Attributes Reference
+
+* `status` - Webhosting network status (`disabled`, `disabling`, `enabled` or `enabling`)
+
+The id is set to the value of `service_name`.
+
+## Import
+
+The webhosting network access can be imported using the `service_name`. E.g.,
+
+```
+$ terraform import ovh_hosting_privatedatabase_webhosting_network.network service_name
+```


### PR DESCRIPTION
# Description

Add the resource `ovh_hosting_privatedatabase_webhosting_network`, which manages whether the
OVHcloud webhosting network is allowed to reach a Web Cloud Databases instance, through
`/hosting/privateDatabase/{serviceName}/webhostingNetwork`.

The access is enabled by default on a private database, so the resource exposes an explicit
`enabled` boolean rather than relying on its own presence: applying `enabled = true` on a fresh
instance is a no-op, and `Delete` restores the platform default instead of leaving behind an access
closed by a resource that no longer exists. The transient `enabling` and `disabling` statuses are
awaited before and after each change, and the asynchronous `POST` and `DELETE` tasks are followed
through the existing `WaitArchivedHostingPrivateDabaseTask` helper.

**Motivation and context.** The API endpoint already exposes this setting, but it was unreachable
from Terraform: a user willing to close the webhosting network access on a Web Cloud Databases
instance had to do it from the control panel, which the next `terraform apply` could not see. The
request comes from an internal ticket, so there is no public issue to reference.

**Design note.** `ovh_domain_zone_dnssec` models a comparable enable/disable endpoint through the
mere presence of the resource. That pattern was deliberately not reused here: DNSSEC is disabled by
default, so "creating the resource" naturally means "enabling", whereas the webhosting network
access is *enabled* by default. A presence-based resource would therefore be unable to express the
only useful operation, which is disabling the access. Hence the explicit boolean, an in-place
`Update`, and a `RequiresReplace` limited to `service_name`.

No data source is added, to keep this pull request reviewable. No dependency change: `go.mod`,
`go.sum` and `vendor/` are untouched.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

The acceptance test is written and committed, but **has not been run yet**: it needs a real Web
Cloud Databases instance, which I do not have at hand. It drives the full cycle — disable, then
import, then re-enable:

- [ ] Test A: `make testacc TESTARGS="-run TestAccHostingPrivateDatabaseWebhostingNetwork_basic"`
      — requires the OVHcloud credentials plus `OVH_HOSTING_PRIVATEDATABASE_SERVICE_TEST` set to the
      service name of a Web Cloud Databases instance. Help running it against a test instance is
      welcome.

What has actually been verified locally:

- [x] `make build` / `go build ./...`, `go vet ./ovh/` and `gofmt -l ovh/` are clean
- [x] `go test ./ovh/ -run 'TestProvider$'` passes, so the schema of the new resource is valid and
      its registration in `provider_new.go` is consistent
- [x] the provider binary was exercised through a `dev_overrides` block: `terraform validate`
      succeeds on a valid configuration, an unknown attribute is rejected with *Unsupported
      argument*, and omitting `enabled` is rejected with *Missing required argument*. `terraform
      plan` then reaches the API and stops on credentials, which is as far as this setup goes.

**Test Configuration**:
* Terraform version: `Terraform v1.11.1 on darwin_arm64`
* Existing HCL configuration you used:
```hcl
resource "ovh_hosting_privatedatabase_webhosting_network" "network" {
  service_name = "XXXXXX"
  enabled      = false
}
```

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or issues
- [x] I have added acceptance tests that prove my fix is effective or that my feature works
- [ ] New and existing acceptance tests pass locally with my changes — the new acceptance test has
      not been run yet, see above
- [x] I ran successfully `go mod vendor` if I added or modify `go.mod` file — not applicable, no
      dependency change
