### PR TITLE
feat(dedicated_server_reinstall_task): add app_to_install customization

### DIFF
--- a/ovh/resource_dedicated_server_reinstall_task.go
+++ b/ovh/resource_dedicated_server_reinstall_task.go
@@ -48,6 +48,12 @@ func resourceDedicatedServerReinstallTask() *schema.Resource {
 				Description: "OS reinstallation customizations",
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
+						"app_to_install": {
+							Type:        schema.TypeString,
+							Optional:    true,
+							ForceNew:    true,
+							Description: "Application to install with the auto installer",
+						},
 						"config_drive_metadata": {
 							Type:        schema.TypeMap,
 							Optional:    true,

--- a/ovh/resource_dedicated_server_reinstall_task_test.go
+++ b/ovh/resource_dedicated_server_reinstall_task_test.go
@@ -163,6 +163,37 @@ func TestAccDedicatedServerReinstall_storage(t *testing.T) {
 	})
 }
 
+func TestAccDedicatedServerReinstall_apptoinstall(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheckCredentials(t)
+			testAccPreCheckDedicatedServer(t)
+		},
+		Providers: testAccProviders,
+		ExternalProviders: map[string]resource.ExternalProvider{
+			"time": {
+				VersionConstraint: "0.10.0",
+				Source:            "hashicorp/time",
+			},
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDedicatedServerReinstallConfig("apptoinstall"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(
+						"ovh_dedicated_server_update.server", "state", "ok"),
+					resource.TestCheckResourceAttr(
+						"ovh_dedicated_server_update.server", "monitoring", "false"),
+					resource.TestCheckResourceAttr(
+						"ovh_dedicated_server_reinstall_task.server_reinstall", "function", "reinstallServer"),
+					resource.TestCheckResourceAttr(
+						"ovh_dedicated_server_reinstall_task.server_reinstall", "status", "done"),
+				),
+			},
+		},
+	})
+}
+
 func testAccDedicatedServerReinstallConfig(config string) string {
 	dedicated_server := os.Getenv("OVH_DEDICATED_SERVER")
 	sshKey := os.Getenv("OVH_SSH_KEY")
@@ -194,6 +225,13 @@ func testAccDedicatedServerReinstallConfig(config string) string {
 	if config == "storage" {
 		return fmt.Sprintf(
 			testAccDedicatedServerReinstallConfig_Storage,
+			dedicated_server,
+		)
+	}
+
+	if config == "apptoinstall" {
+		return fmt.Sprintf(
+			testAccDedicatedServerReinstallConfig_AppToInstall,
 			dedicated_server,
 		)
 	}
@@ -303,6 +341,29 @@ resource "ovh_dedicated_server_reinstall_task" "server_reinstall" {
 	http_headers = {
 		Authorization = "Basic bG9naW46cGFzc3dvcmQ="
 	}
+  }
+}
+`
+
+const testAccDedicatedServerReinstallConfig_AppToInstall = `
+data "ovh_dedicated_server_boots" "harddisk" {
+  service_name = "%s"
+  boot_type    = "harddisk"
+}
+
+resource "ovh_dedicated_server_update" "server" {
+  service_name = data.ovh_dedicated_server_boots.harddisk.service_name
+  boot_id      = data.ovh_dedicated_server_boots.harddisk.result[0]
+  monitoring   = false
+  state        = "ok"
+}
+
+resource "ovh_dedicated_server_reinstall_task" "server_reinstall" {
+  service_name = data.ovh_dedicated_server_boots.harddisk.service_name
+  os            = "ubuntu2404-withapp_64"
+  customizations {
+    hostname       = "mon-tux"
+    app_to_install = "wordpress"
   }
 }
 `

--- a/ovh/types_dedicated_server.go
+++ b/ovh/types_dedicated_server.go
@@ -184,6 +184,7 @@ type ExtrasDetails struct {
 }
 
 type DedicatedServerReinstallTaskCustomizations struct {
+	AppToInstall                    *string                `json:"appToInstall,omitempty"`
 	ConfigDriveMetadata             map[string]interface{} `json:"configDriveMetadata,omitempty"`
 	ConfigDriveUserData             *string                `json:"configDriveUserData,omitempty"`
 	EfiBootloaderPath               *string                `json:"efiBootloaderPath,omitempty"`
@@ -200,6 +201,7 @@ type DedicatedServerReinstallTaskCustomizations struct {
 }
 
 func (opts *DedicatedServerReinstallTaskCustomizations) FromResource(d *schema.ResourceData, parent string) *DedicatedServerReinstallTaskCustomizations {
+	opts.AppToInstall = helpers.GetNilStringPointerFromData(d, fmt.Sprintf("%s.app_to_install", parent))
 	opts.ConfigDriveMetadata = helpers.GetMapFromData(d, fmt.Sprintf("%s.config_drive_metadata", parent))
 	opts.ConfigDriveUserData = helpers.GetNilStringPointerFromData(d, fmt.Sprintf("%s.config_drive_user_data", parent))
 	opts.EfiBootloaderPath = helpers.GetNilStringPointerFromData(d, fmt.Sprintf("%s.efi_bootloader_path", parent))


### PR DESCRIPTION
# Description

OS ubuntu2404-withapp_64 enables the user ability to install applications directly on top of the Ubuntu 24 OS installation.
API provides dynamic list of installable application. We don't want this complexity, so the terraform parameter is a string (that will be checked by API whether in the application list or not).

Treats #PUBM-55274

## Type of change

- [x] Improvement (improve existing resource(s) or datasource(s))

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Test A: `make testacc TESTARGS="-run TestAccDedicatedServerReinstall_apptoinstall"`

```none
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -run TestAccDedicatedServerReinstall_apptoinstall -timeout 600m -p 10
?   	github.com/ovh/terraform-provider-ovh/v2	[no test files]
=== RUN   TestAccDedicatedServerReinstall_apptoinstall
--- PASS: TestAccDedicatedServerReinstall_apptoinstall (560.15s)
PASS
ok  	github.com/ovh/terraform-provider-ovh/v2/ovh	560.164s
?   	github.com/ovh/terraform-provider-ovh/v2/ovh/datasources/cloud_project_rancher	[no test files]
testing: warning: no tests to run
PASS
ok  	github.com/ovh/terraform-provider-ovh/v2/ovh/helpers	0.007s [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/ovh/terraform-provider-ovh/v2/ovh/helpers/hashcode	0.002s [no tests to run]
?   	github.com/ovh/terraform-provider-ovh/v2/ovh/ovhwrap	[no test files]
?   	github.com/ovh/terraform-provider-ovh/v2/ovh/resources/cloud_project_rancher	[no test files]
?   	github.com/ovh/terraform-provider-ovh/v2/ovh/types	[no test files]
```

**Test Configuration**:
* Terraform version: `terraform version`: Terraform v1.12.2

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation -> no because we don't want to promote it for the moment
- [x] My changes generate no new warnings or issues
- [x] I have added acceptance tests that prove my fix is effective or that my feature works
- [x] New and existing acceptance tests pass locally with my changes
