### PR TITLE
feat(database): support in-place network update for cloud_project_dat…

### DIFF
--- a/docs/resources/cloud_project_database.md
+++ b/docs/resources/cloud_project_database.md
@@ -170,6 +170,54 @@ resource "ovh_cloud_project_database" "mongodb" {
 }
 ```
 
+### Network Update
+
+You can update the network of an existing database service without recreating it.
+
+To switch from public to private network, add `network_id` and `subnet_id` to the nodes:
+
+```terraform
+resource "ovh_cloud_project_database" "db" {
+  service_name  = "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+  description   = "my-database"
+  engine        = "postgresql"
+  version       = "14"
+  plan          = "business"
+  nodes {
+    region      = "GRA"
+    network_id  = "XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX"
+    subnet_id   = "YYYYYYYY-YYYY-YYYY-YYYY-YYYYYYYYYYYY"
+  }
+  nodes {
+    region      = "GRA"
+    network_id  = "XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX"
+    subnet_id   = "YYYYYYYY-YYYY-YYYY-YYYY-YYYYYYYYYYYY"
+  }
+  flavor        = "db1-4"
+}
+```
+
+To switch from private to public network, remove `network_id` and `subnet_id` from the nodes:
+
+```terraform
+resource "ovh_cloud_project_database" "db" {
+  service_name  = "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+  description   = "my-database"
+  engine        = "postgresql"
+  version       = "14"
+  plan          = "business"
+  nodes {
+    region      = "GRA"
+  }
+  nodes {
+    region      = "GRA"
+  }
+  flavor        = "db1-4"
+}
+```
+
+~> **Important:** Changing the network triggers a service rebuild. The service will go through `UPDATING` / `REBUILDING` states before returning to `RUNNING`. During this time the service may be temporarily unavailable. IP restrictions are cleared during a network change as the old IPs are no longer valid on the new network.
+
 ## Argument Reference
 
 The following arguments are supported:
@@ -185,9 +233,9 @@ The following arguments are supported:
 * `kafka_rest_api` - (Optional) Defines whether the REST API is enabled on a kafka cluster
 * `kafka_schema_registry` - (Optional) Defines whether the schema registry is enabled on a Kafka cluster
 * `nodes` - (Required, Minimum Items: 1) List of nodes object. Multi region cluster are not yet available, all node should be identical.
-  * `network_id` - (Optional, Forces new resource) Private network id in which the node should be deployed. It's the regional openstackId of the private network
+  * `network_id` - (Optional) Private network id in which the node should be deployed. It's the regional openstackId of the private network. Can be updated in-place to change the network without recreating the service.
   * `region` - (Required, Forces new resource) Public cloud region in which the node should be deployed. Ex: "GRA'.
-  * `subnet_id` - (Optional, Forces new resource) Private subnet ID in which the node is.
+  * `subnet_id` - (Optional) Private subnet ID in which the node is. Can be updated in-place to change the network without recreating the service.
 * `opensearch_acls_enabled` - (Optional) Defines whether the ACLs are enabled on an OpenSearch cluster
 * `disk_size` - (Optional) The disk size (in GB) of the database service.
 * `advanced_configuration` - (Optional) Advanced configuration key / value.

--- a/ovh/resource_cloud_project_database.go
+++ b/ovh/resource_cloud_project_database.go
@@ -270,7 +270,7 @@ func resourceCloudProjectDatabase() *schema.Resource {
 			for i := 0; i < minLen; i++ {
 				o := oldNodes[i].(map[string]interface{})
 				n := newNodes[i].(map[string]interface{})
-				if o["region"] != n["region"] || o["network_id"] != n["network_id"] {
+				if o["region"] != n["region"] {
 					return true
 				}
 			}

--- a/ovh/types_cloud_project_database.go
+++ b/ovh/types_cloud_project_database.go
@@ -2,6 +2,7 @@ package ovh
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"log"
@@ -284,7 +285,9 @@ type CloudProjectDatabaseUpdateOpts struct {
 	Flavor             string                              `json:"flavor,omitempty"`
 	IPRestrictions     []CloudProjectDatabaseIPRestriction `json:"ipRestrictions,omitempty"`
 	MaintenanceTime    string                              `json:"maintenanceTime,omitempty"`
+	NetworkID          json.RawMessage                     `json:"networkId,omitempty"`
 	Plan               string                              `json:"plan,omitempty"`
+	SubnetID           json.RawMessage                     `json:"subnetId,omitempty"`
 	DeletionProtection *bool                               `json:"deletionProtection,omitempty"`
 	RestAPI            *bool                               `json:"restApi,omitempty"`
 	SchemaRegistry     *bool                               `json:"schemaRegistry,omitempty"`
@@ -342,6 +345,41 @@ func (opts *CloudProjectDatabaseUpdateOpts) fromResource(d *schema.ResourceData)
 	}
 
 	opts.MaintenanceTime = d.Get("maintenance_time").(string)
+
+	// Handle network update: only send networkId/subnetId when they actually changed
+	if d.HasChange("nodes") {
+		oldNodes, newNodes := d.GetChange("nodes")
+		oldList := oldNodes.([]interface{})
+		newList := newNodes.([]interface{})
+
+		oldNetworkID := ""
+		if len(oldList) > 0 {
+			oldNetworkID = oldList[0].(map[string]interface{})["network_id"].(string)
+		}
+		newNetworkID := ""
+		newSubnetID := ""
+		if len(newList) > 0 {
+			newNetworkID = newList[0].(map[string]interface{})["network_id"].(string)
+			newSubnetID = newList[0].(map[string]interface{})["subnet_id"].(string)
+		}
+
+		oldSubnetID := ""
+		if len(oldList) > 0 {
+			oldSubnetID = oldList[0].(map[string]interface{})["subnet_id"].(string)
+		}
+
+		if oldNetworkID != newNetworkID || oldSubnetID != newSubnetID {
+			if newNetworkID == "" {
+				// Switch to public: send null
+				opts.NetworkID = json.RawMessage("null")
+				opts.SubnetID = json.RawMessage("null")
+			} else {
+				// Switch to private: send the UUID
+				opts.NetworkID, _ = json.Marshal(newNetworkID)
+				opts.SubnetID, _ = json.Marshal(newSubnetID)
+			}
+		}
+	}
 
 	return opts, nil
 }

--- a/ovh/types_cloud_project_database_test.go
+++ b/ovh/types_cloud_project_database_test.go
@@ -1,0 +1,68 @@
+package ovh
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestCloudProjectDatabaseUpdateOpts_networkSerialization(t *testing.T) {
+	t.Run("no network change - fields omitted", func(t *testing.T) {
+		opts := CloudProjectDatabaseUpdateOpts{
+			Description: "test",
+			Plan:        "essential",
+		}
+		data, err := json.Marshal(opts)
+		if err != nil {
+			t.Fatalf("unexpected marshal error: %v", err)
+		}
+		if strings.Contains(string(data), "networkId") {
+			t.Errorf("networkId should be omitted when no network change, got: %s", data)
+		}
+		if strings.Contains(string(data), "subnetId") {
+			t.Errorf("subnetId should be omitted when no network change, got: %s", data)
+		}
+	})
+
+	t.Run("switch to public - sends null", func(t *testing.T) {
+		opts := CloudProjectDatabaseUpdateOpts{
+			Description: "test",
+			Plan:        "essential",
+			NetworkID:   json.RawMessage("null"),
+			SubnetID:    json.RawMessage("null"),
+		}
+		data, err := json.Marshal(opts)
+		if err != nil {
+			t.Fatalf("unexpected marshal error: %v", err)
+		}
+		if !strings.Contains(string(data), `"networkId":null`) {
+			t.Errorf("expected null networkId, got: %s", data)
+		}
+		if !strings.Contains(string(data), `"subnetId":null`) {
+			t.Errorf("expected null subnetId, got: %s", data)
+		}
+	})
+
+	t.Run("switch to private - sends UUID", func(t *testing.T) {
+		networkUUID := "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+		subnetUUID := "11111111-2222-3333-4444-555555555555"
+
+		opts := CloudProjectDatabaseUpdateOpts{
+			Description: "test",
+			Plan:        "essential",
+		}
+		opts.NetworkID, _ = json.Marshal(networkUUID)
+		opts.SubnetID, _ = json.Marshal(subnetUUID)
+
+		data, err := json.Marshal(opts)
+		if err != nil {
+			t.Fatalf("unexpected marshal error: %v", err)
+		}
+		if !strings.Contains(string(data), `"networkId":"aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"`) {
+			t.Errorf("expected UUID networkId, got: %s", data)
+		}
+		if !strings.Contains(string(data), `"subnetId":"11111111-2222-3333-4444-555555555555"`) {
+			t.Errorf("expected UUID subnetId, got: %s", data)
+		}
+	})
+}


### PR DESCRIPTION
feat(database): support in-place network update for cloud_project_database

# Description

Allow updating `network_id` and `subnet_id` on `ovh_cloud_project_database` nodes without forcing resource recreation. This enables switching between public and private networks via `terraform apply`.

Previously, changing `network_id` on a node triggered a destroy+recreate of the entire database cluster. This change makes it an in-place update by:

- Removing `network_id` from `ForceNewIfChange` in `CustomizeDiff`
- Adding `NetworkID`/`SubnetID` as `json.RawMessage` to the update opts for proper null handling (omitted = no change, `null` = switch to public, UUID string = switch to private)
- Only including network fields in the PUT request when they actually changed
- Adding unit tests for network serialization
- Updating documentation with network update examples

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] Documentation update

# How Has This Been Tested?

- [x] Unit test: `go test ./ovh/ -run TestCloudProjectDatabaseUpdateOpts_networkSerialization`
- [x] Manual test: public to private network switch (in-place update, ~16min)
- [x] Manual test: private to public network switch (in-place update)

**Test Configuration**:
* Terraform version: `terraform version`: Terraform v1.9.7
* Existing HCL configuration used:
```hcl
resource "ovh_cloud_project_database" "db" {
  service_name = "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
  description  = "test-network-update"
  engine       = "postgresql"
  version      = "17"
  plan         = "production"
  nodes {
    region     = "EU-WEST-PAR"
    network_id = "XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX"
    subnet_id  = "YYYYYYYY-YYYY-YYYY-YYYY-YYYYYYYYYYYY"
  }
  nodes {
    region     = "EU-WEST-PAR"
    network_id = "XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX"
    subnet_id  = "YYYYYYYY-YYYY-YYYY-YYYY-YYYYYYYYYYYY"
  }
  flavor = "b3-8"
}
```

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or issues
- [ ] I have added acceptance tests that prove my fix is effective or that my feature works
- [ ] New and existing acceptance tests pass locally with my changes
- [x] I ran successfully `go mod vendor` if I added or modify `go.mod` file
