### PR TITLE
feat(config,provider): ability to specify some http headers

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -194,9 +194,21 @@ The following arguments are supported:
 
 * `user_agent_extra` - (Optional) Extra information to append at the end of the user-agent used when making API calls.
 
+* `http_headers` - (Optional) A map of extra HTTP headers to add to every request made to the OVH API. Example:
+
+```hcl
+provider "ovh" {
+  http_headers = {
+    foo = "bar"
+  }
+}
+```
+
+  If omitted, headers can instead be set via numbered `OVH_HTTP_HEADERS_0`, `OVH_HTTP_HEADERS_1`, ... environment variables, each formatted as a raw HTTP header line (e.g. `OVH_HTTP_HEADERS_0="foo: bar"`). This is mainly useful for injecting headers in acceptance tests (`make testacc`) without editing the test's provider configuration.
+
 * `api_rate_limit` - (Optional) Specify the API request rate limit, X operations by seconds. If omitted, unlimited.
 
-* `ignore_init_error` - (Optional) **⚠️ Use with caution and only if you know what you are doing.** If set to `true`, the provider will skip authentication validation during initialization. If omitted, the `OVH_IGNORE_INIT_ERROR` environment variable is used. This allows the provider to load even with invalid credentials, but any actual API calls will still fail. This is intended for development/testing purposes only where valid credentials are not available but the provider configuration must be present.
+* `ignore_init_error` - (Optional) **⚠️ Use with caution and only if you know what you are doing.** If set to `true`, the provider will not send the `/auth/details` validation request at all during initialization. If omitted, the `OVH_IGNORE_INIT_ERROR` environment variable is used. This allows the provider to load even with invalid or absent credentials, but any actual API calls will still fail unless the target endpoint doesn't require authentication. This is intended for development/testing purposes only where valid credentials are not available but the provider configuration must be present.
 
 ## Terraform State storage in an OVHcloud Object Storage (S3 compatibility)
 

--- a/ovh/config.go
+++ b/ovh/config.go
@@ -34,6 +34,9 @@ type Config struct {
 	// Extra user-agent information
 	UserAgentExtra string
 
+	// Extra HTTP headers to add to every request
+	HttpHeaders map[string]string
+
 	// Ignore initialization errors
 	IgnoreInitError bool
 
@@ -120,15 +123,18 @@ func (c *Config) loadAndValidate() error {
 			return fmt.Errorf("OVH client not initialized")
 		}
 
+		// Skip the /auth/details verification call entirely when
+		// OVH_IGNORE_INIT_ERROR=true, instead of sending it and discarding
+		// a failure, so no request is made at all (e.g. for endpoints that
+		// don't support this check).
+		if c.IgnoreInitError {
+			log.Printf("[WARN] ignore_init_error is set, skipping /auth/details validation")
+			// Leave c.authenticated=false so runtime calls may retry auth
+			return nil
+		}
+
 		var details OvhAuthDetails
 		if err := c.OVHClient.Get("/auth/details", &details); err != nil {
-			// Allow ignoring the /auth/details verification step when OVH_IGNORE_INIT_ERROR=true
-			// and using OAuth2 (ClientID provided).
-			if c.IgnoreInitError {
-				log.Printf("[WARN] Ignoring /auth/details verification error: %v", err)
-				// Leave c.authenticated=false so runtime calls may retry auth
-				return nil
-			}
 			c.authFailed = fmt.Errorf("OVH client seems to be misconfigured: %q", err)
 			return c.authFailed
 		}
@@ -163,8 +169,9 @@ func (c *Config) load() error {
 	}
 
 	// Chain transports: schemasVersion (adds X-Schemas-Version for /v2/ paths)
+	// → extra headers (adds user-configured HTTP headers)
 	// → logging (logs request/response) → original transport (sends over the wire).
-	httpClient.Transport = newSchemasVersionTransport(logging.NewTransport("OVH", httpClient.Transport))
+	httpClient.Transport = newSchemasVersionTransport(newHeadersTransport(c.HttpHeaders, logging.NewTransport("OVH", httpClient.Transport)))
 	c.OVHClient = ovhwrap.NewClient(targetClient, c.ApiRateLimit)
 	return nil
 }

--- a/ovh/headers_transport.go
+++ b/ovh/headers_transport.go
@@ -1,0 +1,61 @@
+package ovh
+
+import (
+	"fmt"
+	"net/http"
+	"os"
+	"strings"
+)
+
+// headersTransport is an http.RoundTripper middleware that injects a fixed
+// set of extra HTTP headers on every outgoing request.
+type headersTransport struct {
+	headers map[string]string
+	next    http.RoundTripper
+}
+
+func (t *headersTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	// Clone the request so we don't mutate the caller's original.
+	req = req.Clone(req.Context())
+	for k, v := range t.headers {
+		// Set the header key exactly as configured, bypassing
+		// http.Header.Set's canonicalization (e.g. "x-ovh-nic" would
+		// otherwise be rewritten to "X-Ovh-Nic" on the wire), since some
+		// upstream gateways match header names literally.
+		req.Header[k] = []string{v}
+	}
+	return t.next.RoundTrip(req)
+}
+
+// newHeadersTransport wraps the given RoundTripper with extra header
+// injection. If headers is empty, next is returned unchanged.
+func newHeadersTransport(headers map[string]string, next http.RoundTripper) http.RoundTripper {
+	if len(headers) == 0 {
+		return next
+	}
+	return &headersTransport{headers: headers, next: next}
+}
+
+// httpHeadersFromEnv reads extra HTTP headers from numbered
+// OVH_HTTP_HEADERS_N environment variables, each formatted like a raw HTTP
+// header line (e.g. OVH_HTTP_HEADERS_0="x-ovh-nic: ab123456-ovh"). It exists
+// so that headers can be injected without editing provider configuration,
+// e.g. from `make testacc`. Reading stops at the first unset index.
+func httpHeadersFromEnv() map[string]string {
+	headers := make(map[string]string)
+	for i := 0; ; i++ {
+		v, ok := os.LookupEnv(fmt.Sprintf("OVH_HTTP_HEADERS_%d", i))
+		if !ok {
+			break
+		}
+		k, val, found := strings.Cut(v, ":")
+		if !found {
+			continue
+		}
+		headers[strings.TrimSpace(k)] = strings.TrimSpace(val)
+	}
+	if len(headers) == 0 {
+		return nil
+	}
+	return headers
+}

--- a/ovh/provider.go
+++ b/ovh/provider.go
@@ -35,6 +35,9 @@ var (
 		// Extra info in user-agent
 		"user_agent_extra": "Extra information to append to the user-agent",
 
+		// Extra HTTP headers
+		"http_headers": "Extra HTTP headers to add to every request made to the OVH API",
+
 		// Ignore initialization errors
 		"ignore_init_error": "If set to true, initialization errors (like invalid OAuth credentials) will be ignored",
 
@@ -86,6 +89,12 @@ func Provider() *schema.Provider {
 				Type:        schema.TypeString,
 				Optional:    true,
 				Description: descriptions["user_agent_extra"],
+			},
+			"http_headers": {
+				Type:        schema.TypeMap,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+				Optional:    true,
+				Description: descriptions["http_headers"],
 			},
 			"ignore_init_error": {
 				Type:        schema.TypeBool,
@@ -345,6 +354,15 @@ func ConfigureContextFunc(context context.Context, d *schema.ResourceData) (inte
 	}
 	if v, ok := d.GetOk("user_agent_extra"); ok {
 		config.UserAgentExtra = v.(string)
+	}
+	if v, ok := d.GetOk("http_headers"); ok {
+		headers := make(map[string]string)
+		for k, val := range v.(map[string]interface{}) {
+			headers[k] = val.(string)
+		}
+		config.HttpHeaders = headers
+	} else if headers := httpHeadersFromEnv(); headers != nil {
+		config.HttpHeaders = headers
 	}
 	if v, ok := d.GetOk("ignore_init_error"); ok {
 		config.IgnoreInitError = v.(bool)

--- a/ovh/provider_new.go
+++ b/ovh/provider_new.go
@@ -71,6 +71,11 @@ func (p *OvhProvider) Schema(_ context.Context, _ provider.SchemaRequest, resp *
 				Optional:    true,
 				Description: descriptions["user_agent_extra"],
 			},
+			"http_headers": schema.MapAttribute{
+				ElementType: types.StringType,
+				Optional:    true,
+				Description: descriptions["http_headers"],
+			},
 			"ignore_init_error": schema.BoolAttribute{
 				Optional:    true,
 				Description: descriptions["ignore_init_error"],
@@ -194,6 +199,17 @@ func (p *OvhProvider) Configure(ctx context.Context, req provider.ConfigureReque
 	}
 	if !config.UserAgentExtra.IsNull() {
 		clientConfig.UserAgentExtra = config.UserAgentExtra.ValueString()
+	}
+	if !config.HttpHeaders.IsNull() {
+		headers := make(map[string]string, len(config.HttpHeaders.Elements()))
+		diags = config.HttpHeaders.ElementsAs(ctx, &headers, false)
+		resp.Diagnostics.Append(diags...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+		clientConfig.HttpHeaders = headers
+	} else if headers := httpHeadersFromEnv(); headers != nil {
+		clientConfig.HttpHeaders = headers
 	}
 	if !config.IgnoreInitError.IsNull() {
 		clientConfig.IgnoreInitError = config.IgnoreInitError.ValueBool()
@@ -432,6 +448,7 @@ type ovhProviderModel struct {
 	ClientID          types.String `tfsdk:"client_id"`
 	ClientSecret      types.String `tfsdk:"client_secret"`
 	UserAgentExtra    types.String `tfsdk:"user_agent_extra"`
+	HttpHeaders       types.Map    `tfsdk:"http_headers"`
 	IgnoreInitError   types.Bool   `tfsdk:"ignore_init_error"`
 	ApiRateLimit      types.Int32  `tfsdk:"api_rate_limit"`
 }

--- a/templates/index.md.tmpl
+++ b/templates/index.md.tmpl
@@ -146,9 +146,21 @@ The following arguments are supported:
 
 * `user_agent_extra` - (Optional) Extra information to append at the end of the user-agent used when making API calls.
 
+* `http_headers` - (Optional) A map of extra HTTP headers to add to every request made to the OVH API. Example:
+
+```hcl
+provider "ovh" {
+  http_headers = {
+    foo = "bar"
+  }
+}
+```
+
+  If omitted, headers can instead be set via numbered `OVH_HTTP_HEADERS_0`, `OVH_HTTP_HEADERS_1`, ... environment variables, each formatted as a raw HTTP header line (e.g. `OVH_HTTP_HEADERS_0="foo: bar"`). This is mainly useful for injecting headers in acceptance tests (`make testacc`) without editing the test's provider configuration.
+
 * `api_rate_limit` - (Optional) Specify the API request rate limit, X operations by seconds. If omitted, unlimited.
 
-* `ignore_init_error` - (Optional) **⚠️ Use with caution and only if you know what you are doing.** If set to `true`, the provider will skip authentication validation during initialization. If omitted, the `OVH_IGNORE_INIT_ERROR` environment variable is used. This allows the provider to load even with invalid credentials, but any actual API calls will still fail. This is intended for development/testing purposes only where valid credentials are not available but the provider configuration must be present.
+* `ignore_init_error` - (Optional) **⚠️ Use with caution and only if you know what you are doing.** If set to `true`, the provider will not send the `/auth/details` validation request at all during initialization. If omitted, the `OVH_IGNORE_INIT_ERROR` environment variable is used. This allows the provider to load even with invalid or absent credentials, but any actual API calls will still fail unless the target endpoint doesn't require authentication. This is intended for development/testing purposes only where valid credentials are not available but the provider configuration must be present.
 
 ## Terraform State storage in an OVHcloud Object Storage (S3 compatibility)
 


### PR DESCRIPTION
# Description

Ability to specify some http headers to be able to use terraform provider in some test environments

Fixes #1407 (issue)

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] Documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Test A: `make testacc TESTARGS="-run TestAccDedicatedServerReinstall_byolinux"`
```none
export OVH_ENDPOINT="http://internal-dev-gateway.example.com:55713/1.0"
export OVH_APPLICATION_KEY="toto"
export OVH_APPLICATION_SECRET="toto"
export OVH_CONSUMER_KEY="toto"
export OVH_IGNORE_INIT_ERROR=true
export OVH_HTTP_HEADERS_0="x-ovh-nic: xxxxxxxx-ovh"

make testacc --debug TESTARGS="-run TestAccDedicatedServerReinstall_byolinux"
GNU Make 4.3
Built for x86_64-pc-linux-gnu
Copyright (C) 1988-2020 Free Software Foundation, Inc.
License GPLv3+: GNU GPL version 3 or later <http://gnu.org/licenses/gpl.html>
This is free software: you are free to change and redistribute it.
There is NO WARRANTY, to the extent permitted by law.
Reading makefiles...
Updating makefiles....
Updating goal targets....
 File 'testacc' does not exist.
   File 'fmtcheck' does not exist.
  Must remake target 'fmtcheck'.
==> Checking that code complies with gofmt requirements...
  Successfully remade target file 'fmtcheck'.
Must remake target 'testacc'.
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -run TestAccDedicatedServerReinstall_byolinux -timeout 600m -p 10
?   	github.com/ovh/terraform-provider-ovh/v2	[no test files]
^C=== RUN   TestAccDedicatedServerReinstall_byolinux
signal: interrupt
FAIL	github.com/ovh/terraform-provider-ovh/v2/ovh	363.803s
?   	github.com/ovh/terraform-provider-ovh/v2/ovh/datasources/cloud_project_rancher	[no test files]
make: *** [GNUmakefile:17: testacc] Interrupt
```
And I see the task created in my custom endpoint environment

**Test Configuration**:
* Terraform version: `terraform version`: Terraform v1.12.2
* Existing HCL configuration you used: 
```hcl
resource "ovh_dedicated_server_reinstall_task" "server_reinstall" {
  service_name = "nsxxxxxxxxxxxxxxxxxx"
  os           = "debian13_64"
}
```
```none
TF_LOG=DEBUG terraform apply
2026-08-21T17:15:10.185+0200 [INFO]  Terraform version: 1.12.2
2026-08-21T17:15:10.186+0200 [DEBUG] using github.com/hashicorp/go-tfe v1.74.1
2026-08-21T17:15:10.186+0200 [DEBUG] using github.com/hashicorp/hcl/v2 v2.23.1-0.20250203194505-ba0759438da2
2026-08-21T17:15:10.186+0200 [DEBUG] using github.com/hashicorp/terraform-svchost v0.1.1
2026-08-21T17:15:10.186+0200 [DEBUG] using github.com/zclconf/go-cty v1.16.2
2026-08-21T17:15:10.186+0200 [INFO]  Go runtime version: go1.24.2
2026-08-21T17:15:10.186+0200 [INFO]  CLI args: []string{"terraform", "apply"}
2026-08-21T17:15:10.186+0200 [DEBUG] Attempting to open CLI config file: /home/user/.terraformrc
2026-08-21T17:15:10.186+0200 [INFO]  Loading CLI configuration from /home/user/.terraformrc
2026-08-21T17:15:10.186+0200 [DEBUG] checking for credentials in "/home/user/.terraform.d/plugins"
2026-08-21T17:15:10.186+0200 [DEBUG] Explicit provider installation configuration is set
2026-08-21T17:15:10.186+0200 [INFO]  CLI command args: []string{"apply"}
2026-08-21T17:15:10.187+0200 [DEBUG] Provider registry.terraform.io/ovh/ovh is overridden by dev_overrides
2026-08-21T17:15:10.187+0200 [DEBUG] Provider registry.terraform.io/ovh/ovh is overridden to load from /home/user/.go/bin
2026-08-21T17:15:10.188+0200 [DEBUG] checking for provisioner in "."
2026-08-21T17:15:10.188+0200 [DEBUG] checking for provisioner in "/home/user/.local/bin"
2026-08-21T17:15:10.188+0200 [DEBUG] checking for provisioner in "/home/user/.terraform.d/plugins"
2026-08-21T17:15:10.188+0200 [DEBUG] Provider registry.terraform.io/ovh/ovh is overridden by dev_overrides
╷
│ Warning: Provider development overrides are in effect
│ 
│ The following provider development overrides are set in the CLI configuration:
│  - ovh/ovh in /home/user/.go/bin
│ 
│ The behavior may therefore not match any released version of the provider and applying changes may cause the state to become incompatible with published releases.
╵
2026-08-21T17:15:10.188+0200 [INFO]  backend/local: starting Apply operation
2026-08-21T17:15:10.190+0200 [DEBUG] Config.VerifyDependencySelections: skipping registry.terraform.io/ovh/ovh because it's overridden by a special configuration setting
2026-08-21T17:15:10.190+0200 [DEBUG] created provider logger: level=debug
2026-08-21T17:15:10.190+0200 [INFO]  provider: configuring client automatic mTLS
2026-08-21T17:15:10.199+0200 [DEBUG] provider: starting plugin: path=/home/user/.go/bin/terraform-provider-ovh args=["/home/user/.go/bin/terraform-provider-ovh"]
2026-08-21T17:15:10.201+0200 [DEBUG] provider: plugin started: path=/home/user/.go/bin/terraform-provider-ovh pid=202552
2026-08-21T17:15:10.201+0200 [DEBUG] provider: waiting for RPC address: plugin=/home/user/.go/bin/terraform-provider-ovh
2026-08-21T17:15:10.208+0200 [INFO]  provider.terraform-provider-ovh: configuring server automatic mTLS: timestamp="2026-08-21T17:15:10.207+0200"
2026-08-21T17:15:10.218+0200 [DEBUG] provider.terraform-provider-ovh: plugin address: address=/tmp/plugin2188376866 network=unix timestamp="2026-08-21T17:15:10.218+0200"
2026-08-21T17:15:10.218+0200 [DEBUG] provider: using plugin: version=6
2026-08-21T17:15:10.266+0200 [DEBUG] provider.stdio: received EOF, stopping recv loop: err="rpc error: code = Unavailable desc = error reading from server: EOF"
2026-08-21T17:15:10.270+0200 [INFO]  provider: plugin process exited: plugin=/home/user/.go/bin/terraform-provider-ovh id=202552
2026-08-21T17:15:10.270+0200 [DEBUG] provider: plugin exited
2026-08-21T17:15:10.270+0200 [DEBUG] Building and walking validate graph
2026-08-21T17:15:10.270+0200 [DEBUG] ProviderTransformer: "ovh_dedicated_server_reinstall_task.server_reinstall" (*terraform.NodeValidatableResource) needs provider["registry.terraform.io/ovh/ovh"]
2026-08-21T17:15:10.270+0200 [DEBUG] ReferenceTransformer: "ovh_dedicated_server_reinstall_task.server_reinstall" references: []
2026-08-21T17:15:10.270+0200 [DEBUG] ReferenceTransformer: "provider[\"registry.terraform.io/ovh/ovh\"]" references: []
2026-08-21T17:15:10.270+0200 [DEBUG] Starting graph walk: walkValidate
2026-08-21T17:15:10.271+0200 [DEBUG] created provider logger: level=debug
2026-08-21T17:15:10.271+0200 [INFO]  provider: configuring client automatic mTLS
2026-08-21T17:15:10.274+0200 [DEBUG] provider: starting plugin: path=/home/user/.go/bin/terraform-provider-ovh args=["/home/user/.go/bin/terraform-provider-ovh"]
2026-08-21T17:15:10.275+0200 [DEBUG] provider: plugin started: path=/home/user/.go/bin/terraform-provider-ovh pid=202570
2026-08-21T17:15:10.275+0200 [DEBUG] provider: waiting for RPC address: plugin=/home/user/.go/bin/terraform-provider-ovh
2026-08-21T17:15:10.282+0200 [INFO]  provider.terraform-provider-ovh: configuring server automatic mTLS: timestamp="2026-08-21T17:15:10.282+0200"
2026-08-21T17:15:10.295+0200 [DEBUG] provider.terraform-provider-ovh: plugin address: address=/tmp/plugin779520328 network=unix timestamp="2026-08-21T17:15:10.294+0200"
2026-08-21T17:15:10.295+0200 [DEBUG] provider: using plugin: version=6
2026-08-21T17:15:10.310+0200 [DEBUG] provider.stdio: received EOF, stopping recv loop: err="rpc error: code = Unavailable desc = error reading from server: EOF"
2026-08-21T17:15:10.313+0200 [INFO]  provider: plugin process exited: plugin=/home/user/.go/bin/terraform-provider-ovh id=202570
2026-08-21T17:15:10.313+0200 [DEBUG] provider: plugin exited
2026-08-21T17:15:10.313+0200 [INFO]  backend/local: apply calling Plan
2026-08-21T17:15:10.313+0200 [DEBUG] Building and walking plan graph for NormalMode
2026-08-21T17:15:10.313+0200 [DEBUG] ProviderTransformer: "ovh_dedicated_server_reinstall_task.server_reinstall (expand)" (*terraform.nodeExpandPlannableResource) needs provider["registry.terraform.io/ovh/ovh"]
2026-08-21T17:15:10.313+0200 [DEBUG] ReferenceTransformer: "ovh_dedicated_server_reinstall_task.server_reinstall (expand)" references: []
2026-08-21T17:15:10.313+0200 [DEBUG] ReferenceTransformer: "provider[\"registry.terraform.io/ovh/ovh\"]" references: []
2026-08-21T17:15:10.313+0200 [DEBUG] Starting graph walk: walkPlan
2026-08-21T17:15:10.313+0200 [DEBUG] created provider logger: level=debug
2026-08-21T17:15:10.313+0200 [INFO]  provider: configuring client automatic mTLS
2026-08-21T17:15:10.317+0200 [DEBUG] provider: starting plugin: path=/home/user/.go/bin/terraform-provider-ovh args=["/home/user/.go/bin/terraform-provider-ovh"]
2026-08-21T17:15:10.318+0200 [DEBUG] provider: plugin started: path=/home/user/.go/bin/terraform-provider-ovh pid=202583
2026-08-21T17:15:10.318+0200 [DEBUG] provider: waiting for RPC address: plugin=/home/user/.go/bin/terraform-provider-ovh
2026-08-21T17:15:10.325+0200 [INFO]  provider.terraform-provider-ovh: configuring server automatic mTLS: timestamp="2026-08-21T17:15:10.325+0200"
2026-08-21T17:15:10.338+0200 [DEBUG] provider.terraform-provider-ovh: plugin address: network=unix address=/tmp/plugin4089158574 timestamp="2026-08-21T17:15:10.338+0200"
2026-08-21T17:15:10.338+0200 [DEBUG] provider: using plugin: version=6
2026-08-21T17:15:10.350+0200 [DEBUG] provider.terraform-provider-ovh: 2026/08/21 17:15:10 [WARN] ignore_init_error is set, skipping /auth/details validation
2026-08-21T17:15:10.351+0200 [DEBUG] provider.terraform-provider-ovh: 2026/08/21 17:15:10 [WARN] ignore_init_error is set, skipping /auth/details validation
2026-08-21T17:15:10.351+0200 [DEBUG] Resource instance state not found for node "ovh_dedicated_server_reinstall_task.server_reinstall", instance ovh_dedicated_server_reinstall_task.server_reinstall
2026-08-21T17:15:10.351+0200 [DEBUG] ReferenceTransformer: "ovh_dedicated_server_reinstall_task.server_reinstall" references: []
2026-08-21T17:15:10.351+0200 [DEBUG] refresh: ovh_dedicated_server_reinstall_task.server_reinstall: no state, so not refreshing
2026-08-21T17:15:10.356+0200 [DEBUG] provider.stdio: received EOF, stopping recv loop: err="rpc error: code = Unavailable desc = error reading from server: EOF"
2026-08-21T17:15:10.359+0200 [INFO]  provider: plugin process exited: plugin=/home/user/.go/bin/terraform-provider-ovh id=202583
2026-08-21T17:15:10.359+0200 [DEBUG] provider: plugin exited
2026-08-21T17:15:10.359+0200 [DEBUG] building apply graph to check for errors
2026-08-21T17:15:10.359+0200 [DEBUG] Resource state not found for node "ovh_dedicated_server_reinstall_task.server_reinstall", instance ovh_dedicated_server_reinstall_task.server_reinstall
2026-08-21T17:15:10.359+0200 [DEBUG] ProviderTransformer: "ovh_dedicated_server_reinstall_task.server_reinstall (expand)" (*terraform.nodeExpandApplyableResource) needs provider["registry.terraform.io/ovh/ovh"]
2026-08-21T17:15:10.359+0200 [DEBUG] ProviderTransformer: "ovh_dedicated_server_reinstall_task.server_reinstall" (*terraform.NodeApplyableResourceInstance) needs provider["registry.terraform.io/ovh/ovh"]
2026-08-21T17:15:10.360+0200 [DEBUG] ReferenceTransformer: "ovh_dedicated_server_reinstall_task.server_reinstall (expand)" references: []
2026-08-21T17:15:10.360+0200 [DEBUG] ReferenceTransformer: "ovh_dedicated_server_reinstall_task.server_reinstall" references: []
2026-08-21T17:15:10.360+0200 [DEBUG] ReferenceTransformer: "provider[\"registry.terraform.io/ovh/ovh\"]" references: []

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # ovh_dedicated_server_reinstall_task.server_reinstall will be created
  + resource "ovh_dedicated_server_reinstall_task" "server_reinstall" {
      + comment      = (known after apply)
      + done_date    = (known after apply)
      + function     = (known after apply)
      + id           = (known after apply)
      + last_update  = (known after apply)
      + os           = "debian13_64"
      + service_name = "nsxxxxxxxxxxxxxxxxxx"
      + start_date   = (known after apply)
      + status       = (known after apply)
    }

Plan: 1 to add, 0 to change, 0 to destroy.
2026-08-21T17:15:10.361+0200 [DEBUG] command: asking for input: "\nDo you want to perform these actions?"

Do you want to perform these actions?
  Terraform will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: yes

2026-08-21T17:15:14.164+0200 [INFO]  backend/local: apply calling Apply
2026-08-21T17:15:14.164+0200 [DEBUG] Building and walking apply graph for NormalMode plan
2026-08-21T17:15:14.164+0200 [DEBUG] Resource state not found for node "ovh_dedicated_server_reinstall_task.server_reinstall", instance ovh_dedicated_server_reinstall_task.server_reinstall
2026-08-21T17:15:14.164+0200 [DEBUG] ProviderTransformer: "ovh_dedicated_server_reinstall_task.server_reinstall (expand)" (*terraform.nodeExpandApplyableResource) needs provider["registry.terraform.io/ovh/ovh"]
2026-08-21T17:15:14.164+0200 [DEBUG] ProviderTransformer: "ovh_dedicated_server_reinstall_task.server_reinstall" (*terraform.NodeApplyableResourceInstance) needs provider["registry.terraform.io/ovh/ovh"]
2026-08-21T17:15:14.165+0200 [DEBUG] ReferenceTransformer: "ovh_dedicated_server_reinstall_task.server_reinstall (expand)" references: []
2026-08-21T17:15:14.165+0200 [DEBUG] ReferenceTransformer: "ovh_dedicated_server_reinstall_task.server_reinstall" references: []
2026-08-21T17:15:14.165+0200 [DEBUG] ReferenceTransformer: "provider[\"registry.terraform.io/ovh/ovh\"]" references: []
2026-08-21T17:15:14.165+0200 [DEBUG] Starting graph walk: walkApply
2026-08-21T17:15:14.165+0200 [DEBUG] created provider logger: level=debug
2026-08-21T17:15:14.165+0200 [INFO]  provider: configuring client automatic mTLS
2026-08-21T17:15:14.169+0200 [DEBUG] provider: starting plugin: path=/home/user/.go/bin/terraform-provider-ovh args=["/home/user/.go/bin/terraform-provider-ovh"]
2026-08-21T17:15:14.170+0200 [DEBUG] provider: plugin started: path=/home/user/.go/bin/terraform-provider-ovh pid=202601
2026-08-21T17:15:14.170+0200 [DEBUG] provider: waiting for RPC address: plugin=/home/user/.go/bin/terraform-provider-ovh
2026-08-21T17:15:14.178+0200 [INFO]  provider.terraform-provider-ovh: configuring server automatic mTLS: timestamp="2026-08-21T17:15:14.178+0200"
2026-08-21T17:15:14.190+0200 [DEBUG] provider.terraform-provider-ovh: plugin address: address=/tmp/plugin4284138743 network=unix timestamp="2026-08-21T17:15:14.190+0200"
2026-08-21T17:15:14.190+0200 [DEBUG] provider: using plugin: version=6
2026-08-21T17:15:14.204+0200 [DEBUG] provider.terraform-provider-ovh: 2026/08/21 17:15:14 [WARN] ignore_init_error is set, skipping /auth/details validation
2026-08-21T17:15:14.204+0200 [DEBUG] provider.terraform-provider-ovh: 2026/08/21 17:15:14 [WARN] ignore_init_error is set, skipping /auth/details validation
ovh_dedicated_server_reinstall_task.server_reinstall: Creating...
2026-08-21T17:15:14.209+0200 [INFO]  Starting apply for ovh_dedicated_server_reinstall_task.server_reinstall
2026-08-21T17:15:14.209+0200 [DEBUG] ovh_dedicated_server_reinstall_task.server_reinstall: applying the planned Create change
2026-08-21T17:15:14.210+0200 [DEBUG] provider.terraform-provider-ovh: 2026/08/21 17:15:14 [DEBUG] OVH API Request Details:
2026-08-21T17:15:14.210+0200 [DEBUG] provider.terraform-provider-ovh: ---[ REQUEST ]---------------------------------------
2026-08-21T17:15:14.210+0200 [DEBUG] provider.terraform-provider-ovh: GET /1.0/auth/time HTTP/1.1
2026-08-21T17:15:14.210+0200 [DEBUG] provider.terraform-provider-ovh: Host: internal-dev-gateway.example.com:55713
2026-08-21T17:15:14.210+0200 [DEBUG] provider.terraform-provider-ovh: User-Agent: github.com/ovh/go-ovh (Terraform//)
2026-08-21T17:15:14.210+0200 [DEBUG] provider.terraform-provider-ovh: Accept: application/json
2026-08-21T17:15:14.210+0200 [DEBUG] provider.terraform-provider-ovh: X-Ovh-Application: toto
2026-08-21T17:15:14.210+0200 [DEBUG] provider.terraform-provider-ovh: x-ovh-nic: xxxxxxxx-ovh
2026-08-21T17:15:14.210+0200 [DEBUG] provider.terraform-provider-ovh: Accept-Encoding: gzip
2026-08-21T17:15:14.210+0200 [DEBUG] provider.terraform-provider-ovh
2026-08-21T17:15:14.210+0200 [DEBUG] provider.terraform-provider-ovh
2026-08-21T17:15:14.210+0200 [DEBUG] provider.terraform-provider-ovh: -----------------------------------------------------
2026-08-21T17:15:14.231+0200 [DEBUG] provider.terraform-provider-ovh: 2026/08/21 17:15:14 [DEBUG] OVH API Response Details:
2026-08-21T17:15:14.231+0200 [DEBUG] provider.terraform-provider-ovh: ---[ RESPONSE ]--------------------------------------
2026-08-21T17:15:14.231+0200 [DEBUG] provider.terraform-provider-ovh: HTTP/1.1 200 OK
2026-08-21T17:15:14.231+0200 [DEBUG] provider.terraform-provider-ovh: Connection: close
2026-08-21T17:15:14.231+0200 [DEBUG] provider.terraform-provider-ovh: Content-Length: 10
2026-08-21T17:15:14.231+0200 [DEBUG] provider.terraform-provider-ovh: Access-Control-Allow-Headers: X-Ovh-Nic, X-Ovh-Timestamp, X-Ovh-Consumer, X-Ovh-Application, X-Ovh-Signature, X-Ovh-Session, Authorization, Content-Type
2026-08-21T17:15:14.231+0200 [DEBUG] provider.terraform-provider-ovh: Access-Control-Allow-Methods: GET
2026-08-21T17:15:14.231+0200 [DEBUG] provider.terraform-provider-ovh: Access-Control-Allow-Origin: *
2026-08-21T17:15:14.231+0200 [DEBUG] provider.terraform-provider-ovh: Cache-Control: no-cache, no-store
2026-08-21T17:15:14.231+0200 [DEBUG] provider.terraform-provider-ovh: Content-Type: application/json; charset=utf-8
2026-08-21T17:15:14.231+0200 [DEBUG] provider.terraform-provider-ovh: Date: Fri, 21 Aug 2026 15:15:14 GMT
2026-08-21T17:15:14.231+0200 [DEBUG] provider.terraform-provider-ovh: X-Ovh-Queryid: SDEV.6a886b82.41.8396959a-eeca-4f30-8382-8b739b14ff7b
2026-08-21T17:15:14.231+0200 [DEBUG] provider.terraform-provider-ovh
2026-08-21T17:15:14.231+0200 [DEBUG] provider.terraform-provider-ovh: 1787325314
2026-08-21T17:15:14.231+0200 [DEBUG] provider.terraform-provider-ovh: -----------------------------------------------------
2026-08-21T17:15:14.231+0200 [DEBUG] provider.terraform-provider-ovh: 2026/08/21 17:15:14 [DEBUG] OVH API Request Details:
2026-08-21T17:15:14.231+0200 [DEBUG] provider.terraform-provider-ovh: ---[ REQUEST ]---------------------------------------
2026-08-21T17:15:14.231+0200 [DEBUG] provider.terraform-provider-ovh: POST /1.0/dedicated/server/nsxxxxxxxxxxxxxxxxxx/reinstall HTTP/1.1
2026-08-21T17:15:14.231+0200 [DEBUG] provider.terraform-provider-ovh: Host: internal-dev-gateway.example.com:55713
2026-08-21T17:15:14.231+0200 [DEBUG] provider.terraform-provider-ovh: User-Agent: github.com/ovh/go-ovh (Terraform//)
2026-08-21T17:15:14.231+0200 [DEBUG] provider.terraform-provider-ovh: Content-Length: 33
2026-08-21T17:15:14.231+0200 [DEBUG] provider.terraform-provider-ovh: Accept: application/json
2026-08-21T17:15:14.231+0200 [DEBUG] provider.terraform-provider-ovh: Content-Type: application/json;charset=utf-8
2026-08-21T17:15:14.231+0200 [DEBUG] provider.terraform-provider-ovh: X-Ovh-Application: toto
2026-08-21T17:15:14.231+0200 [DEBUG] provider.terraform-provider-ovh: X-Ovh-Consumer: toto
2026-08-21T17:15:14.231+0200 [DEBUG] provider.terraform-provider-ovh: X-Ovh-Signature: xxxxxxxxx
2026-08-21T17:15:14.231+0200 [DEBUG] provider.terraform-provider-ovh: X-Ovh-Timestamp: 1787325314
2026-08-21T17:15:14.231+0200 [DEBUG] provider.terraform-provider-ovh: x-ovh-nic: xxxxxxxx-ovh
2026-08-21T17:15:14.231+0200 [DEBUG] provider.terraform-provider-ovh: Accept-Encoding: gzip
2026-08-21T17:15:14.231+0200 [DEBUG] provider.terraform-provider-ovh
2026-08-21T17:15:14.231+0200 [DEBUG] provider.terraform-provider-ovh: {
2026-08-21T17:15:14.231+0200 [DEBUG] provider.terraform-provider-ovh:  "operatingSystem": "debian13_64"
2026-08-21T17:15:14.231+0200 [DEBUG] provider.terraform-provider-ovh: }
2026-08-21T17:15:14.231+0200 [DEBUG] provider.terraform-provider-ovh: -----------------------------------------------------
2026-08-21T17:15:16.640+0200 [DEBUG] provider.terraform-provider-ovh: 2026/08/21 17:15:16 [DEBUG] OVH API Response Details:
2026-08-21T17:15:16.640+0200 [DEBUG] provider.terraform-provider-ovh: ---[ RESPONSE ]--------------------------------------
2026-08-21T17:15:16.640+0200 [DEBUG] provider.terraform-provider-ovh: HTTP/1.1 200 OK
2026-08-21T17:15:16.640+0200 [DEBUG] provider.terraform-provider-ovh: Connection: close
2026-08-21T17:15:16.640+0200 [DEBUG] provider.terraform-provider-ovh: Content-Length: 166
2026-08-21T17:15:16.640+0200 [DEBUG] provider.terraform-provider-ovh: Access-Control-Allow-Headers: X-Ovh-Nic, X-Ovh-Timestamp, X-Ovh-Consumer, X-Ovh-Application, X-Ovh-Signature, X-Ovh-Session, Authorization, Content-Type
2026-08-21T17:15:16.640+0200 [DEBUG] provider.terraform-provider-ovh: Access-Control-Allow-Methods: POST
2026-08-21T17:15:16.640+0200 [DEBUG] provider.terraform-provider-ovh: Access-Control-Allow-Origin: *
2026-08-21T17:15:16.640+0200 [DEBUG] provider.terraform-provider-ovh: Cache-Control: no-cache, no-store
2026-08-21T17:15:16.640+0200 [DEBUG] provider.terraform-provider-ovh: Content-Type: application/json; charset=utf-8
2026-08-21T17:15:16.640+0200 [DEBUG] provider.terraform-provider-ovh: Date: Fri, 21 Aug 2026 15:15:16 GMT
2026-08-21T17:15:16.640+0200 [DEBUG] provider.terraform-provider-ovh: X-Ovh-Queryid: SDEV.6a886b82.41.7a2bf9a1-050d-455f-bf27-a64e9b9bc2b7
2026-08-21T17:15:16.640+0200 [DEBUG] provider.terraform-provider-ovh
2026-08-21T17:15:16.640+0200 [DEBUG] provider.terraform-provider-ovh: {
2026-08-21T17:15:16.640+0200 [DEBUG] provider.terraform-provider-ovh:  "comment": "Start bare metal OS installation",
2026-08-21T17:15:16.640+0200 [DEBUG] provider.terraform-provider-ovh:  "doneDate": null,
2026-08-21T17:15:16.640+0200 [DEBUG] provider.terraform-provider-ovh:  "function": "reinstallServer",
2026-08-21T17:15:16.640+0200 [DEBUG] provider.terraform-provider-ovh:  "startDate": "2026-08-21T17:15:16+02:00",
2026-08-21T17:15:16.640+0200 [DEBUG] provider.terraform-provider-ovh:  "status": "init",
2026-08-21T17:15:16.640+0200 [DEBUG] provider.terraform-provider-ovh:  "taskId": 559821713
2026-08-21T17:15:16.640+0200 [DEBUG] provider.terraform-provider-ovh: }
2026-08-21T17:15:16.640+0200 [DEBUG] provider.terraform-provider-ovh: -----------------------------------------------------
```


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or issues
- [ ] I have added acceptance tests that prove my fix is effective or that my feature works
- [ ] New and existing acceptance tests pass locally with my changes
