### PR TITLE
feat(dedicated_server_reinstall_task): partial diskgroups erasure

### DIFF
--- a/docs/resources/dedicated_server_reinstall_task.md
+++ b/docs/resources/dedicated_server_reinstall_task.md
@@ -225,6 +225,38 @@ resource "ovh_dedicated_server_reinstall_task" "server_install" {
 }
 ```
 
+### Example 7 - Linux Installation on diskGroup 1 while preserving data on diskGroup 2
+
+```terraform
+data "ovh_dedicated_server" "server" {
+  service_name = "nsxxxxxxx.ip-xx-xx-xx.eu"
+}
+
+data "ovh_dedicated_installation_template" "template" {
+  template_name = "debian12_64"
+}
+
+resource "ovh_dedicated_server_reinstall_task" "server_install" {
+  service_name = data.ovh_dedicated_server.server.service_name
+  os           = data.ovh_dedicated_installation_template.template.template_name
+  customizations {
+    hostname = "mon-tux"
+  }
+  storage {
+    disk_group_id = 1
+    partitioning {
+      scheme_name = "default"
+    }
+  }
+  storage {
+    disk_group_id = 2
+    erase         = false
+  }
+}
+```
+
+By default, every disk group of the server is erased during the OS installation, whether it is declared in the `storage` block or not. Declaring a `storage` block for a disk group with `erase = false` (and no `partitioning`/`hardware_raid`) is the only way to keep its existing data. The disk group actually receiving the OS installation cannot have `erase = false`, and a given `disk_group_id` cannot be declared more than once.
+
 ## Argument Reference
 
 The following arguments are supported:
@@ -243,6 +275,7 @@ The following arguments are supported:
 
 * `storage`: OS reinstallation storage configurations. [More details about disks, hardware/software RAID and partitioning configuration](https://help.ovhcloud.com/csm/en-dedicated-servers-api-partitioning?id=kb_article_view&sysparm_article=KB0043882) (do not forget to adapt camel case parameters to snake case parameters).
   * `disk_group_id`: Disk group id to install the OS to (default is 0, meaning automatic).
+  * `erase`: Whether to erase this disk group's data (default is true). Set to false to keep existing data on a disk group not used for the OS installation. Cannot be set to false on the disk group receiving the OS installation, and a given `disk_group_id` cannot be declared more than once.
   * `hardware_raid`: Hardware Raid configurations (if not specified, all disks of the chosen disk group id will be configured in JBOD mode).
     * `arrays`: Number of arrays (default is 1)
     * `disks`: Total number of disks in the disk group involved in the hardware raid configuration (all disks of the disk group by default)

--- a/examples/resources/dedicated_server_reinstall_task/example_7.tf
+++ b/examples/resources/dedicated_server_reinstall_task/example_7.tf
@@ -1,0 +1,25 @@
+data "ovh_dedicated_server" "server" {
+  service_name = "nsxxxxxxx.ip-xx-xx-xx.eu"
+}
+
+data "ovh_dedicated_installation_template" "template" {
+  template_name = "debian12_64"
+}
+
+resource "ovh_dedicated_server_reinstall_task" "server_install" {
+  service_name = data.ovh_dedicated_server.server.service_name
+  os           = data.ovh_dedicated_installation_template.template.template_name
+  customizations {
+    hostname = "mon-tux"
+  }
+  storage {
+    disk_group_id = 1
+    partitioning {
+      scheme_name = "default"
+    }
+  }
+  storage {
+    disk_group_id = 2
+    erase         = false
+  }
+}

--- a/ovh/resource_dedicated_server_reinstall_task.go
+++ b/ovh/resource_dedicated_server_reinstall_task.go
@@ -1,10 +1,12 @@
 package ovh
 
 import (
+	"context"
 	"fmt"
 	"log"
 	"net/url"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -17,6 +19,8 @@ func resourceDedicatedServerReinstallTask() *schema.Resource {
 		Update: resourceDedicatedServerReinstallTaskUpdate,
 		Read:   resourceDedicatedServerReinstallTaskRead,
 		Delete: resourceDedicatedServerReinstallTaskDelete,
+
+		CustomizeDiff: resourceDedicatedServerReinstallTaskCustomizeDiff,
 
 		Timeouts: &schema.ResourceTimeout{
 			Create: schema.DefaultTimeout(60 * time.Minute),
@@ -156,6 +160,13 @@ func resourceDedicatedServerReinstallTask() *schema.Resource {
 							Optional:    true,
 							ForceNew:    true,
 							Description: "Disk group id (default is 0, meaning automatic)",
+						},
+						"erase": {
+							Type:        schema.TypeBool,
+							Optional:    true,
+							Default:     true,
+							ForceNew:    true,
+							Description: "Whether to erase this disk group's data (default is true). Set to false to keep existing data on a disk group not used for the OS installation.",
 						},
 						"hardware_raid": {
 							Type:        schema.TypeList,
@@ -325,6 +336,49 @@ func resourceDedicatedServerReinstallTask() *schema.Resource {
 			},
 		},
 	}
+}
+
+func resourceDedicatedServerReinstallTaskCustomizeDiff(ctx context.Context, diff *schema.ResourceDiff, meta interface{}) error {
+	return validateDedicatedServerReinstallTaskStorage(diff.Get("storage").([]interface{}))
+}
+
+// validateDedicatedServerReinstallTaskStorage checks the "storage" blocks against constraints
+// enforced by the OVH reinstall API: a disk group cannot have erase=false while also carrying
+// partitioning/hardware_raid (it is implicitly erased when installed on), the same disk_group_id
+// cannot be declared twice, and only one disk group may carry install attributes.
+func validateDedicatedServerReinstallTaskStorage(storage []interface{}) error {
+	seenDiskGroupIds := map[int]bool{}
+	installTargets := 0
+	var errs []string
+
+	for _, raw := range storage {
+		s := raw.(map[string]interface{})
+		diskGroupId := s["disk_group_id"].(int)
+		erase := s["erase"].(bool)
+		hasPartitioning := len(s["partitioning"].([]interface{})) > 0
+		hasHardwareRaid := len(s["hardware_raid"].([]interface{})) > 0
+
+		if seenDiskGroupIds[diskGroupId] {
+			errs = append(errs, fmt.Sprintf("disk_group_id %d is declared more than once in \"storage\"", diskGroupId))
+		}
+		seenDiskGroupIds[diskGroupId] = true
+
+		if hasPartitioning || hasHardwareRaid {
+			installTargets++
+			if !erase {
+				errs = append(errs, fmt.Sprintf("storage block for disk_group_id %d cannot set erase = false while also configuring partitioning/hardware_raid: the disk group being installed on is always erased", diskGroupId))
+			}
+		}
+	}
+
+	if installTargets > 1 {
+		errs = append(errs, fmt.Sprintf("only one \"storage\" block may carry partitioning/hardware_raid (the disk group being installed on), but %d were found", installTargets))
+	}
+
+	if len(errs) > 0 {
+		return fmt.Errorf("invalid \"storage\" configuration:\n- %s", strings.Join(errs, "\n- "))
+	}
+	return nil
 }
 
 func resourceDedicatedServerReinstallTaskCreate(d *schema.ResourceData, meta interface{}) error {

--- a/ovh/resource_dedicated_server_reinstall_task_test.go
+++ b/ovh/resource_dedicated_server_reinstall_task_test.go
@@ -8,6 +8,104 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 )
 
+func storageBlock(diskGroupId int, erase bool, withPartitioning, withHardwareRaid bool) map[string]interface{} {
+	partitioning := []interface{}{}
+	if withPartitioning {
+		partitioning = []interface{}{map[string]interface{}{}}
+	}
+
+	hardwareRaid := []interface{}{}
+	if withHardwareRaid {
+		hardwareRaid = []interface{}{map[string]interface{}{}}
+	}
+
+	return map[string]interface{}{
+		"disk_group_id": diskGroupId,
+		"erase":         erase,
+		"partitioning":  partitioning,
+		"hardware_raid": hardwareRaid,
+	}
+}
+
+func TestValidateDedicatedServerReinstallTaskStorage(t *testing.T) {
+	testCases := []struct {
+		name      string
+		storage   []interface{}
+		expectErr bool
+	}{
+		{
+			name:      "no storage blocks",
+			storage:   []interface{}{},
+			expectErr: false,
+		},
+		{
+			name: "single install block, no erase override",
+			storage: []interface{}{
+				storageBlock(0, true, true, false),
+			},
+			expectErr: false,
+		},
+		{
+			name: "install block plus erase=false on another disk group",
+			storage: []interface{}{
+				storageBlock(1, true, true, false),
+				storageBlock(2, false, false, false),
+			},
+			expectErr: false,
+		},
+		{
+			name: "erase=false combined with partitioning on the same block",
+			storage: []interface{}{
+				storageBlock(1, false, true, false),
+			},
+			expectErr: true,
+		},
+		{
+			name: "erase=false combined with hardware_raid on the same block",
+			storage: []interface{}{
+				storageBlock(1, false, false, true),
+			},
+			expectErr: true,
+		},
+		{
+			name: "duplicate disk_group_id",
+			storage: []interface{}{
+				storageBlock(2, true, false, false),
+				storageBlock(2, false, false, false),
+			},
+			expectErr: true,
+		},
+		{
+			name: "duplicate implicit disk_group_id (both default to 0)",
+			storage: []interface{}{
+				storageBlock(0, true, true, false),
+				storageBlock(0, true, false, false),
+			},
+			expectErr: true,
+		},
+		{
+			name: "more than one install target",
+			storage: []interface{}{
+				storageBlock(1, true, true, false),
+				storageBlock(2, true, false, true),
+			},
+			expectErr: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validateDedicatedServerReinstallTaskStorage(tc.storage)
+			if tc.expectErr && err == nil {
+				t.Fatalf("expected an error, got none")
+			}
+			if !tc.expectErr && err != nil {
+				t.Fatalf("expected no error, got: %v", err)
+			}
+		})
+	}
+}
+
 func TestAccDedicatedServerReinstall_basic(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
@@ -163,6 +261,39 @@ func TestAccDedicatedServerReinstall_storage(t *testing.T) {
 	})
 }
 
+func TestAccDedicatedServerReinstall_storageErase(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheckCredentials(t)
+			testAccPreCheckDedicatedServer(t)
+		},
+		Providers: testAccProviders,
+		ExternalProviders: map[string]resource.ExternalProvider{
+			"time": {
+				VersionConstraint: "0.10.0",
+				Source:            "hashicorp/time",
+			},
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDedicatedServerReinstallConfig("storageErase"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(
+						"ovh_dedicated_server_update.server", "state", "ok"),
+					resource.TestCheckResourceAttr(
+						"ovh_dedicated_server_update.server", "monitoring", "false"),
+					resource.TestCheckResourceAttr(
+						"ovh_dedicated_server_reinstall_task.server_reinstall", "function", "reinstallServer"),
+					resource.TestCheckResourceAttr(
+						"ovh_dedicated_server_reinstall_task.server_reinstall", "status", "done"),
+					resource.TestCheckResourceAttr(
+						"ovh_dedicated_server_reinstall_task.server_reinstall", "storage.1.erase", "false"),
+				),
+			},
+		},
+	})
+}
+
 func testAccDedicatedServerReinstallConfig(config string) string {
 	dedicated_server := os.Getenv("OVH_DEDICATED_SERVER")
 	sshKey := os.Getenv("OVH_SSH_KEY")
@@ -194,6 +325,13 @@ func testAccDedicatedServerReinstallConfig(config string) string {
 	if config == "storage" {
 		return fmt.Sprintf(
 			testAccDedicatedServerReinstallConfig_Storage,
+			dedicated_server,
+		)
+	}
+
+	if config == "storageErase" {
+		return fmt.Sprintf(
+			testAccDedicatedServerReinstallConfig_StorageErase,
 			dedicated_server,
 		)
 	}
@@ -363,6 +501,38 @@ resource "ovh_dedicated_server_reinstall_task" "server_reinstall" {
         }
       }
     }
+  }
+}
+`
+
+const testAccDedicatedServerReinstallConfig_StorageErase = `
+data "ovh_dedicated_server_boots" "harddisk" {
+  service_name = "%s"
+  boot_type    = "harddisk"
+}
+
+resource "ovh_dedicated_server_update" "server" {
+  service_name = data.ovh_dedicated_server_boots.harddisk.service_name
+  boot_id      = data.ovh_dedicated_server_boots.harddisk.result[0]
+  monitoring   = false
+  state        = "ok"
+}
+
+resource "ovh_dedicated_server_reinstall_task" "server_reinstall" {
+  service_name     = data.ovh_dedicated_server_boots.harddisk.service_name
+  os = "debian12_64"
+  customizations {
+    hostname = "mon-tux"
+  }
+  storage {
+    disk_group_id = 1
+    partitioning {
+      scheme_name = "default"
+    }
+  }
+  storage {
+    disk_group_id = 2
+    erase         = false
   }
 }
 `

--- a/ovh/types_dedicated_server.go
+++ b/ovh/types_dedicated_server.go
@@ -149,6 +149,7 @@ func (opts *DedicatedServerReinstallTaskCreateOpts) FromResource(d *schema.Resou
 
 type DedicatedServerReinstallTaskStorage struct {
 	DiskGroupId  int                   `json:"diskGroupId,omitempty"`
+	Erase        *bool                 `json:"erase,omitempty"`
 	HardwareRaid []HardwareRaidInstall `json:"hardwareRaid,omitempty"`
 	Partitioning *Partitioning         `json:"partitioning,omitempty"`
 }
@@ -219,8 +220,12 @@ func (opts *DedicatedServerReinstallTaskCustomizations) FromResource(d *schema.R
 
 func (opts *DedicatedServerReinstallTaskStorage) FromResource(d *schema.ResourceData, parent string) *DedicatedServerReinstallTaskStorage {
 	opts.DiskGroupId = d.Get(fmt.Sprintf("%s.disk_group_id", parent)).(int)
+	opts.Erase = helpers.GetNilBoolPointerFromData(d, fmt.Sprintf("%s.erase", parent))
 
-	opts.Partitioning = (&Partitioning{}).FromResource(d, fmt.Sprintf("%s.partitioning.0", parent))
+	partitioning := d.Get(fmt.Sprintf("%s.partitioning", parent)).([]interface{})
+	if len(partitioning) >= 1 {
+		opts.Partitioning = (&Partitioning{}).FromResource(d, fmt.Sprintf("%s.partitioning.0", parent))
+	}
 
 	hardwareRaid := d.Get(fmt.Sprintf("%s.hardware_raid", parent)).([]interface{})
 	if len(hardwareRaid) >= 1 {

--- a/templates/resources/dedicated_server_reinstall_task.md.tmpl
+++ b/templates/resources/dedicated_server_reinstall_task.md.tmpl
@@ -71,6 +71,12 @@ Here is the clear-text post-installation PowerShell script from the example abov
 
 {{tffile "examples/resources/dedicated_server_reinstall_task/example_6.tf"}}
 
+### Example 7 - Linux Installation on diskGroup 1 while preserving data on diskGroup 2
+
+{{tffile "examples/resources/dedicated_server_reinstall_task/example_7.tf"}}
+
+By default, every disk group of the server is erased during the OS installation, whether it is declared in the `storage` block or not. Declaring a `storage` block for a disk group with `erase = false` (and no `partitioning`/`hardware_raid`) is the only way to keep its existing data. The disk group actually receiving the OS installation cannot have `erase = false`, and a given `disk_group_id` cannot be declared more than once.
+
 ## Argument Reference
 
 The following arguments are supported:
@@ -89,6 +95,7 @@ The following arguments are supported:
 
 * `storage`: OS reinstallation storage configurations. [More details about disks, hardware/software RAID and partitioning configuration](https://help.ovhcloud.com/csm/en-dedicated-servers-api-partitioning?id=kb_article_view&sysparm_article=KB0043882) (do not forget to adapt camel case parameters to snake case parameters).
   * `disk_group_id`: Disk group id to install the OS to (default is 0, meaning automatic).
+  * `erase`: Whether to erase this disk group's data (default is true). Set to false to keep existing data on a disk group not used for the OS installation. Cannot be set to false on the disk group receiving the OS installation, and a given `disk_group_id` cannot be declared more than once.
   * `hardware_raid`: Hardware Raid configurations (if not specified, all disks of the chosen disk group id will be configured in JBOD mode).
     * `arrays`: Number of arrays (default is 1)
     * `disks`: Total number of disks in the disk group involved in the hardware raid configuration (all disks of the disk group by default)


### PR DESCRIPTION
# Description

For dedicated servers with multiple disk groups, ability to preserve data on disk groups (other than the one targeted for OS reinstallation).

Treats #PUBM-53674

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] Documentation update

# How Has This Been Tested?

Since the schema is not prodded yet, it has been tested in a dev environment (using the recently added feature with custom HTTP headers) against the new API schema supporting that feature

- [x] Test A: `make testacc TESTARGS="-run TestAccDedicatedServerReinstall_basic"`
```none
GNU Make 4.3
Built for x86_64-pc-linux-gnu
Copyright (C) 1988-2020 Free Software Foundation, Inc.
License GPLv3+: GNU GPL version 3 or later <http://gnu.org/licenses/gpl.html>
This is free software: you are free to change and redistribute it.
There is NO WARRANTY, to the extent permitted by law.
Reading makefiles...
Updating makefiles....
Updating goal targets....
 File 'testacc' does not exist.
   File 'fmtcheck' does not exist.
  Must remake target 'fmtcheck'.
==> Checking that code complies with gofmt requirements...
  Successfully remade target file 'fmtcheck'.
Must remake target 'testacc'.
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -run TestAccDedicatedServerReinstall_basic -timeout 600m -p 10
?   	github.com/ovh/terraform-provider-ovh/v2	[no test files]
=== RUN   TestAccDedicatedServerReinstall_basic
--- PASS: TestAccDedicatedServerReinstall_basic (16.54s)
PASS
ok  	github.com/ovh/terraform-provider-ovh/v2/ovh	16.558s
?   	github.com/ovh/terraform-provider-ovh/v2/ovh/datasources/cloud_project_rancher	[no test files]
testing: warning: no tests to run
PASS
ok  	github.com/ovh/terraform-provider-ovh/v2/ovh/helpers	0.009s [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/ovh/terraform-provider-ovh/v2/ovh/helpers/hashcode	0.003s [no tests to run]
?   	github.com/ovh/terraform-provider-ovh/v2/ovh/ovhwrap	[no test files]
?   	github.com/ovh/terraform-provider-ovh/v2/ovh/resources/cloud_project_rancher	[no test files]
?   	github.com/ovh/terraform-provider-ovh/v2/ovh/types	[no test files]
Successfully remade target file 'testacc'.
```
- [x] Test B: `make testacc TESTARGS="-run TestValidateDedicatedServerReinstallTaskStorage"`
```none
GNU Make 4.3
Built for x86_64-pc-linux-gnu
Copyright (C) 1988-2020 Free Software Foundation, Inc.
License GPLv3+: GNU GPL version 3 or later <http://gnu.org/licenses/gpl.html>
This is free software: you are free to change and redistribute it.
There is NO WARRANTY, to the extent permitted by law.
Reading makefiles...
Updating makefiles....
Updating goal targets....
 File 'testacc' does not exist.
   File 'fmtcheck' does not exist.
  Must remake target 'fmtcheck'.
==> Checking that code complies with gofmt requirements...
  Successfully remade target file 'fmtcheck'.
Must remake target 'testacc'.
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -run TestValidateDedicatedServerReinstallTaskStorage -timeout 600m -p 10
?   	github.com/ovh/terraform-provider-ovh/v2	[no test files]
=== RUN   TestValidateDedicatedServerReinstallTaskStorage
=== RUN   TestValidateDedicatedServerReinstallTaskStorage/no_storage_blocks
=== RUN   TestValidateDedicatedServerReinstallTaskStorage/single_install_block,_no_erase_override
=== RUN   TestValidateDedicatedServerReinstallTaskStorage/install_block_plus_erase=false_on_another_disk_group
=== RUN   TestValidateDedicatedServerReinstallTaskStorage/erase=false_combined_with_partitioning_on_the_same_block
=== RUN   TestValidateDedicatedServerReinstallTaskStorage/erase=false_combined_with_hardware_raid_on_the_same_block
=== RUN   TestValidateDedicatedServerReinstallTaskStorage/duplicate_disk_group_id
=== RUN   TestValidateDedicatedServerReinstallTaskStorage/duplicate_implicit_disk_group_id_(both_default_to_0)
=== RUN   TestValidateDedicatedServerReinstallTaskStorage/more_than_one_install_target
--- PASS: TestValidateDedicatedServerReinstallTaskStorage (0.00s)
    --- PASS: TestValidateDedicatedServerReinstallTaskStorage/no_storage_blocks (0.00s)
    --- PASS: TestValidateDedicatedServerReinstallTaskStorage/single_install_block,_no_erase_override (0.00s)
    --- PASS: TestValidateDedicatedServerReinstallTaskStorage/install_block_plus_erase=false_on_another_disk_group (0.00s)
    --- PASS: TestValidateDedicatedServerReinstallTaskStorage/erase=false_combined_with_partitioning_on_the_same_block (0.00s)
    --- PASS: TestValidateDedicatedServerReinstallTaskStorage/erase=false_combined_with_hardware_raid_on_the_same_block (0.00s)
    --- PASS: TestValidateDedicatedServerReinstallTaskStorage/duplicate_disk_group_id (0.00s)
    --- PASS: TestValidateDedicatedServerReinstallTaskStorage/duplicate_implicit_disk_group_id_(both_default_to_0) (0.00s)
    --- PASS: TestValidateDedicatedServerReinstallTaskStorage/more_than_one_install_target (0.00s)
PASS
ok  	github.com/ovh/terraform-provider-ovh/v2/ovh	0.018s
?   	github.com/ovh/terraform-provider-ovh/v2/ovh/datasources/cloud_project_rancher	[no test files]
testing: warning: no tests to run
PASS
ok  	github.com/ovh/terraform-provider-ovh/v2/ovh/helpers	0.009s [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/ovh/terraform-provider-ovh/v2/ovh/helpers/hashcode	0.004s [no tests to run]
?   	github.com/ovh/terraform-provider-ovh/v2/ovh/ovhwrap	[no test files]
?   	github.com/ovh/terraform-provider-ovh/v2/ovh/resources/cloud_project_rancher	[no test files]
?   	github.com/ovh/terraform-provider-ovh/v2/ovh/types	[no test files]
Successfully remade target file 'testacc'.
```
- [x] Test C: `make testacc TESTARGS="-run TestAccDedicatedServerReinstall_storageErase"`
```none
GNU Make 4.3
Built for x86_64-pc-linux-gnu
Copyright (C) 1988-2020 Free Software Foundation, Inc.
License GPLv3+: GNU GPL version 3 or later <http://gnu.org/licenses/gpl.html>
This is free software: you are free to change and redistribute it.
There is NO WARRANTY, to the extent permitted by law.
Reading makefiles...
Updating makefiles....
Updating goal targets....
 File 'testacc' does not exist.
   File 'fmtcheck' does not exist.
  Must remake target 'fmtcheck'.
==> Checking that code complies with gofmt requirements...
  Successfully remade target file 'fmtcheck'.
Must remake target 'testacc'.
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -run TestAccDedicatedServerReinstall_storageErase -timeout 600m -p 10
?   	github.com/ovh/terraform-provider-ovh/v2	[no test files]

=== RUN   TestAccDedicatedServerReinstall_storageErase
--- PASS: TestAccDedicatedServerReinstall_storageErase (58.19s)
PASS
ok  	github.com/ovh/terraform-provider-ovh/v2/ovh	58.206s
?   	github.com/ovh/terraform-provider-ovh/v2/ovh/datasources/cloud_project_rancher	[no test files]
testing: warning: no tests to run
PASS
ok  	github.com/ovh/terraform-provider-ovh/v2/ovh/helpers	(cached) [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/ovh/terraform-provider-ovh/v2/ovh/helpers/hashcode	(cached) [no tests to run]
?   	github.com/ovh/terraform-provider-ovh/v2/ovh/ovhwrap	[no test files]
?   	github.com/ovh/terraform-provider-ovh/v2/ovh/resources/cloud_project_rancher	[no test files]
?   	github.com/ovh/terraform-provider-ovh/v2/ovh/types	[no test files]
Successfully remade target file 'testacc'.
```

**Test Configuration**:
* Terraform version: `terraform version`: Terraform v1.12.2
* Environment:
```bash
export OVH_ENDPOINT="https://my-custom-local-api-endpoint/1.0"
export OVH_APPLICATION_KEY="toto"
export OVH_APPLICATION_SECRET="toto"
export OVH_CONSUMER_KEY="toto"
export OVH_IGNORE_INIT_ERROR=true
export OVH_HTTP_HEADERS_0="x-ovh-nic: ab123456-ovh"
export OVH_DEDICATED_SERVER="nsXXXXXXX"
```

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or issues
- [x] I have added acceptance tests that prove my fix is effective or that my feature works
- [x] New and existing acceptance tests pass locally with my changes
