### PR TITLE
fix: remove email field from cloud_project_alerting resource

### DIFF
--- a/docs/resources/cloud_project_alerting.md
+++ b/docs/resources/cloud_project_alerting.md
@@ -12,7 +12,6 @@ Creates an alert on a public cloud project.
 resource "ovh_cloud_project_alerting" "my_alert" {
   service_name = "XXX"
   delay = 3600
-  email = "aaa.bbb@domain.com"
   monthly_threshold = 1000
 }
 ```
@@ -21,7 +20,6 @@ resource "ovh_cloud_project_alerting" "my_alert" {
 
 * `service_name` - The id of the public cloud project. If omitted, the `OVH_CLOUD_PROJECT_SERVICE` environment variable is used.
 * `delay` - Delay between two alerts in seconds
-* `email` - Email to contact
 * `monthly_threshold` - Monthly threshold for this alerting in currency
 
 ## Attributes Reference
@@ -31,7 +29,6 @@ The following attributes are exported:
 * `id` - Alert ID
 * `creationDate` - Alerting creation date
 * `delay` - Delay between two alerts in seconds
-* `email` - Email to contact
 * `monthly_threshold` - Monthly threshold for this alerting in currency
 * `formatted_monthly_threshold` - Formatted monthly threshold for this alerting
   * `currency_code` - Currency of the monthly threshold

--- a/examples/resources/cloud_project_alerting/example_1.tf
+++ b/examples/resources/cloud_project_alerting/example_1.tf
@@ -1,6 +1,5 @@
 resource "ovh_cloud_project_alerting" "my_alert" {
   service_name = "XXX"
   delay = 3600
-  email = "aaa.bbb@domain.com"
   monthly_threshold = 1000
 }

--- a/ovh/resource_cloud_project_alerting.go
+++ b/ovh/resource_cloud_project_alerting.go
@@ -78,9 +78,6 @@ func (r *cloudProjectAlertingResource) Create(ctx context.Context, req resource.
 
 	responseData.MergeWith(&data)
 
-	// Explicitly set email to the plan value as it's not returned by the API
-	responseData.Email = data.Email
-
 	// Save data into Terraform state
 	resp.Diagnostics.Append(resp.State.Set(ctx, &responseData)...)
 }
@@ -146,9 +143,6 @@ func (r *cloudProjectAlertingResource) Update(ctx context.Context, req resource.
 	}
 
 	responseData.MergeWith(&planData)
-
-	// Explicitly set email to the plan value as it's not returned by the API
-	responseData.Email = planData.Email
 
 	// Save updated data into Terraform state
 	resp.Diagnostics.Append(resp.State.Set(ctx, &responseData)...)

--- a/ovh/resource_cloud_project_alerting_gen.go
+++ b/ovh/resource_cloud_project_alerting_gen.go
@@ -49,12 +49,6 @@ func CloudProjectAlertingResourceSchema(ctx context.Context) schema.Schema {
 					),
 				},
 			},
-			"email": schema.StringAttribute{
-				CustomType:          ovhtypes.TfStringType{},
-				Required:            true,
-				Description:         "Email to contact",
-				MarkdownDescription: "Email to contact",
-			},
 			"formatted_monthly_threshold": schema.SingleNestedAttribute{
 				Attributes: map[string]schema.Attribute{
 					"currency_code": schema.StringAttribute{
@@ -107,7 +101,6 @@ func CloudProjectAlertingResourceSchema(ctx context.Context) schema.Schema {
 type CloudProjectAlertingModel struct {
 	CreationDate              ovhtypes.TfStringValue         `tfsdk:"creation_date" json:"creationDate"`
 	Delay                     ovhtypes.TfInt64Value          `tfsdk:"delay" json:"delay"`
-	Email                     ovhtypes.TfStringValue         `tfsdk:"email" json:"email"`
 	FormattedMonthlyThreshold FormattedMonthlyThresholdValue `tfsdk:"formatted_monthly_threshold" json:"formattedMonthlyThreshold"`
 	Id                        ovhtypes.TfStringValue         `tfsdk:"id" json:"id"`
 	MonthlyThreshold          ovhtypes.TfInt64Value          `tfsdk:"monthly_threshold" json:"monthlyThreshold"`
@@ -122,10 +115,6 @@ func (v *CloudProjectAlertingModel) MergeWith(other *CloudProjectAlertingModel) 
 
 	if (v.Delay.IsUnknown() || v.Delay.IsNull()) && !other.Delay.IsUnknown() {
 		v.Delay = other.Delay
-	}
-
-	if (v.Email.IsUnknown() || v.Email.IsNull()) && !other.Email.IsUnknown() {
-		v.Email = other.Email
 	}
 
 	if v.FormattedMonthlyThreshold.IsUnknown() && !other.FormattedMonthlyThreshold.IsUnknown() {
@@ -149,9 +138,8 @@ func (v *CloudProjectAlertingModel) MergeWith(other *CloudProjectAlertingModel) 
 }
 
 type CloudProjectAlertingWritableModel struct {
-	Delay            *ovhtypes.TfInt64Value  `tfsdk:"delay" json:"delay,omitempty"`
-	Email            *ovhtypes.TfStringValue `tfsdk:"email" json:"email,omitempty"`
-	MonthlyThreshold *ovhtypes.TfInt64Value  `tfsdk:"monthly_threshold" json:"monthlyThreshold,omitempty"`
+	Delay            *ovhtypes.TfInt64Value `tfsdk:"delay" json:"delay,omitempty"`
+	MonthlyThreshold *ovhtypes.TfInt64Value `tfsdk:"monthly_threshold" json:"monthlyThreshold,omitempty"`
 }
 
 func (v CloudProjectAlertingModel) ToCreate() *CloudProjectAlertingWritableModel {
@@ -159,10 +147,6 @@ func (v CloudProjectAlertingModel) ToCreate() *CloudProjectAlertingWritableModel
 
 	if !v.Delay.IsUnknown() {
 		res.Delay = &v.Delay
-	}
-
-	if !v.Email.IsUnknown() {
-		res.Email = &v.Email
 	}
 
 	if !v.MonthlyThreshold.IsUnknown() {
@@ -177,10 +161,6 @@ func (v CloudProjectAlertingModel) ToUpdate() *CloudProjectAlertingWritableModel
 
 	if !v.Delay.IsUnknown() {
 		res.Delay = &v.Delay
-	}
-
-	if !v.Email.IsUnknown() {
-		res.Email = &v.Email
 	}
 
 	if !v.MonthlyThreshold.IsUnknown() {

--- a/ovh/resource_cloud_project_alerting_test.go
+++ b/ovh/resource_cloud_project_alerting_test.go
@@ -13,7 +13,6 @@ resource "ovh_cloud_project_alerting" "alert" {
 	service_name = "%s"
 	delay = 259200
 	monthly_threshold = 3000
-	email = "some.test@ovhcloud.com"
 }
 `
 
@@ -22,7 +21,6 @@ resource "ovh_cloud_project_alerting" "alert" {
 	service_name = "%s"
 	delay = 604800
 	monthly_threshold = 100
-	email = "some.test@ovhcloud.com"
 }
 `
 
@@ -44,8 +42,6 @@ func TestAccCloudProjectAlerting_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"ovh_cloud_project_alerting.alert", "monthly_threshold", "3000"),
 					resource.TestCheckResourceAttr(
-						"ovh_cloud_project_alerting.alert", "email", "some.test@ovhcloud.com"),
-					resource.TestCheckResourceAttr(
 						"ovh_cloud_project_alerting.alert", "formatted_monthly_threshold.currency_code", "EUR"),
 					resource.TestCheckResourceAttr(
 						"ovh_cloud_project_alerting.alert", "formatted_monthly_threshold.text", "3 000,00 €"),
@@ -60,8 +56,6 @@ func TestAccCloudProjectAlerting_basic(t *testing.T) {
 						"ovh_cloud_project_alerting.alert", "delay", "604800"),
 					resource.TestCheckResourceAttr(
 						"ovh_cloud_project_alerting.alert", "monthly_threshold", "100"),
-					resource.TestCheckResourceAttr(
-						"ovh_cloud_project_alerting.alert", "email", "some.test@ovhcloud.com"),
 					resource.TestCheckResourceAttr(
 						"ovh_cloud_project_alerting.alert", "formatted_monthly_threshold.currency_code", "EUR"),
 					resource.TestCheckResourceAttr(

--- a/templates/resources/cloud_project_alerting.md.tmpl
+++ b/templates/resources/cloud_project_alerting.md.tmpl
@@ -19,7 +19,6 @@ Creates an alert on a public cloud project.
 * `service_name` - The id of the public cloud project. If omitted, the `OVH_CLOUD_PROJECT_SERVICE` environment variable is used.
 
 * `delay` - Delay between two alerts in seconds
-* `email` - Email to contact
 * `monthly_threshold` - Monthly threshold for this alerting in currency
 
 ## Attributes Reference
@@ -29,7 +28,6 @@ The following attributes are exported:
 * `id` - Alert ID
 * `creationDate` - Alerting creation date
 * `delay` - Delay between two alerts in seconds
-* `email` - Email to contact
 * `monthly_threshold` - Monthly threshold for this alerting in currency
 * `formatted_monthly_threshold` - Formatted monthly threshold for this alerting
   * `currency_code` - Currency of the monthly threshold


### PR DESCRIPTION

# Description

Remove email attribute of the cloud_project_alerting resource
Fixes #1150 (issue)

## Type of change

Please delete options that are not relevant.

- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings or issues
- [X] I have added acceptance tests that prove my fix is effective or that my feature works
- [X] New and existing acceptance tests pass locally with my changes
