### PR TITLE
fix(domain_zone): return zone refresh errors instead of only logging them

### DIFF
--- a/docs/resources/domain_zone_record.md
+++ b/docs/resources/domain_zone_record.md
@@ -10,6 +10,8 @@ Provides a OVHcloud domain zone record.
 
 ~> **WARNING** This resource and resource `ovh_domain_zone_import` should not be used together as `ovh_domain_zone_import` controls the whole DNS zone at once.
 
+~> **NOTE** Creating, updating or deleting a record triggers a zone refresh (`POST /domain/zone/{zone}/refresh`), without which the change is recorded but never served by the OVHcloud DNS servers. The credentials used by the provider must therefore carry the `dnsZone:apiovh:refresh` permission in addition to the record permissions, otherwise the apply fails.
+
 ## Example Usage
 
 ```terraform

--- a/docs/resources/domain_zone_redirection.md
+++ b/docs/resources/domain_zone_redirection.md
@@ -6,6 +6,8 @@ subcategory : "Domain names"
 
 Provides a OVHcloud domain zone redirection.
 
+~> **NOTE** Creating, updating or deleting a redirection triggers a zone refresh (`POST /domain/zone/{zone}/refresh`), without which the change is recorded but never served by the OVHcloud DNS servers. The credentials used by the provider must therefore carry the `dnsZone:apiovh:refresh` permission in addition to the redirection permissions, otherwise the apply fails.
+
 ## Example Usage
 
 ```terraform

--- a/ovh/resource_domain_zone_record.go
+++ b/ovh/resource_domain_zone_record.go
@@ -170,7 +170,7 @@ func resourceOvhDomainZoneRecordCreate(d *schema.ResourceData, meta interface{})
 	d.SetId(strconv.FormatInt(resultRecord.Id, 10))
 
 	if err := ovhDomainZoneRefresh(d, meta); err != nil {
-		return err
+		return fmt.Errorf("OVH Domain zone refresh after record creation failed: %w", err)
 	}
 
 	return resourceOvhDomainZoneRecordRead(d, meta)
@@ -227,7 +227,7 @@ func resourceOvhDomainZoneRecordUpdate(d *schema.ResourceData, meta interface{})
 	}
 
 	if err := ovhDomainZoneRefresh(d, meta); err != nil {
-		return err
+		return fmt.Errorf("OVH Domain zone refresh after record update failed: %w", err)
 	}
 
 	return resourceOvhDomainZoneRecordRead(d, meta)
@@ -247,7 +247,7 @@ func resourceOvhDomainZoneRecordDelete(d *schema.ResourceData, meta interface{})
 	// published, so the resource must stay in state for the next apply to retry.
 	// Deleting an already deleted record is a no-op, see helpers.CheckDeleted.
 	if err := ovhDomainZoneRefresh(d, meta); err != nil {
-		return err
+		return fmt.Errorf("OVH Domain zone refresh after record deletion failed: %w", err)
 	}
 
 	d.SetId("")

--- a/ovh/resource_domain_zone_record.go
+++ b/ovh/resource_domain_zone_record.go
@@ -170,7 +170,7 @@ func resourceOvhDomainZoneRecordCreate(d *schema.ResourceData, meta interface{})
 	d.SetId(strconv.FormatInt(resultRecord.Id, 10))
 
 	if err := ovhDomainZoneRefresh(d, meta); err != nil {
-		log.Printf("[WARN] OVH Domain zone refresh after record creation failed: %s", err)
+		return err
 	}
 
 	return resourceOvhDomainZoneRecordRead(d, meta)
@@ -227,7 +227,7 @@ func resourceOvhDomainZoneRecordUpdate(d *schema.ResourceData, meta interface{})
 	}
 
 	if err := ovhDomainZoneRefresh(d, meta); err != nil {
-		log.Printf("[WARN] OVH Domain zone refresh after record update failed: %s", err)
+		return err
 	}
 
 	return resourceOvhDomainZoneRecordRead(d, meta)
@@ -243,11 +243,14 @@ func resourceOvhDomainZoneRecordDelete(d *schema.ResourceData, meta interface{})
 		return helpers.CheckDeleted(d, err, endpoint)
 	}
 
-	d.SetId("")
-
+	// Refresh before clearing the ID: if the refresh fails the record is still
+	// published, so the resource must stay in state for the next apply to retry.
+	// Deleting an already deleted record is a no-op, see helpers.CheckDeleted.
 	if err := ovhDomainZoneRefresh(d, meta); err != nil {
-		log.Printf("[WARN] OVH Domain zone refresh after record deletion failed: %s", err)
+		return err
 	}
+
+	d.SetId("")
 
 	return nil
 }

--- a/ovh/resource_domain_zone_record_test.go
+++ b/ovh/resource_domain_zone_record_test.go
@@ -3,17 +3,25 @@ package ovh
 import (
 	"fmt"
 	"log"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"regexp"
 	"strconv"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	ovhsdk "github.com/ovh/go-ovh/ovh"
+	"go.uber.org/ratelimit"
+
+	"github.com/ovh/terraform-provider-ovh/v2/ovh/ovhwrap"
 )
 
 func init() {
@@ -393,4 +401,105 @@ resource "ovh_domain_zone_record" "foobar" {
 	fieldtype = "TXT"
 	ttl = %d
 }`, zone, subdomain, target, ttl)
+}
+
+// newRefreshTestConfig returns a Config whose OVH client talks to the given test
+// server. Dummy credentials are supplied so go-ovh signs requests (which also
+// triggers the /auth/time call served by the test server) without reading any
+// ambient OVH configuration.
+func newRefreshTestConfig(t *testing.T, serverURL string) *Config {
+	t.Helper()
+	client, err := ovhsdk.NewClient(serverURL, "appKey", "appSecret", "consumerKey")
+	if err != nil {
+		t.Fatalf("failed to create go-ovh client: %s", err)
+	}
+	return &Config{OVHClient: ovhwrap.NewClient(client, ratelimit.NewUnlimited())}
+}
+
+// refreshDeniedServer serves the record endpoints and rejects the zone refresh
+// with a 403, mimicking credentials that lack the dnsZone:apiovh:refresh
+// permission.
+func refreshDeniedServer(t *testing.T, zone string, refreshCalls *int32) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/auth/time":
+			fmt.Fprint(w, "1700000000")
+		case r.URL.Path == "/domain/zone/"+zone+"/refresh" && r.Method == http.MethodPost:
+			atomic.AddInt32(refreshCalls, 1)
+			w.WriteHeader(http.StatusForbidden)
+			fmt.Fprint(w, `{"message":"This call has not been granted"}`)
+		case r.URL.Path == "/domain/zone/"+zone+"/record" && r.Method == http.MethodPost:
+			fmt.Fprint(w, `{"id":42,"zone":"`+zone+`","subDomain":"test","fieldType":"A","target":"192.0.2.1","ttl":3600}`)
+		case r.URL.Path == "/domain/zone/"+zone+"/record/42" && r.Method == http.MethodDelete:
+			fmt.Fprint(w, `null`)
+		case r.URL.Path == "/domain/zone/"+zone+"/record/42" && r.Method == http.MethodGet:
+			// Only reached if the refresh error is swallowed and the read runs anyway.
+			fmt.Fprint(w, `{"id":42,"zone":"`+zone+`","subDomain":"test","fieldType":"A","target":"192.0.2.1","ttl":3600}`)
+		default:
+			t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+}
+
+func testRecordResourceData(t *testing.T, zone string) *schema.ResourceData {
+	t.Helper()
+	return schema.TestResourceDataRaw(t, resourceOvhDomainZoneRecord().Schema, map[string]interface{}{
+		"zone":      zone,
+		"subdomain": "test",
+		"fieldtype": "A",
+		"target":    "192.0.2.1",
+		"ttl":       3600,
+	})
+}
+
+// A record is only served by the DNS servers once the zone is refreshed, so a
+// denied refresh must fail the apply rather than be swallowed into a log line.
+func TestDomainZoneRecordCreateFailsWhenRefreshDenied(t *testing.T) {
+	const zone = "example.com"
+	var refreshCalls int32
+
+	server := refreshDeniedServer(t, zone, &refreshCalls)
+	defer server.Close()
+
+	d := testRecordResourceData(t, zone)
+
+	err := resourceOvhDomainZoneRecordCreate(d, newRefreshTestConfig(t, server.URL))
+	if err == nil {
+		t.Fatal("expected create to fail when the zone refresh is denied, got nil")
+	}
+	if !strings.Contains(err.Error(), "refresh after record creation failed") {
+		t.Errorf("error should name the failing operation, got: %s", err)
+	}
+	if got := atomic.LoadInt32(&refreshCalls); got != 1 {
+		t.Errorf("expected exactly 1 refresh call, got %d", got)
+	}
+}
+
+// On delete the refresh runs before the ID is cleared, so a denied refresh
+// leaves the resource in state for the next apply to retry.
+func TestDomainZoneRecordDeleteFailsWhenRefreshDeniedAndKeepsID(t *testing.T) {
+	const zone = "example.com"
+	var refreshCalls int32
+
+	server := refreshDeniedServer(t, zone, &refreshCalls)
+	defer server.Close()
+
+	d := testRecordResourceData(t, zone)
+	d.SetId("42")
+
+	err := resourceOvhDomainZoneRecordDelete(d, newRefreshTestConfig(t, server.URL))
+	if err == nil {
+		t.Fatal("expected delete to fail when the zone refresh is denied, got nil")
+	}
+	if !strings.Contains(err.Error(), "refresh after record deletion failed") {
+		t.Errorf("error should name the failing operation, got: %s", err)
+	}
+	if d.Id() != "42" {
+		t.Errorf("id must be preserved so the next apply retries the delete, got %q", d.Id())
+	}
+	if got := atomic.LoadInt32(&refreshCalls); got != 1 {
+		t.Errorf("expected exactly 1 refresh call, got %d", got)
+	}
 }

--- a/ovh/resource_domain_zone_redirection.go
+++ b/ovh/resource_domain_zone_redirection.go
@@ -93,7 +93,7 @@ func resourceOvhDomainZoneRedirectionCreate(d *schema.ResourceData, meta interfa
 	log.Printf("[INFO] OVH Redirection ID: %s", d.Id())
 
 	if err := ovhDomainZoneRefresh(d, meta); err != nil {
-		log.Printf("[WARN] OVH Domain zone refresh after redirection creation failed: %s", err)
+		return err
 	}
 
 	return resourceOvhDomainZoneRedirectionRead(d, meta)
@@ -156,7 +156,7 @@ func resourceOvhDomainZoneRedirectionUpdate(d *schema.ResourceData, meta interfa
 	}
 
 	if err := ovhDomainZoneRefresh(d, meta); err != nil {
-		log.Printf("[WARN] OVH Domain zone refresh after redirection update failed: %s", err)
+		return err
 	}
 
 	return resourceOvhDomainZoneRedirectionRead(d, meta)
@@ -177,7 +177,7 @@ func resourceOvhDomainZoneRedirectionDelete(d *schema.ResourceData, meta interfa
 	}
 
 	if err := ovhDomainZoneRefresh(d, meta); err != nil {
-		log.Printf("[WARN] OVH Domain zone refresh after redirection deletion failed: %s", err)
+		return err
 	}
 
 	return nil

--- a/ovh/resource_domain_zone_redirection.go
+++ b/ovh/resource_domain_zone_redirection.go
@@ -93,7 +93,7 @@ func resourceOvhDomainZoneRedirectionCreate(d *schema.ResourceData, meta interfa
 	log.Printf("[INFO] OVH Redirection ID: %s", d.Id())
 
 	if err := ovhDomainZoneRefresh(d, meta); err != nil {
-		return err
+		return fmt.Errorf("OVH Domain zone refresh after redirection creation failed: %w", err)
 	}
 
 	return resourceOvhDomainZoneRedirectionRead(d, meta)
@@ -156,7 +156,7 @@ func resourceOvhDomainZoneRedirectionUpdate(d *schema.ResourceData, meta interfa
 	}
 
 	if err := ovhDomainZoneRefresh(d, meta); err != nil {
-		return err
+		return fmt.Errorf("OVH Domain zone refresh after redirection update failed: %w", err)
 	}
 
 	return resourceOvhDomainZoneRedirectionRead(d, meta)
@@ -177,7 +177,7 @@ func resourceOvhDomainZoneRedirectionDelete(d *schema.ResourceData, meta interfa
 	}
 
 	if err := ovhDomainZoneRefresh(d, meta); err != nil {
-		return err
+		return fmt.Errorf("OVH Domain zone refresh after redirection deletion failed: %w", err)
 	}
 
 	return nil

--- a/templates/resources/domain_zone_record.md.tmpl
+++ b/templates/resources/domain_zone_record.md.tmpl
@@ -14,6 +14,8 @@ Provides a OVHcloud domain zone record.
 
 ~> **WARNING** This resource and resource `ovh_domain_zone_import` should not be used together as `ovh_domain_zone_import` controls the whole DNS zone at once.
 
+~> **NOTE** Creating, updating or deleting a record triggers a zone refresh (`POST /domain/zone/{zone}/refresh`), without which the change is recorded but never served by the OVHcloud DNS servers. The credentials used by the provider must therefore carry the `dnsZone:apiovh:refresh` permission in addition to the record permissions, otherwise the apply fails.
+
 ## Example Usage
 
 {{tffile "examples/resources/domain_zone_record/example_1.tf"}}

--- a/templates/resources/domain_zone_redirection.md.tmpl
+++ b/templates/resources/domain_zone_redirection.md.tmpl
@@ -10,6 +10,8 @@ For example, the {{ .SchemaMarkdown }} template can be used to replace manual sc
 
 Provides a OVHcloud domain zone redirection.
 
+~> **NOTE** Creating, updating or deleting a redirection triggers a zone refresh (`POST /domain/zone/{zone}/refresh`), without which the change is recorded but never served by the OVHcloud DNS servers. The credentials used by the provider must therefore carry the `dnsZone:apiovh:refresh` permission in addition to the redirection permissions, otherwise the apply fails.
+
 ## Example Usage
 
 {{tffile "examples/resources/domain_zone_redirection/example_1.tf"}}


### PR DESCRIPTION
# Description

`ovhDomainZoneRefresh` returns its error, but every caller discarded it into a log line — `resource_domain_zone_record.go` (create, update, delete) and `resource_domain_zone_redirection.go` (create, update, delete).

A change is only served by the OVHcloud DNS servers once the zone is refreshed. When the credentials lack the `dnsZone:apiovh:refresh` permission that refresh returns 403, and because the error was only logged at `[WARN]` the apply reported success while the record was never published. Nothing surfaces unless `TF_LOG` is set, which is what makes the reported symptom so hard to diagnose: the record is visible in the web console but never resolves.

This returns the error instead, so an apply fails when the change did not take effect.

Three details worth reviewing:

- The per-operation wording from the old `[WARN]` lines is kept, wrapped with `%w`. The refresh helper only reports `Error refresh OVH Zone`, so returning its error bare would have lost the distinction between creation, update and deletion. Wrapping keeps that context and, unlike the log line, it actually reaches the user.
- In the **record delete** path the refresh now runs *before* `d.SetId("")`, so a failed refresh leaves the resource in state and the next apply retries it. Re-deleting an already deleted record is a no-op — `helpers.CheckDeleted` returns `nil` on 404. The redirection delete does not call `d.SetId("")` itself, so it needed no reordering.
- I did **not** add a Terraform warning diagnostic instead of an error. Both resources use the legacy SDKv2 CRUD signatures (`Create:`/`Read:`/`Update:`/`Delete:` returning `error`), which cannot emit warning diagnostics — that would require migrating them to the `*Context` functions returning `diag.Diagnostics`, which felt out of scope for a bug fix. Happy to go that way instead if you would prefer a warning over a hard failure.

Fixes #1290

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

Flagging the breaking-change box deliberately: configurations whose credentials lack `dnsZone:apiovh:refresh` used to apply silently and will now fail. That is the point of the fix, but it will want a mention in the release notes.

# How Has This Been Tested?

**Unit tests** (new, no credentials required). Added to `ovh/resource_domain_zone_record_test.go`, following the `httptest` pattern already used in `ovh/helpers/apiv2_test.go`. They point the OVH client at a test server that denies `POST /domain/zone/{zone}/refresh` with a 403 and assert that:

- create returns the error instead of swallowing it, and
- delete returns the error **and preserves the resource ID**, so the next apply retries.

Both tests fail against the previous code with `expected create to fail when the zone refresh is denied, got nil` — that `nil` is exactly the reported bug.

```
--- PASS: TestDomainZoneRecordCreateFailsWhenRefreshDenied
--- PASS: TestDomainZoneRecordDeleteFailsWhenRefreshDeniedAndKeepsID
```

**Acceptance tests**, run against a real OVHcloud DNS zone I control, covering both resources touched:

```
$ TF_ACC=1 OVH_ZONE_TEST=<my-test-zone> go test ./ovh/ -run 'TestAccDomainZoneRe' -v

--- PASS: TestAccDomainZoneRecordDataSource_basic (4.96s)
--- PASS: TestAccDomainZoneRecordsDataSource_basic (3.12s)
--- PASS: TestAccDomainZoneRecord_Basic (8.50s)
--- PASS: TestAccDomainZoneRecord_Updated (9.48s)
--- PASS: TestAccDomainZoneRecord_updateType (6.69s)
--- PASS: TestAccDomainZoneRecord_EmptyPlanForTXT (4.30s)
--- PASS: TestAccDomainZoneRedirection_Basic (3.24s)
--- PASS: TestAccDomainZoneRedirection_Updated (11.32s)
ok      github.com/ovh/terraform-provider-ovh/v2/ovh    51.626s
```

These confirm the normal path is unaffected: where the credentials do carry `dnsZone:apiovh:refresh`, the refresh succeeds and behaviour is unchanged. I also verified the zone was left clean afterwards (no leftover `testacc-terraform*` records).

Also clean: `go build ./...`, `make fmtcheck`, `go vet ./ovh/...`.

One unrelated pre-existing failure shows up in a full `go test ./ovh/...` run without credentials: `TestAccCloudQuotaResource_basic` fails with `Couldn't load OVH Client: missing authentication information`. I confirmed it fails identically on a clean checkout of `master` without my changes — it appears not to be guarded by a `TF_ACC` check. Untouched by this PR.

**Test Configuration**:
* Terraform version: v1.15.8
* Existing HCL configuration this affects:
```hcl
resource "ovh_domain_zone_record" "test" {
  zone      = "example.com"
  subdomain = "test"
  fieldtype = "CNAME"
  ttl       = 60
  target    = "target.example.net."
}
```
With credentials granted `dnsZone:apiovh:record/create|update|delete` but not `dnsZone:apiovh:refresh`, this apply previously succeeded while the record never resolved. It now fails with the refresh error.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or issues
- [x] I have added acceptance tests that prove my fix is effective or that my feature works
- [x] New and existing acceptance tests pass locally with my changes
- [x] I ran successfully `go mod vendor` if I added or modify `go.mod` file — n/a, `go.mod` untouched

On the tests box: the proof that the fix works is in the two unit tests above, because reproducing the bug needs credentials holding the record permissions but *not* `dnsZone:apiovh:refresh`, and the acceptance harness runs against a single set of credentials from the environment so it cannot express that. The acceptance tests for both affected resources were run and pass, covering the no-regression side. If you would rather see this as an acceptance test too, tell me how you would like the restricted-credential case wired up and I will add it.

Documentation: added a note to both resources (template + generated docs) stating that a zone refresh is triggered on every change and that the credentials must therefore carry `dnsZone:apiovh:refresh`.
