### PR TITLE
fix: vrack ip id format

### DIFF
--- a/ovh/resource_vrack_ip.go
+++ b/ovh/resource_vrack_ip.go
@@ -94,7 +94,7 @@ func resourceVrackIpCreate(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	//set id
-	d.SetId(fmt.Sprintf("vrack_%s-dedicatedserver_%s", serviceName, opts.Block))
+	d.SetId(fmt.Sprintf("vrack_%s-block_%s", serviceName, opts.Block))
 
 	return resourceVrackIpRead(d, meta)
 }


### PR DESCRIPTION
# Description

Typo fix in vrack_ip resource ID field
Fixes #936 (issue)

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (improve existing resource(s) or datasource(s))
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [X] Test A: `make testacc TESTARGS="-run TestAccVrackIp_basic"`
- [X] Test B: `make testacc TESTARGS="-run TestAccVrackIpWithRegion_basic"`


# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings or issues
- [X] New and existing acceptance tests pass locally with my changes
