### PR TITLE
feat(blockstorage): expose availability zone on volume snapshot

### DIFF
--- a/docs/data-sources/cloud_storage_block_volume_snapshot.md
+++ b/docs/data-sources/cloud_storage_block_volume_snapshot.md
@@ -26,6 +26,7 @@ data "ovh_cloud_storage_block_volume_snapshot" "snapshot" {
 * `description` - Snapshot description.
 * `location` - Location of the snapshot:
   * `region` - Region.
+  * `availability_zone` - Availability zone. Empty in 1AZ regions.
 * `volume_id` - ID of the snapshotted volume.
 * `size` - Size of the snapshot in GB.
 * `resource_status` - Snapshot readiness in the system (`CREATING`, `DELETING`, `ERROR`, `OUT_OF_SYNC`, `READY`, `UPDATING`).

--- a/docs/data-sources/cloud_storage_block_volume_snapshots.md
+++ b/docs/data-sources/cloud_storage_block_volume_snapshots.md
@@ -30,6 +30,7 @@ data "ovh_cloud_storage_block_volume_snapshots" "snapshots" {
   * `description` - Snapshot description.
   * `location` - Location of the snapshot:
     * `region` - Region.
+    * `availability_zone` - Availability zone. Empty in 1AZ regions.
   * `volume_id` - ID of the snapshotted volume.
   * `size` - Size of the snapshot in GB.
   * `resource_status` - Snapshot readiness in the system (`CREATING`, `DELETING`, `ERROR`, `OUT_OF_SYNC`, `READY`, `UPDATING`).

--- a/docs/resources/cloud_storage_block_volume_snapshot.md
+++ b/docs/resources/cloud_storage_block_volume_snapshot.md
@@ -42,6 +42,7 @@ The following arguments are supported:
 * `name` - (Required) The name of the snapshot.
 * `description` - (Optional) A description for the snapshot.
 * `region` - (Required) The region where the snapshot will be created. Changing this value recreates the resource.
+* `availability_zone` - (Optional) The availability zone where the snapshot will be created. Only meaningful in 3AZ regions; leave unset in 1AZ regions, where it is empty. Defaults to the value returned by the API. Changing this value recreates the resource.
 * `volume_id` - (Required) The ID of the volume to snapshot. Changing this value recreates the resource.
 
 ## Attributes Reference
@@ -56,6 +57,7 @@ The following attributes are exported:
 * `current_state` - Current state of the snapshot:
   * `location` - Current location:
     * `region` - Region.
+    * `availability_zone` - Availability zone. Empty in 1AZ regions.
   * `name` - Snapshot name.
   * `description` - Snapshot description.
   * `volume_id` - ID of the snapshotted volume.

--- a/ovh/data_cloud_storage_block_volume_snapshot.go
+++ b/ovh/data_cloud_storage_block_volume_snapshot.go
@@ -79,6 +79,11 @@ func (d *cloudStorageBlockVolumeSnapshotDataSource) Schema(ctx context.Context, 
 						Computed:    true,
 						Description: "Region",
 					},
+					"availability_zone": schema.StringAttribute{
+						CustomType:  ovhtypes.TfStringType{},
+						Computed:    true,
+						Description: "Availability zone",
+					},
 				},
 			},
 			"volume_id": schema.StringAttribute{
@@ -135,12 +140,14 @@ func (d *cloudStorageBlockVolumeSnapshotDataSource) Read(ctx context.Context, re
 	description := ""
 	volumeId := ""
 	region := ""
+	az := ""
 	if s.TargetSpec != nil {
 		name = s.TargetSpec.Name
 		description = s.TargetSpec.Description
 		volumeId = s.TargetSpec.VolumeId
 		if s.TargetSpec.Location != nil {
 			region = s.TargetSpec.Location.Region
+			az = s.TargetSpec.Location.AvailabilityZone
 		}
 	}
 
@@ -158,13 +165,21 @@ func (d *cloudStorageBlockVolumeSnapshotDataSource) Read(ctx context.Context, re
 		}
 		if s.CurrentState.Location != nil {
 			region = s.CurrentState.Location.Region
+			// Empty in 1AZ regions: keep the targetSpec value instead of blanking it.
+			if s.CurrentState.Location.AvailabilityZone != "" {
+				az = s.CurrentState.Location.AvailabilityZone
+			}
 		}
 	}
 
 	locObj, diags := types.ObjectValue(
-		map[string]attr.Type{"region": ovhtypes.TfStringType{}},
+		map[string]attr.Type{
+			"region":            ovhtypes.TfStringType{},
+			"availability_zone": ovhtypes.TfStringType{},
+		},
 		map[string]attr.Value{
-			"region": ovhtypes.TfStringValue{StringValue: types.StringValue(region)},
+			"region":            ovhtypes.TfStringValue{StringValue: types.StringValue(region)},
+			"availability_zone": ovhtypes.TfStringValue{StringValue: types.StringValue(az)},
 		},
 	)
 	resp.Diagnostics.Append(diags...)

--- a/ovh/data_cloud_storage_block_volume_snapshot_test.go
+++ b/ovh/data_cloud_storage_block_volume_snapshot_test.go
@@ -24,6 +24,7 @@ resource "ovh_cloud_storage_block_volume_snapshot" "snapshot" {
   description  = "%s"
   region       = "%s"
   volume_id    = ovh_cloud_storage_block_volume.volume.id
+  %s
 }
 
 data "ovh_cloud_storage_block_volume_snapshot" "snapshot" {
@@ -38,13 +39,39 @@ func TestAccDataSourceCloudStorageBlockVolumeSnapshot_basic(t *testing.T) {
 	volumeName := acctest.RandomWithPrefix(test_prefix)
 	snapshotName := acctest.RandomWithPrefix(test_prefix)
 	description := "test snapshot description"
+	// Optional: only set for 3AZ regions, where the API reports an availability zone.
+	az := os.Getenv("OVH_CLOUD_PROJECT_AZ_TEST")
+
+	azConfig := ""
+	if az != "" {
+		azConfig = fmt.Sprintf("availability_zone = %q", az)
+	}
 
 	config := fmt.Sprintf(
 		testAccDataSourceCloudStorageBlockVolumeSnapshotConfig,
 		serviceName, volumeName, region,
-		serviceName, snapshotName, description, region,
+		serviceName, snapshotName, description, region, azConfig,
 		serviceName,
 	)
+
+	checks := []resource.TestCheckFunc{
+		resource.TestCheckResourceAttr("data.ovh_cloud_storage_block_volume_snapshot.snapshot", "service_name", serviceName),
+		resource.TestCheckResourceAttrPair(
+			"data.ovh_cloud_storage_block_volume_snapshot.snapshot", "id",
+			"ovh_cloud_storage_block_volume_snapshot.snapshot", "id",
+		),
+		resource.TestCheckResourceAttrPair(
+			"data.ovh_cloud_storage_block_volume_snapshot.snapshot", "volume_id",
+			"ovh_cloud_storage_block_volume.volume", "id",
+		),
+		resource.TestCheckResourceAttr("data.ovh_cloud_storage_block_volume_snapshot.snapshot", "name", snapshotName),
+		resource.TestCheckResourceAttr("data.ovh_cloud_storage_block_volume_snapshot.snapshot", "description", description),
+		resource.TestCheckResourceAttrSet("data.ovh_cloud_storage_block_volume_snapshot.snapshot", "size"),
+		resource.TestCheckResourceAttr("data.ovh_cloud_storage_block_volume_snapshot.snapshot", "location.region", region),
+	}
+	if az != "" {
+		checks = append(checks, resource.TestCheckResourceAttr("data.ovh_cloud_storage_block_volume_snapshot.snapshot", "location.availability_zone", az))
+	}
 
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
@@ -55,21 +82,7 @@ func TestAccDataSourceCloudStorageBlockVolumeSnapshot_basic(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: config,
-				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr("data.ovh_cloud_storage_block_volume_snapshot.snapshot", "service_name", serviceName),
-					resource.TestCheckResourceAttrPair(
-						"data.ovh_cloud_storage_block_volume_snapshot.snapshot", "id",
-						"ovh_cloud_storage_block_volume_snapshot.snapshot", "id",
-					),
-					resource.TestCheckResourceAttrPair(
-						"data.ovh_cloud_storage_block_volume_snapshot.snapshot", "volume_id",
-						"ovh_cloud_storage_block_volume.volume", "id",
-					),
-					resource.TestCheckResourceAttr("data.ovh_cloud_storage_block_volume_snapshot.snapshot", "name", snapshotName),
-					resource.TestCheckResourceAttr("data.ovh_cloud_storage_block_volume_snapshot.snapshot", "description", description),
-					resource.TestCheckResourceAttrSet("data.ovh_cloud_storage_block_volume_snapshot.snapshot", "size"),
-					resource.TestCheckResourceAttr("data.ovh_cloud_storage_block_volume_snapshot.snapshot", "location.region", region),
-				),
+				Check:  resource.ComposeAggregateTestCheckFunc(checks...),
 			},
 		},
 	})

--- a/ovh/data_cloud_storage_block_volume_snapshots.go
+++ b/ovh/data_cloud_storage_block_volume_snapshots.go
@@ -96,6 +96,11 @@ func (d *cloudStorageBlockVolumeSnapshotsDataSource) Schema(ctx context.Context,
 									Computed:    true,
 									Description: "Region",
 								},
+								"availability_zone": schema.StringAttribute{
+									CustomType:  ovhtypes.TfStringType{},
+									Computed:    true,
+									Description: "Availability zone",
+								},
 							},
 						},
 						"volume_id": schema.StringAttribute{
@@ -134,7 +139,8 @@ func snapshotListItemAttrTypes() map[string]attr.Type {
 		"name":        ovhtypes.TfStringType{},
 		"description": ovhtypes.TfStringType{},
 		"location": types.ObjectType{AttrTypes: map[string]attr.Type{
-			"region": ovhtypes.TfStringType{},
+			"region":            ovhtypes.TfStringType{},
+			"availability_zone": ovhtypes.TfStringType{},
 		}},
 		"volume_id":       ovhtypes.TfStringType{},
 		"size":            types.Int64Type,
@@ -173,10 +179,14 @@ func (d *cloudStorageBlockVolumeSnapshotsDataSource) Read(ctx context.Context, r
 		name := ""
 		description := ""
 		volumeId := ""
+		az := ""
 		if s.TargetSpec != nil {
 			name = s.TargetSpec.Name
 			description = s.TargetSpec.Description
 			volumeId = s.TargetSpec.VolumeId
+			if s.TargetSpec.Location != nil {
+				az = s.TargetSpec.Location.AvailabilityZone
+			}
 		}
 
 		size := int64(0)
@@ -194,13 +204,21 @@ func (d *cloudStorageBlockVolumeSnapshotsDataSource) Read(ctx context.Context, r
 			}
 			if s.CurrentState.Location != nil {
 				region = s.CurrentState.Location.Region
+				// Empty in 1AZ regions: keep the targetSpec value instead of blanking it.
+				if s.CurrentState.Location.AvailabilityZone != "" {
+					az = s.CurrentState.Location.AvailabilityZone
+				}
 			}
 		}
 
 		locObj, diags := types.ObjectValue(
-			map[string]attr.Type{"region": ovhtypes.TfStringType{}},
+			map[string]attr.Type{
+				"region":            ovhtypes.TfStringType{},
+				"availability_zone": ovhtypes.TfStringType{},
+			},
 			map[string]attr.Value{
-				"region": ovhtypes.TfStringValue{StringValue: types.StringValue(region)},
+				"region":            ovhtypes.TfStringValue{StringValue: types.StringValue(region)},
+				"availability_zone": ovhtypes.TfStringValue{StringValue: types.StringValue(az)},
 			},
 		)
 		resp.Diagnostics.Append(diags...)

--- a/ovh/data_cloud_storage_block_volume_snapshots_test.go
+++ b/ovh/data_cloud_storage_block_volume_snapshots_test.go
@@ -24,6 +24,7 @@ resource "ovh_cloud_storage_block_volume_snapshot" "snapshot" {
   description  = "%s"
   region       = "%s"
   volume_id    = ovh_cloud_storage_block_volume.volume.id
+  %s
 }
 
 data "ovh_cloud_storage_block_volume_snapshots" "snapshots" {
@@ -41,13 +42,39 @@ func TestAccDataSourceCloudStorageBlockVolumeSnapshots_basic(t *testing.T) {
 	volumeName := acctest.RandomWithPrefix(test_prefix)
 	snapshotName := acctest.RandomWithPrefix(test_prefix)
 	description := "test snapshot description"
+	// Optional: only set for 3AZ regions, where the API reports an availability zone.
+	az := os.Getenv("OVH_CLOUD_PROJECT_AZ_TEST")
+
+	azConfig := ""
+	if az != "" {
+		azConfig = fmt.Sprintf("availability_zone = %q", az)
+	}
 
 	config := fmt.Sprintf(
 		testAccDataSourceCloudStorageBlockVolumeSnapshotsConfig,
 		serviceName, volumeName, region,
-		serviceName, snapshotName, description, region,
+		serviceName, snapshotName, description, region, azConfig,
 		serviceName, region,
 	)
+
+	checks := []resource.TestCheckFunc{
+		resource.TestCheckResourceAttr("data.ovh_cloud_storage_block_volume_snapshots.snapshots", "service_name", serviceName),
+		resource.TestCheckResourceAttr("data.ovh_cloud_storage_block_volume_snapshots.snapshots", "region", region),
+		resource.TestCheckResourceAttrPair(
+			"data.ovh_cloud_storage_block_volume_snapshots.snapshots", "volume_id",
+			"ovh_cloud_storage_block_volume.volume", "id",
+		),
+		resource.TestCheckResourceAttrPair(
+			"data.ovh_cloud_storage_block_volume_snapshots.snapshots", "snapshots.0.id",
+			"ovh_cloud_storage_block_volume_snapshot.snapshot", "id",
+		),
+		resource.TestCheckResourceAttr("data.ovh_cloud_storage_block_volume_snapshots.snapshots", "snapshots.0.name", snapshotName),
+		resource.TestCheckResourceAttrSet("data.ovh_cloud_storage_block_volume_snapshots.snapshots", "snapshots.0.size"),
+		resource.TestCheckResourceAttr("data.ovh_cloud_storage_block_volume_snapshots.snapshots", "snapshots.0.location.region", region),
+	}
+	if az != "" {
+		checks = append(checks, resource.TestCheckResourceAttr("data.ovh_cloud_storage_block_volume_snapshots.snapshots", "snapshots.0.location.availability_zone", az))
+	}
 
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
@@ -58,21 +85,7 @@ func TestAccDataSourceCloudStorageBlockVolumeSnapshots_basic(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: config,
-				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr("data.ovh_cloud_storage_block_volume_snapshots.snapshots", "service_name", serviceName),
-					resource.TestCheckResourceAttr("data.ovh_cloud_storage_block_volume_snapshots.snapshots", "region", region),
-					resource.TestCheckResourceAttrPair(
-						"data.ovh_cloud_storage_block_volume_snapshots.snapshots", "volume_id",
-						"ovh_cloud_storage_block_volume.volume", "id",
-					),
-					resource.TestCheckResourceAttrPair(
-						"data.ovh_cloud_storage_block_volume_snapshots.snapshots", "snapshots.0.id",
-						"ovh_cloud_storage_block_volume_snapshot.snapshot", "id",
-					),
-					resource.TestCheckResourceAttr("data.ovh_cloud_storage_block_volume_snapshots.snapshots", "snapshots.0.name", snapshotName),
-					resource.TestCheckResourceAttrSet("data.ovh_cloud_storage_block_volume_snapshots.snapshots", "snapshots.0.size"),
-					resource.TestCheckResourceAttr("data.ovh_cloud_storage_block_volume_snapshots.snapshots", "snapshots.0.location.region", region),
-				),
+				Check:  resource.ComposeAggregateTestCheckFunc(checks...),
 			},
 		},
 	})

--- a/ovh/resource_cloud_storage_block_volume_snapshot.go
+++ b/ovh/resource_cloud_storage_block_volume_snapshot.go
@@ -94,6 +94,17 @@ func (r *cloudStorageBlockVolumeSnapshotResource) Schema(ctx context.Context, re
 					stringplanmodifier.RequiresReplace(),
 				},
 			},
+			"availability_zone": schema.StringAttribute{
+				CustomType:          ovhtypes.TfStringType{},
+				Optional:            true,
+				Computed:            true,
+				Description:         "Availability zone where the snapshot will be created",
+				MarkdownDescription: "Availability zone where the snapshot will be created",
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+					stringplanmodifier.RequiresReplace(),
+				},
+			},
 			"volume_id": schema.StringAttribute{
 				CustomType:          ovhtypes.TfStringType{},
 				Required:            true,
@@ -158,6 +169,12 @@ func (r *cloudStorageBlockVolumeSnapshotResource) Schema(ctx context.Context, re
 								Computed:            true,
 								Description:         "Region",
 								MarkdownDescription: "Region",
+							},
+							"availability_zone": schema.StringAttribute{
+								CustomType:          ovhtypes.TfStringType{},
+								Computed:            true,
+								Description:         "Availability zone",
+								MarkdownDescription: "Availability zone",
 							},
 						},
 					},

--- a/ovh/resource_cloud_storage_block_volume_snapshot_test.go
+++ b/ovh/resource_cloud_storage_block_volume_snapshot_test.go
@@ -25,6 +25,7 @@ resource "ovh_cloud_storage_block_volume_snapshot" "snapshot" {
   description  = "%s"
   region       = "%s"
   volume_id    = ovh_cloud_storage_block_volume.volume.id
+  %s
 }
 `
 
@@ -43,6 +44,7 @@ resource "ovh_cloud_storage_block_volume_snapshot" "snapshot" {
   description  = "%s"
   region       = "%s"
   volume_id    = ovh_cloud_storage_block_volume.volume.id
+  %s
 }
 `
 
@@ -52,12 +54,35 @@ func TestAccCloudStorageBlockVolumeSnapshot_basic(t *testing.T) {
 	volumeName := acctest.RandomWithPrefix(test_prefix)
 	snapshotName := acctest.RandomWithPrefix(test_prefix)
 	description := "test snapshot description"
+	// Optional: only set for 3AZ regions, where the API reports an availability zone.
+	az := os.Getenv("OVH_CLOUD_PROJECT_AZ_TEST")
+
+	azConfig := ""
+	if az != "" {
+		azConfig = fmt.Sprintf("availability_zone = %q", az)
+	}
 
 	config := fmt.Sprintf(
 		testAccCloudStorageBlockVolumeSnapshotConfig,
 		serviceName, volumeName, region,
-		serviceName, snapshotName, description, region,
+		serviceName, snapshotName, description, region, azConfig,
 	)
+
+	checks := []resource.TestCheckFunc{
+		resource.TestCheckResourceAttr("ovh_cloud_storage_block_volume_snapshot.snapshot", "service_name", serviceName),
+		resource.TestCheckResourceAttr("ovh_cloud_storage_block_volume_snapshot.snapshot", "name", snapshotName),
+		resource.TestCheckResourceAttr("ovh_cloud_storage_block_volume_snapshot.snapshot", "description", description),
+		resource.TestCheckResourceAttr("ovh_cloud_storage_block_volume_snapshot.snapshot", "region", region),
+		resource.TestCheckResourceAttrSet("ovh_cloud_storage_block_volume_snapshot.snapshot", "id"),
+		resource.TestCheckResourceAttrSet("ovh_cloud_storage_block_volume_snapshot.snapshot", "checksum"),
+		resource.TestCheckResourceAttrSet("ovh_cloud_storage_block_volume_snapshot.snapshot", "created_at"),
+		resource.TestCheckResourceAttrSet("ovh_cloud_storage_block_volume_snapshot.snapshot", "volume_id"),
+		resource.TestCheckResourceAttrSet("ovh_cloud_storage_block_volume_snapshot.snapshot", "current_state.name"),
+		resource.TestCheckResourceAttrSet("ovh_cloud_storage_block_volume_snapshot.snapshot", "current_state.volume_id"),
+	}
+	if az != "" {
+		checks = append(checks, resource.TestCheckResourceAttr("ovh_cloud_storage_block_volume_snapshot.snapshot", "availability_zone", az))
+	}
 
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
@@ -68,18 +93,7 @@ func TestAccCloudStorageBlockVolumeSnapshot_basic(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: config,
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("ovh_cloud_storage_block_volume_snapshot.snapshot", "service_name", serviceName),
-					resource.TestCheckResourceAttr("ovh_cloud_storage_block_volume_snapshot.snapshot", "name", snapshotName),
-					resource.TestCheckResourceAttr("ovh_cloud_storage_block_volume_snapshot.snapshot", "description", description),
-					resource.TestCheckResourceAttr("ovh_cloud_storage_block_volume_snapshot.snapshot", "region", region),
-					resource.TestCheckResourceAttrSet("ovh_cloud_storage_block_volume_snapshot.snapshot", "id"),
-					resource.TestCheckResourceAttrSet("ovh_cloud_storage_block_volume_snapshot.snapshot", "checksum"),
-					resource.TestCheckResourceAttrSet("ovh_cloud_storage_block_volume_snapshot.snapshot", "created_at"),
-					resource.TestCheckResourceAttrSet("ovh_cloud_storage_block_volume_snapshot.snapshot", "volume_id"),
-					resource.TestCheckResourceAttrSet("ovh_cloud_storage_block_volume_snapshot.snapshot", "current_state.name"),
-					resource.TestCheckResourceAttrSet("ovh_cloud_storage_block_volume_snapshot.snapshot", "current_state.volume_id"),
-				),
+				Check:  resource.ComposeTestCheckFunc(checks...),
 			},
 			{
 				ResourceName:      "ovh_cloud_storage_block_volume_snapshot.snapshot",
@@ -105,18 +119,34 @@ func TestAccCloudStorageBlockVolumeSnapshot_update(t *testing.T) {
 	snapshotNameUpdated := acctest.RandomWithPrefix(test_prefix)
 	description := "test snapshot description"
 	descriptionUpdated := "updated snapshot description"
+	// Optional: only set for 3AZ regions, where the API reports an availability zone.
+	az := os.Getenv("OVH_CLOUD_PROJECT_AZ_TEST")
+
+	azConfig := ""
+	if az != "" {
+		azConfig = fmt.Sprintf("availability_zone = %q", az)
+	}
 
 	config := fmt.Sprintf(
 		testAccCloudStorageBlockVolumeSnapshotConfig,
 		serviceName, volumeName, region,
-		serviceName, snapshotName, description, region,
+		serviceName, snapshotName, description, region, azConfig,
 	)
 
 	configUpdated := fmt.Sprintf(
 		testAccCloudStorageBlockVolumeSnapshotUpdatedConfig,
 		serviceName, volumeName, region,
-		serviceName, snapshotNameUpdated, descriptionUpdated, region,
+		serviceName, snapshotNameUpdated, descriptionUpdated, region, azConfig,
 	)
+
+	// AZ is immutable: it must survive a name/description update without a replace.
+	updatedChecks := []resource.TestCheckFunc{
+		resource.TestCheckResourceAttr("ovh_cloud_storage_block_volume_snapshot.snapshot", "name", snapshotNameUpdated),
+		resource.TestCheckResourceAttr("ovh_cloud_storage_block_volume_snapshot.snapshot", "description", descriptionUpdated),
+	}
+	if az != "" {
+		updatedChecks = append(updatedChecks, resource.TestCheckResourceAttr("ovh_cloud_storage_block_volume_snapshot.snapshot", "availability_zone", az))
+	}
 
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
@@ -134,10 +164,7 @@ func TestAccCloudStorageBlockVolumeSnapshot_update(t *testing.T) {
 			},
 			{
 				Config: configUpdated,
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("ovh_cloud_storage_block_volume_snapshot.snapshot", "name", snapshotNameUpdated),
-					resource.TestCheckResourceAttr("ovh_cloud_storage_block_volume_snapshot.snapshot", "description", descriptionUpdated),
-				),
+				Check:  resource.ComposeTestCheckFunc(updatedChecks...),
 			},
 		},
 	})

--- a/ovh/types_cloud_storage_block_volume_backup.go
+++ b/ovh/types_cloud_storage_block_volume_backup.go
@@ -117,9 +117,14 @@ func (m *CloudStorageBlockVolumeBackupModel) MergeWith(ctx context.Context, resp
 
 	// Build current_state from API currentState
 	if response.CurrentState != nil {
+		region := ""
+		if response.CurrentState.Location != nil {
+			region = response.CurrentState.Location.Region
+		}
+
 		locObj, _ := types.ObjectValue(
 			map[string]attr.Type{"region": ovhtypes.TfStringType{}},
-			map[string]attr.Value{"region": ovhtypes.TfStringValue{StringValue: types.StringValue(response.CurrentState.Location.Region)}},
+			map[string]attr.Value{"region": ovhtypes.TfStringValue{StringValue: types.StringValue(region)}},
 		)
 
 		currentStateObj, _ := types.ObjectValue(

--- a/ovh/types_cloud_storage_block_volume_snapshot.go
+++ b/ovh/types_cloud_storage_block_volume_snapshot.go
@@ -14,6 +14,8 @@ type CloudStorageBlockVolumeSnapshotModel struct {
 	ServiceName ovhtypes.TfStringValue `tfsdk:"service_name"`
 	Region      ovhtypes.TfStringValue `tfsdk:"region"`
 	VolumeId    ovhtypes.TfStringValue `tfsdk:"volume_id"`
+	// Optional — immutable
+	AvailabilityZone ovhtypes.TfStringValue `tfsdk:"availability_zone"`
 	// Required — mutable
 	Name ovhtypes.TfStringValue `tfsdk:"name"`
 	// Optional — mutable
@@ -54,7 +56,8 @@ type CloudStorageBlockVolumeSnapshotTargetSpec struct {
 }
 
 type CloudStorageBlockVolumeSnapshotLocation struct {
-	Region string `json:"region,omitempty"`
+	Region           string `json:"region,omitempty"`
+	AvailabilityZone string `json:"availabilityZone,omitempty"`
 }
 
 // Create payload
@@ -75,9 +78,14 @@ type CloudStorageBlockVolumeSnapshotUpdateTargetSpec struct {
 
 // ToCreate converts the Terraform model to the API create payload
 func (m *CloudStorageBlockVolumeSnapshotModel) ToCreate() *CloudStorageBlockVolumeSnapshotCreatePayload {
+	location := &CloudStorageBlockVolumeSnapshotLocation{Region: m.Region.ValueString()}
+	if !m.AvailabilityZone.IsNull() && !m.AvailabilityZone.IsUnknown() {
+		location.AvailabilityZone = m.AvailabilityZone.ValueString()
+	}
+
 	return &CloudStorageBlockVolumeSnapshotCreatePayload{
 		TargetSpec: &CloudStorageBlockVolumeSnapshotTargetSpec{
-			Location:    &CloudStorageBlockVolumeSnapshotLocation{Region: m.Region.ValueString()},
+			Location:    location,
 			Name:        m.Name.ValueString(),
 			Description: m.Description.ValueString(),
 			VolumeId:    m.VolumeId.ValueString(),
@@ -99,7 +107,10 @@ func (m *CloudStorageBlockVolumeSnapshotModel) ToUpdate(checksum string) *CloudS
 // SnapshotCurrentStateAttrTypes returns the attribute types for the current_state object
 func SnapshotCurrentStateAttrTypes() map[string]attr.Type {
 	return map[string]attr.Type{
-		"location":    types.ObjectType{AttrTypes: map[string]attr.Type{"region": ovhtypes.TfStringType{}}},
+		"location": types.ObjectType{AttrTypes: map[string]attr.Type{
+			"region":            ovhtypes.TfStringType{},
+			"availability_zone": ovhtypes.TfStringType{},
+		}},
 		"name":        ovhtypes.TfStringType{},
 		"description": ovhtypes.TfStringType{},
 		"volume_id":   ovhtypes.TfStringType{},
@@ -117,9 +128,22 @@ func (m *CloudStorageBlockVolumeSnapshotModel) MergeWith(ctx context.Context, re
 
 	// Build current_state from API currentState
 	if response.CurrentState != nil {
+		region := ""
+		az := ""
+		if response.CurrentState.Location != nil {
+			region = response.CurrentState.Location.Region
+			az = response.CurrentState.Location.AvailabilityZone
+		}
+
 		locObj, _ := types.ObjectValue(
-			map[string]attr.Type{"region": ovhtypes.TfStringType{}},
-			map[string]attr.Value{"region": ovhtypes.TfStringValue{StringValue: types.StringValue(response.CurrentState.Location.Region)}},
+			map[string]attr.Type{
+				"region":            ovhtypes.TfStringType{},
+				"availability_zone": ovhtypes.TfStringType{},
+			},
+			map[string]attr.Value{
+				"region":            ovhtypes.TfStringValue{StringValue: types.StringValue(region)},
+				"availability_zone": ovhtypes.TfStringValue{StringValue: types.StringValue(az)},
+			},
 		)
 
 		currentStateObj, _ := types.ObjectValue(
@@ -142,6 +166,7 @@ func (m *CloudStorageBlockVolumeSnapshotModel) MergeWith(ctx context.Context, re
 	if response.TargetSpec != nil {
 		if response.TargetSpec.Location != nil {
 			m.Region = ovhtypes.TfStringValue{StringValue: types.StringValue(response.TargetSpec.Location.Region)}
+			m.AvailabilityZone = ovhtypes.TfStringValue{StringValue: types.StringValue(response.TargetSpec.Location.AvailabilityZone)}
 		}
 		m.Name = ovhtypes.TfStringValue{StringValue: types.StringValue(response.TargetSpec.Name)}
 		m.Description = ovhtypes.TfStringValue{StringValue: types.StringValue(response.TargetSpec.Description)}


### PR DESCRIPTION
Replaces #1424, reworked after API review: **block storage backups are regional and expose no availability zone.** Only snapshots carry one, so this drops the backup half entirely.

## Description

API v2 populates `location.availabilityZone` for block volume snapshots. The provider mapped `region` only, so the zone was invisible in 3AZ regions.

Adds `availability_zone` to:
- `ovh_cloud_storage_block_volume_snapshot` (root target spec + nested `current_state.location`)
- `ovh_cloud_storage_block_volume_snapshot` / `..._snapshots` data sources
- the docs pages for all of the above

## Design notes

The block volume resource models no AZ, so this mirrors `cloud_storage_file_share_snapshot` instead: `Optional`+`Computed` with `UseStateForUnknown()` then `RequiresReplace()` on the writable target spec, `Computed` only in current state and data sources. Classification is schema-derived — `Location.availabilityZone` is `writable` and `nullable`, and `location` appears in `SnapshotTargetSpec` but not in `SnapshotUpdateTargetSpec`, so the zone is optional, immutable and API-defaulted. `UseStateForUnknown()` ordering means an omitted zone resolves to the state value at plan time, so there is no perpetual diff and no phantom replace.

In the data sources the `currentState` zone only overrides the `targetSpec` value when non-empty, so a 1AZ region cannot blank out a configured zone.

**Backups are deliberately excluded.** Their `Location` type carries no zone field at all, so the provider cannot emit a key the API now rejects with 400.

Also guards a latent nil deref in both `MergeWith` functions (backup included), which checked `CurrentState != nil` but then dereferenced the pointer `Location` — unrelated to the zone, kept on both families.

## Testing

```
go build ./...                → ok
go vet ./ovh/...              → no issues
gofmt -l ovh/                 → clean
go test -count=1 ./ovh/ -run CloudStorageBlockVolume  → ok
```

Acceptance-test assertions for the new attribute are gated on `OVH_CLOUD_PROJECT_AZ_TEST`, following the existing convention in `resource_cloud_project_volume_test.go`, so no region or zone is hardcoded.

Note: `scripts/gofmtcheck.sh` exits 0 vacuously under `sh` (a `[[` bashism on line 6), so the real `gofmt -l` result is reported above instead.