### PR TITLE
feat: Add userData field to instance resource

### DIFF
--- a/docs/resources/cloud_instance.md
+++ b/docs/resources/cloud_instance.md
@@ -315,6 +315,65 @@ resource "ovh_cloud_instance" "with_shares" {
 }
 ```
 
+### Cloud-init user data
+
+`user_data` carries a cloud-init payload, base64-encoded (standard encoding,
+65535 bytes max). It is **write-only**: the API accepts it but never returns it,
+so Terraform state holds the only copy and a change made outside Terraform stays
+invisible.
+
+**WARNING**: what happens on an update depends on how `user_data` moves in the
+configuration. Removing the argument and setting it to `""` are **not** the same
+thing — `""` is the destructive one:
+
+* **Changed** to a different non-empty value → the API **reinstalls the instance**:
+  it is rebuilt on its current image and the **root disk is wiped**. The instance
+  id, ports and IPs survive (it is an in-place update, not a replacement), but
+  anything written to the root disk since boot is lost.
+* **Set to `""`** while state holds a value → an explicit clear, sent as-is to the
+  API. The instance is **reinstalled** exactly as above (root disk wiped).
+* **Argument removed** from the configuration → the provider leaves the key out of
+  the `PUT`; nothing happens server-side, the instance keeps the user data it
+  booted with and Terraform only drops the value from state. **No rebuild.**
+
+```terraform
+# From a file next to the configuration.
+resource "ovh_cloud_instance" "from_file" {
+  service_name = "<Public cloud project id>"
+  region       = "GRA11"
+  name         = "my-instance-with-cloud-init"
+  flavor_id    = "<flavor id>"
+  image_id     = "<image id>"
+  user_data    = base64encode(file("${path.module}/cloud-init.yaml"))
+
+  networks = [
+    { auto_assign_public_ip = true },
+  ]
+}
+
+# Inline, with a heredoc.
+resource "ovh_cloud_instance" "inline" {
+  service_name = "<Public cloud project id>"
+  region       = "GRA11"
+  name         = "my-instance-with-inline-cloud-init"
+  flavor_id    = "<flavor id>"
+  image_id     = "<image id>"
+
+  user_data = base64encode(<<-EOT
+    #cloud-config
+    packages:
+      - nginx
+    runcmd:
+      - [systemctl, enable, --now, nginx]
+  EOT
+  )
+
+  networks = [
+    { auto_assign_public_ip = true },
+  ]
+}
+```
+
 ### Power state
 
 ```terraform
@@ -391,6 +450,10 @@ The following arguments are supported:
 * `group_id` - (Optional) ID of the placement group the instance belongs to (immutable). This is the only way to make an instance a member of an [`ovh_cloud_instance_group`](cloud_instance_group.md). **Changing this value recreates the resource.**
 * `image_id` - (Optional) Image ID to boot from. Omit for a boot-from-volume instance. **WARNING**: changing it rebuilds the instance and **wipes the root disk**.
 * `power_state` - (Optional) Desired power state: `ACTIVE`, `SHUTOFF` or `SHELVED`. When omitted, the API applies `ACTIVE` server-side and echoes it back; the provider declares no default of its own.
+* `user_data` - (Optional, Sensitive) Cloud-init user data injected at boot, base64-encoded (standard encoding, 65535 bytes max). Pass it through `base64encode()`, for example `base64encode(file("cloud-init.yaml"))`. **Write-only**: the API accepts it but never returns it, so Terraform state holds the only copy and a change made outside Terraform stays invisible. **WARNING**: removing the argument and setting it to `""` are **not** the same thing — `""` is the destructive one:
+  * changed to a different non-empty value → the API **reinstalls the instance** (rebuilt on its current image, **root disk wiped**; instance id, ports and IPs survive, it is applied in place, not as a replacement);
+  * set to `""` while state holds a value → explicit clear, the instance is **reinstalled** as above (root disk wiped);
+  * argument removed from the configuration → the key is left out of the `PUT`, the instance keeps the user data it booted with and Terraform only drops the value from state — **no rebuild**.
 * `networks` - (Optional) Network interfaces attached to the instance. Entries keep the order they are written in; the API returns them sorted by network id and the provider re-orders them back to the configuration. Four shapes:
   * `auto_assign_public_ip` alone — public interface with a platform-assigned public IP (at most one such entry).
   * `ip` alone — a public IP the project already owns: an additional IP, or an Ext-Net IP of the project in the instance's region. Several are allowed and may coexist with `auto_assign_public_ip`.
@@ -480,6 +543,12 @@ is the single observed entry with no `id`.
 * `resource_status = "ERROR"` is terminal: polling stops at once and the
   provider surfaces the summary of the failed task(s) instead of a generic
   unexpected-state error.
+* `user_data` is write-only, so the provider only ever sends it when the
+  configuration moves it: an unchanged value, or an argument absent from the
+  configuration, is left out of the `PUT` entirely, which is what keeps an
+  unrelated update (a rename, a resize) from reinstalling the instance. An
+  explicit `""` is **not** an absence — it is sent as a clear and reinstalls the
+  instance.
 
 ## Import
 
@@ -496,3 +565,9 @@ import {
 ```bash
 $ terraform import ovh_cloud_instance.instance service_name/instance_id
 ```
+
+An imported instance carries no `user_data` in state, since the API never returns
+it. If the configuration sets `user_data`, the first apply after the import will
+therefore see a change and **reinstall the instance** (root disk wiped). Import an
+instance whose user data matters with `user_data` absent from the configuration
+first, then add it only when a rebuild is acceptable.

--- a/examples/resources/cloud_instance/user_data.tf
+++ b/examples/resources/cloud_instance/user_data.tf
@@ -1,0 +1,45 @@
+# user_data carries a cloud-init payload, base64-encoded (standard encoding,
+# 65535 bytes max). It is write-only: the API accepts it but never returns it, so
+# Terraform state holds the only copy and a change made outside Terraform stays
+# invisible.
+#
+# WARNING: changing or clearing user_data reinstalls the instance — the API
+# rebuilds it on its current image and the root disk is wiped. The instance id,
+# ports and IPs survive (it is an in-place update, not a replacement), but
+# anything written to the root disk since boot is lost.
+
+# From a file next to the configuration.
+resource "ovh_cloud_instance" "from_file" {
+  service_name = "<Public cloud project id>"
+  region       = "GRA11"
+  name         = "my-instance-with-cloud-init"
+  flavor_id    = "<flavor id>"
+  image_id     = "<image id>"
+  user_data    = base64encode(file("${path.module}/cloud-init.yaml"))
+
+  networks = [
+    { auto_assign_public_ip = true },
+  ]
+}
+
+# Inline, with a heredoc.
+resource "ovh_cloud_instance" "inline" {
+  service_name = "<Public cloud project id>"
+  region       = "GRA11"
+  name         = "my-instance-with-inline-cloud-init"
+  flavor_id    = "<flavor id>"
+  image_id     = "<image id>"
+
+  user_data = base64encode(<<-EOT
+    #cloud-config
+    packages:
+      - nginx
+    runcmd:
+      - [systemctl, enable, --now, nginx]
+  EOT
+  )
+
+  networks = [
+    { auto_assign_public_ip = true },
+  ]
+}

--- a/ovh/resource_cloud_instance.go
+++ b/ovh/resource_cloud_instance.go
@@ -54,7 +54,7 @@ func (r *cloudInstanceResource) Configure(ctx context.Context, req resource.Conf
 }
 
 var instanceMutableAttrs = MutableAttrs{
-	Strings:           []string{"name", "flavor_id", "image_id", "power_state"},
+	Strings:           []string{"name", "flavor_id", "image_id", "power_state", "user_data"},
 	Lists:             []string{"networks", "shares"},
 	CustomStringLists: []string{"volume_ids", "security_group_ids"},
 }
@@ -134,6 +134,15 @@ func (r *cloudInstanceResource) Schema(ctx context.Context, req resource.SchemaR
 					stringvalidator.OneOf("ACTIVE", "SHUTOFF", "SHELVED"),
 				},
 				PlanModifiers: []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
+			},
+			// Mutable, and NOT RequiresReplace: the API applies a new value by
+			// rebuilding the instance in place, so its id and ports survive.
+			"user_data": schema.StringAttribute{
+				CustomType:          ovhtypes.TfStringType{},
+				Optional:            true,
+				Sensitive:           true,
+				Description:         instanceDescUserData,
+				MarkdownDescription: instanceDescUserDataMd,
 			},
 			"networks": schema.ListNestedAttribute{
 				Optional:    true,
@@ -335,7 +344,7 @@ func (r *cloudInstanceResource) ImportState(ctx context.Context, req resource.Im
 }
 
 func (r *cloudInstanceResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
-	var data CloudInstanceModel
+	var data CloudInstanceResourceModel
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -375,7 +384,7 @@ func (r *cloudInstanceResource) Create(ctx context.Context, req resource.CreateR
 }
 
 func (r *cloudInstanceResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
-	var data CloudInstanceModel
+	var data CloudInstanceResourceModel
 	resp.Diagnostics.Append(req.State.Get(ctx, &data)...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -399,7 +408,7 @@ func (r *cloudInstanceResource) Read(ctx context.Context, req resource.ReadReque
 }
 
 func (r *cloudInstanceResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
-	var data, planData CloudInstanceModel
+	var data, planData CloudInstanceResourceModel
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &planData)...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -420,7 +429,9 @@ func (r *cloudInstanceResource) Update(ctx context.Context, req resource.UpdateR
 		return
 	}
 
-	updatePayload := planData.ToUpdate(currentData.Checksum)
+	// data holds the prior state: ToUpdate needs it to tell an unchanged user_data
+	// (absent key) from one the config actually moved (rebuild).
+	updatePayload := planData.ToUpdate(currentData.Checksum, data.UserData)
 
 	var responseData CloudInstanceAPIResponse
 	if err := r.config.OVHClient.Put(endpoint, updatePayload, &responseData); err != nil {
@@ -445,7 +456,7 @@ func (r *cloudInstanceResource) Update(ctx context.Context, req resource.UpdateR
 }
 
 func (r *cloudInstanceResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
-	var data CloudInstanceModel
+	var data CloudInstanceResourceModel
 	resp.Diagnostics.Append(req.State.Get(ctx, &data)...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/ovh/resource_cloud_instance_test.go
+++ b/ovh/resource_cloud_instance_test.go
@@ -1,6 +1,7 @@
 package ovh
 
 import (
+	"encoding/base64"
 	"fmt"
 	"os"
 	"regexp"
@@ -175,6 +176,25 @@ resource "ovh_cloud_instance" "test" {
   ]
 }
 `, serviceName, keyName, testAccCloudSshKeyPublicKeyA, serviceName, region, name, flavorID, imageID)
+}
+
+// testAccCloudInstanceConfigUserData renders an instance config whose user_data
+// carries a cloud-init payload, base64-encoded the documented way.
+func testAccCloudInstanceConfigUserData(serviceName, region, flavorID, imageID, name, cloudInit string) string {
+	return fmt.Sprintf(`
+resource "ovh_cloud_instance" "test" {
+  service_name = "%s"
+  region       = "%s"
+  name         = "%s"
+  flavor_id    = "%s"
+  image_id     = "%s"
+  user_data    = base64encode(%q)
+
+  networks = [
+    { auto_assign_public_ip = true },
+  ]
+}
+`, serviceName, region, name, flavorID, imageID, cloudInit)
 }
 
 // testAccCloudInstanceConfigBootFromVolume renders a bootable block volume
@@ -358,6 +378,72 @@ func TestAccCloudInstance_rebuildImage(t *testing.T) {
 					resource.TestCheckResourceAttrWith("ovh_cloud_instance.test", "id", func(v string) error {
 						if v != instanceID {
 							return fmt.Errorf("instance was replaced during image rebuild: id changed from %q to %q", instanceID, v)
+						}
+						return nil
+					}),
+				),
+			},
+		},
+	})
+}
+
+// TestAccCloudInstance_userData creates an instance carrying cloud-init user data
+// and then changes it. The API applies a new userData by rebuilding the instance
+// on its current image, so the change must plan as an in-place Update and keep the
+// instance id — never a destroy/recreate. The middle step also locks the absence
+// of spurious drift: user_data is write-only, so a value the API never echoes back
+// must still produce an empty plan.
+func TestAccCloudInstance_userData(t *testing.T) {
+	serviceName := os.Getenv("OVH_CLOUD_PROJECT_SERVICE_TEST")
+	region := os.Getenv("OVH_CLOUD_PROJECT_REGION_TEST")
+	flavorID := resolveInstanceFlavorID(t, serviceName, region, testAccInstanceFlavorName)
+	imageID := resolveInstanceImageID(t, serviceName, region, testAccInstanceImageName)
+	name := acctest.RandomWithPrefix("test-inst-ud")
+
+	const (
+		cloudInitA = "#cloud-config\npackages:\n  - nginx\n"
+		cloudInitB = "#cloud-config\npackages:\n  - htop\n"
+	)
+	encodedA := base64.StdEncoding.EncodeToString([]byte(cloudInitA))
+	encodedB := base64.StdEncoding.EncodeToString([]byte(cloudInitB))
+
+	var instanceID string
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheckCloudInstanceV2(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCloudInstanceConfigUserData(serviceName, region, flavorID, imageID, name, cloudInitA),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("ovh_cloud_instance.test", "user_data", encodedA),
+					resource.TestCheckResourceAttr("ovh_cloud_instance.test", "resource_status", "READY"),
+					resource.TestCheckResourceAttrWith("ovh_cloud_instance.test", "id", func(v string) error {
+						if v == "" {
+							return fmt.Errorf("expected instance id to be set")
+						}
+						instanceID = v
+						return nil
+					}),
+				),
+			},
+			{
+				Config:   testAccCloudInstanceConfigUserData(serviceName, region, flavorID, imageID, name, cloudInitA),
+				PlanOnly: true,
+			},
+			{
+				Config: testAccCloudInstanceConfigUserData(serviceName, region, flavorID, imageID, name, cloudInitB),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction("ovh_cloud_instance.test", plancheck.ResourceActionUpdate),
+					},
+				},
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("ovh_cloud_instance.test", "user_data", encodedB),
+					resource.TestCheckResourceAttr("ovh_cloud_instance.test", "resource_status", "READY"),
+					resource.TestCheckResourceAttrWith("ovh_cloud_instance.test", "id", func(v string) error {
+						if v != instanceID {
+							return fmt.Errorf("instance was replaced by a user_data change: id went from %q to %q", instanceID, v)
 						}
 						return nil
 					}),

--- a/ovh/types_cloud_instance.go
+++ b/ovh/types_cloud_instance.go
@@ -10,7 +10,9 @@ import (
 	ovhtypes "github.com/ovh/terraform-provider-ovh/v2/ovh/types"
 )
 
-// CloudInstanceModel is the Terraform model for the ovh_cloud_instance resource.
+// CloudInstanceModel carries the attributes shared by the ovh_cloud_instance
+// resource and the ovh_cloud_instance data source, which expose the same shape
+// except for the write-only user_data (see CloudInstanceResourceModel).
 type CloudInstanceModel struct {
 	// Required — immutable
 	ServiceName ovhtypes.TfStringValue `tfsdk:"service_name"`
@@ -40,6 +42,19 @@ type CloudInstanceModel struct {
 	UpdatedAt      ovhtypes.TfStringValue `tfsdk:"updated_at"`
 	ResourceStatus ovhtypes.TfStringValue `tfsdk:"resource_status"`
 	CurrentState   types.Object           `tfsdk:"current_state"`
+}
+
+// CloudInstanceResourceModel is the ovh_cloud_instance resource model: the shared
+// attributes plus the write-only user_data.
+//
+// user_data is deliberately NOT part of CloudInstanceModel. The API never returns
+// it, so the data source has nothing to expose, and keeping it out of the model
+// MergeWith writes into makes it structurally impossible for a read to clobber the
+// configured value with a null.
+type CloudInstanceResourceModel struct {
+	CloudInstanceModel
+
+	UserData ovhtypes.TfStringValue `tfsdk:"user_data"`
 }
 
 // ---------- API DTOs (camelCase JSON tags, mirror internal/model/instance.go) ----------
@@ -76,6 +91,8 @@ type CloudInstanceAPITargetSpec struct {
 	PowerState string                       `json:"powerState,omitempty"`
 	Group      *CloudInstanceRef            `json:"group,omitempty"`
 	SSHKeyName string                       `json:"sshKeyName,omitempty"`
+	// Write-only: accepted on create, never echoed back by GET or LIST.
+	UserData string `json:"userData,omitempty"`
 	// No omitempty: the API distinguishes null (apply the project's default
 	// security group on create, leave the groups unchanged on update) from an
 	// explicit empty array (apply no security group at all).
@@ -91,6 +108,13 @@ type CloudInstanceAPIUpdateTargetSpec struct {
 	Networks   []CloudInstanceAPINetworkRef `json:"networks,omitempty"`
 	Volumes    []CloudInstanceRef           `json:"volumes,omitempty"`
 	PowerState string                       `json:"powerState,omitempty"`
+	// Pointer, not string: the API reads userData as a tri-state on PUT — an
+	// absent key keeps the stored value, "" clears it, a non-empty value replaces
+	// it — and clearing or replacing REINSTALLS the instance (Nova rebuild on the
+	// current image, root disk wiped). omitempty drops only a nil pointer, so a
+	// pointer to "" still marshals as `"userData":""` (an explicit clear) while an
+	// untouched field marshals to nothing at all.
+	UserData *string `json:"userData,omitempty"`
 	// See CloudInstanceAPITargetSpec.SecurityGroups: null and [] differ.
 	SecurityGroups []CloudInstanceRef         `json:"securityGroups"`
 	Shares         []CloudInstanceAPIShareRef `json:"shares,omitempty"`
@@ -265,6 +289,9 @@ const (
 	instanceDescNetworkRefAutoAssignMd = "Attach a public interface with a public IP assigned by the platform. Only valid on an entry with no `network_id` and no `ip`, and on at most one entry"
 
 	instanceDescVolumeIds = "IDs of block-storage volumes attached to the instance"
+
+	instanceDescUserData   = "Cloud-init user data injected at boot, base64-encoded (standard encoding, 65535 bytes max). Pass it through base64encode(). Write-only: the API accepts it but never returns it, so the value is only ever read back from Terraform state and a change made outside Terraform stays invisible. WARNING: changing this value to another non-empty one reinstalls the instance (rebuild on the current image — the root disk is wiped); setting it to \"\" is an explicit clear and also reinstalls the instance; removing the argument from the configuration only drops it from state, the instance keeps the user data it booted with and is not rebuilt"
+	instanceDescUserDataMd = "Cloud-init user data injected at boot, base64-encoded (standard encoding, 65535 bytes max). Pass it through `base64encode()`. **Write-only**: the API accepts it but never returns it, so the value is only ever read back from Terraform state and a change made outside Terraform stays invisible. **WARNING**: changing this value to another non-empty one **reinstalls the instance** (rebuild on the current image — the root disk is wiped); setting it to `\"\"` is an explicit clear and **also reinstalls the instance**; removing the argument from the configuration only drops it from state, the instance keeps the user data it booted with and is **not** rebuilt"
 
 	// Read-only wordings for the data sources, where the root attributes expose
 	// the requested target spec rather than a writable input.
@@ -475,7 +502,7 @@ func customStringListToRefs(list ovhtypes.TfListNestedValue[ovhtypes.TfStringVal
 }
 
 // ToCreate builds the create payload including all fields (mutable + immutable).
-func (m *CloudInstanceModel) ToCreate() *CloudInstanceCreatePayload {
+func (m *CloudInstanceResourceModel) ToCreate() *CloudInstanceCreatePayload {
 	ts := &CloudInstanceAPITargetSpec{
 		Name:   m.Name.ValueString(),
 		Flavor: &CloudInstanceRef{Id: m.FlavorId.ValueString()},
@@ -499,6 +526,9 @@ func (m *CloudInstanceModel) ToCreate() *CloudInstanceCreatePayload {
 	if !m.GroupId.IsNull() && !m.GroupId.IsUnknown() && m.GroupId.ValueString() != "" {
 		ts.Group = &CloudInstanceRef{Id: m.GroupId.ValueString()}
 	}
+	if !m.UserData.IsNull() && !m.UserData.IsUnknown() && m.UserData.ValueString() != "" {
+		ts.UserData = m.UserData.ValueString()
+	}
 	ts.Networks = networksToAPI(m.Networks)
 	ts.Volumes = customStringListToRefs(m.VolumeIds)
 	ts.SecurityGroups = customStringListToRefs(m.SecurityGroupIds)
@@ -507,9 +537,33 @@ func (m *CloudInstanceModel) ToCreate() *CloudInstanceCreatePayload {
 	return &CloudInstanceCreatePayload{TargetSpec: ts}
 }
 
+// userDataForUpdate resolves the userData tri-state for a PUT from the planned
+// and prior (state) values.
+//
+// The API reinstalls the instance whenever the key is present and changes the
+// stored value — including `"userData": ""`, which clears it — so the key is
+// emitted ONLY when the configuration actually moved it. An attribute the user
+// never set (null) or left untouched must serialize as an absent key, never as
+// "": the latter would wipe the root disk on any unrelated update.
+func userDataForUpdate(planned, prior ovhtypes.TfStringValue) *string {
+	// Null plan = absent from config. Terraform drops the value from state, but
+	// the instance keeps whatever it booted with: there is no "unset" on the API
+	// side, and clearing would be a destructive reading of an omission.
+	if planned.IsNull() || planned.IsUnknown() {
+		return nil
+	}
+	if !prior.IsNull() && !prior.IsUnknown() && prior.ValueString() == planned.ValueString() {
+		return nil
+	}
+	v := planned.ValueString()
+	return &v
+}
+
 // ToUpdate builds the update payload with mutable fields only, plus checksum.
 // Location, sshKeyName and group are immutable and intentionally excluded.
-func (m *CloudInstanceModel) ToUpdate(checksum string) *CloudInstanceUpdatePayload {
+// priorUserData is the value held in state, needed to resolve the userData
+// tri-state; everything else comes from the plan.
+func (m *CloudInstanceResourceModel) ToUpdate(checksum string, priorUserData ovhtypes.TfStringValue) *CloudInstanceUpdatePayload {
 	ts := &CloudInstanceAPIUpdateTargetSpec{
 		Name:   m.Name.ValueString(),
 		Flavor: &CloudInstanceRef{Id: m.FlavorId.ValueString()},
@@ -521,6 +575,7 @@ func (m *CloudInstanceModel) ToUpdate(checksum string) *CloudInstanceUpdatePaylo
 	if !m.PowerState.IsNull() && !m.PowerState.IsUnknown() {
 		ts.PowerState = m.PowerState.ValueString()
 	}
+	ts.UserData = userDataForUpdate(m.UserData, priorUserData)
 	ts.Networks = networksToAPI(m.Networks)
 	ts.Volumes = customStringListToRefs(m.VolumeIds)
 	ts.SecurityGroups = customStringListToRefs(m.SecurityGroupIds)
@@ -848,6 +903,10 @@ func (m *CloudInstanceModel) priorSpec() instancePriorSpec {
 }
 
 // MergeWith copies the API response into the Terraform model.
+//
+// It cannot reach user_data: that attribute lives on CloudInstanceResourceModel,
+// outside the embedded model written here, so the configured write-only value
+// survives every create/read/update merge untouched.
 func (m *CloudInstanceModel) MergeWith(ctx context.Context, response *CloudInstanceAPIResponse, prior instancePriorSpec) {
 	m.Id = tfStr(response.Id)
 	m.Checksum = tfStr(response.Checksum)

--- a/ovh/types_cloud_instance_test.go
+++ b/ovh/types_cloud_instance_test.go
@@ -3,10 +3,13 @@ package ovh
 import (
 	"context"
 	"encoding/json"
+	"reflect"
+	"sort"
 	"strings"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-framework/attr"
+	fwresource "github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 	ovhtypes "github.com/ovh/terraform-provider-ovh/v2/ovh/types"
@@ -31,20 +34,23 @@ func customStringList(ids ...string) ovhtypes.TfListNestedValue[ovhtypes.TfStrin
 }
 
 func TestUnitCloudInstanceModelToCreate(t *testing.T) {
-	m := &CloudInstanceModel{
-		ServiceName:      strVal("proj"),
-		Region:           strVal("GRA11"),
-		AvailabilityZone: strNull(),
-		Name:             strVal("web-1"),
-		FlavorId:         strVal("flavor-uuid"),
-		ImageId:          strVal("image-uuid"),
-		PowerState:       strNull(),
-		SSHKeyName:       strVal("mykey"),
-		GroupId:          strNull(),
-		Networks:         types.ListNull(types.ObjectType{AttrTypes: instanceNetworkRefAttrTypes()}),
-		VolumeIds:        ovhtypes.TfListNestedValue[ovhtypes.TfStringValue]{ListValue: basetypes.NewListNull(ovhtypes.TfStringType{})},
-		SecurityGroupIds: customStringList("sg-1"),
-		Shares:           types.ListNull(types.ObjectType{AttrTypes: instanceShareRefAttrTypes()}),
+	m := &CloudInstanceResourceModel{
+		CloudInstanceModel: CloudInstanceModel{
+			ServiceName:      strVal("proj"),
+			Region:           strVal("GRA11"),
+			AvailabilityZone: strNull(),
+			Name:             strVal("web-1"),
+			FlavorId:         strVal("flavor-uuid"),
+			ImageId:          strVal("image-uuid"),
+			PowerState:       strNull(),
+			SSHKeyName:       strVal("mykey"),
+			GroupId:          strNull(),
+			Networks:         types.ListNull(types.ObjectType{AttrTypes: instanceNetworkRefAttrTypes()}),
+			VolumeIds:        ovhtypes.TfListNestedValue[ovhtypes.TfStringValue]{ListValue: basetypes.NewListNull(ovhtypes.TfStringType{})},
+			SecurityGroupIds: customStringList("sg-1"),
+			Shares:           types.ListNull(types.ObjectType{AttrTypes: instanceShareRefAttrTypes()}),
+		},
+		UserData: strVal("I2Nsb3VkLWNvbmZpZw=="),
 	}
 
 	payload := m.ToCreate()
@@ -67,6 +73,9 @@ func TestUnitCloudInstanceModelToCreate(t *testing.T) {
 	if payload.TargetSpec.SSHKeyName != "mykey" {
 		t.Fatalf("sshKeyName = %q, want mykey", payload.TargetSpec.SSHKeyName)
 	}
+	if payload.TargetSpec.UserData != "I2Nsb3VkLWNvbmZpZw==" {
+		t.Fatalf("userData = %q, want I2Nsb3VkLWNvbmZpZw==", payload.TargetSpec.UserData)
+	}
 	if len(payload.TargetSpec.SecurityGroups) != 1 || payload.TargetSpec.SecurityGroups[0].Id != "sg-1" {
 		t.Fatalf("securityGroups not set correctly: %+v", payload.TargetSpec.SecurityGroups)
 	}
@@ -78,22 +87,25 @@ func TestUnitCloudInstanceModelToCreate(t *testing.T) {
 }
 
 func TestUnitCloudInstanceModelToUpdate(t *testing.T) {
-	m := &CloudInstanceModel{
-		Region:           strVal("GRA11"),   // immutable — must NOT appear
-		AvailabilityZone: strVal("GRA11-a"), // immutable — must NOT appear
-		SSHKeyName:       strVal("mykey"),   // immutable — must NOT appear
-		GroupId:          strVal("grp-1"),   // immutable — must NOT appear
-		Name:             strVal("web-2"),
-		FlavorId:         strVal("flavor-uuid"),
-		ImageId:          strVal("image-uuid"),
-		PowerState:       strVal("SHUTOFF"),
-		Networks:         types.ListNull(types.ObjectType{AttrTypes: instanceNetworkRefAttrTypes()}),
-		VolumeIds:        ovhtypes.TfListNestedValue[ovhtypes.TfStringValue]{ListValue: basetypes.NewListNull(ovhtypes.TfStringType{})},
-		SecurityGroupIds: ovhtypes.TfListNestedValue[ovhtypes.TfStringValue]{ListValue: basetypes.NewListNull(ovhtypes.TfStringType{})},
-		Shares:           types.ListNull(types.ObjectType{AttrTypes: instanceShareRefAttrTypes()}),
+	m := &CloudInstanceResourceModel{
+		CloudInstanceModel: CloudInstanceModel{
+			Region:           strVal("GRA11"),   // immutable — must NOT appear
+			AvailabilityZone: strVal("GRA11-a"), // immutable — must NOT appear
+			SSHKeyName:       strVal("mykey"),   // immutable — must NOT appear
+			GroupId:          strVal("grp-1"),   // immutable — must NOT appear
+			Name:             strVal("web-2"),
+			FlavorId:         strVal("flavor-uuid"),
+			ImageId:          strVal("image-uuid"),
+			PowerState:       strVal("SHUTOFF"),
+			Networks:         types.ListNull(types.ObjectType{AttrTypes: instanceNetworkRefAttrTypes()}),
+			VolumeIds:        ovhtypes.TfListNestedValue[ovhtypes.TfStringValue]{ListValue: basetypes.NewListNull(ovhtypes.TfStringType{})},
+			SecurityGroupIds: ovhtypes.TfListNestedValue[ovhtypes.TfStringValue]{ListValue: basetypes.NewListNull(ovhtypes.TfStringType{})},
+			Shares:           types.ListNull(types.ObjectType{AttrTypes: instanceShareRefAttrTypes()}),
+		},
+		UserData: strNull(),
 	}
 
-	payload := m.ToUpdate("chk-123")
+	payload := m.ToUpdate("chk-123", strNull())
 
 	if payload.Checksum != "chk-123" {
 		t.Fatalf("checksum = %q, want chk-123", payload.Checksum)
@@ -472,13 +484,16 @@ func nullCustomStringList() ovhtypes.TfListNestedValue[ovhtypes.TfStringValue] {
 // create, leave unchanged on update) from an explicit [] (no security group), so
 // both must survive JSON marshalling instead of being dropped by omitempty.
 func TestUnitCloudInstanceSecurityGroupsNullVersusEmpty(t *testing.T) {
-	base := CloudInstanceModel{
-		Region:    strVal("GRA11"),
-		Name:      strVal("web-1"),
-		FlavorId:  strVal("flavor-uuid"),
-		Networks:  types.ListNull(types.ObjectType{AttrTypes: instanceNetworkRefAttrTypes()}),
-		VolumeIds: nullCustomStringList(),
-		Shares:    types.ListNull(types.ObjectType{AttrTypes: instanceShareRefAttrTypes()}),
+	base := CloudInstanceResourceModel{
+		CloudInstanceModel: CloudInstanceModel{
+			Region:    strVal("GRA11"),
+			Name:      strVal("web-1"),
+			FlavorId:  strVal("flavor-uuid"),
+			Networks:  types.ListNull(types.ObjectType{AttrTypes: instanceNetworkRefAttrTypes()}),
+			VolumeIds: nullCustomStringList(),
+			Shares:    types.ListNull(types.ObjectType{AttrTypes: instanceShareRefAttrTypes()}),
+		},
+		UserData: strNull(),
 	}
 
 	cases := []struct {
@@ -504,7 +519,7 @@ func TestUnitCloudInstanceSecurityGroupsNullVersusEmpty(t *testing.T) {
 				t.Fatalf("create target spec must contain %s: %s", tc.want, string(b))
 			}
 
-			b, err = json.Marshal(m.ToUpdate("chk-1").TargetSpec)
+			b, err = json.Marshal(m.ToUpdate("chk-1", strNull()).TargetSpec)
 			if err != nil {
 				t.Fatalf("marshal update target spec: %s", err)
 			}
@@ -582,5 +597,197 @@ func TestUnitCloudInstanceMergeWithNilImage(t *testing.T) {
 	imgObj, _ := m.CurrentState.Attributes()["image"].(types.Object)
 	if !imgObj.IsNull() {
 		t.Fatalf("current_state.image should be null for boot-from-volume")
+	}
+}
+
+const (
+	testUserDataA = "I2Nsb3VkLWNvbmZpZwpwYWNrYWdlczoKICAtIG5naW54Cg=="
+	testUserDataB = "I2Nsb3VkLWNvbmZpZwpwYWNrYWdlczoKICAtIGh0b3AK"
+)
+
+// userDataUpdateModel builds a minimal resource model whose only interesting
+// field is user_data, for the tri-state assertions below.
+func userDataUpdateModel(planned ovhtypes.TfStringValue) *CloudInstanceResourceModel {
+	return &CloudInstanceResourceModel{
+		CloudInstanceModel: CloudInstanceModel{
+			Name:             strVal("web-1"),
+			FlavorId:         strVal("flavor-uuid"),
+			Networks:         types.ListNull(types.ObjectType{AttrTypes: instanceNetworkRefAttrTypes()}),
+			VolumeIds:        nullCustomStringList(),
+			SecurityGroupIds: nullCustomStringList(),
+			Shares:           types.ListNull(types.ObjectType{AttrTypes: instanceShareRefAttrTypes()}),
+		},
+		UserData: planned,
+	}
+}
+
+// The API reads userData as a tri-state on PUT: an absent key keeps the stored
+// value, "" clears it, a non-empty value replaces it — and both a clear and a
+// replace REINSTALL the instance (Nova rebuild, root disk wiped). So an attribute
+// the user never set, or left untouched, MUST marshal to no key at all: emitting
+// "" would wipe the root disk on every unrelated update.
+func TestUnitCloudInstanceUserDataUpdateTriState(t *testing.T) {
+	cases := []struct {
+		name  string
+		prior ovhtypes.TfStringValue
+		plan  ovhtypes.TfStringValue
+		want  string // "" means the key must be absent entirely
+	}{
+		{name: "never configured", prior: strNull(), plan: strNull(), want: ""},
+		{name: "unchanged", prior: strVal(testUserDataA), plan: strVal(testUserDataA), want: ""},
+		{name: "removed from config", prior: strVal(testUserDataA), plan: strNull(), want: ""},
+		{
+			name:  "unknown plan",
+			prior: strVal(testUserDataA),
+			plan:  ovhtypes.TfStringValue{StringValue: types.StringUnknown()},
+			want:  "",
+		},
+		{name: "first set", prior: strNull(), plan: strVal(testUserDataA), want: `"userData":"` + testUserDataA + `"`},
+		{name: "changed", prior: strVal(testUserDataA), plan: strVal(testUserDataB), want: `"userData":"` + testUserDataB + `"`},
+		{name: "cleared", prior: strVal(testUserDataA), plan: strVal(""), want: `"userData":""`},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			b, err := json.Marshal(userDataUpdateModel(tc.plan).ToUpdate("chk-1", tc.prior).TargetSpec)
+			if err != nil {
+				t.Fatalf("marshal update target spec: %s", err)
+			}
+			got := string(b)
+
+			if tc.want == "" {
+				if strings.Contains(got, "userData") {
+					t.Fatalf("update target spec must carry NO userData key — an empty one clears the user data and wipes the root disk: %s", got)
+				}
+				return
+			}
+			if !strings.Contains(got, tc.want) {
+				t.Fatalf("update target spec must contain %s: %s", tc.want, got)
+			}
+		})
+	}
+}
+
+// Same guarantee on create: an unset user_data sends no userData at all.
+func TestUnitCloudInstanceUserDataOnCreate(t *testing.T) {
+	m := userDataUpdateModel(strNull())
+	b, err := json.Marshal(m.ToCreate().TargetSpec)
+	if err != nil {
+		t.Fatalf("marshal create target spec: %s", err)
+	}
+	if strings.Contains(string(b), "userData") {
+		t.Fatalf("create target spec must carry no userData key when unset: %s", string(b))
+	}
+
+	m = userDataUpdateModel(strVal(testUserDataA))
+	if b, err = json.Marshal(m.ToCreate().TargetSpec); err != nil {
+		t.Fatalf("marshal create target spec: %s", err)
+	}
+	if want := `"userData":"` + testUserDataA + `"`; !strings.Contains(string(b), want) {
+		t.Fatalf("create target spec must contain %s: %s", want, string(b))
+	}
+}
+
+// user_data is write-only: GET and LIST never return it, so a merge must leave the
+// configured value alone. Terraform state holds the only copy.
+func TestUnitCloudInstanceUserDataSurvivesMerge(t *testing.T) {
+	ctx := context.Background()
+
+	m := userDataUpdateModel(strVal(testUserDataA))
+	m.MergeWith(ctx, &CloudInstanceAPIResponse{
+		Id:             "inst-ud",
+		ResourceStatus: "READY",
+		TargetSpec: &CloudInstanceAPITargetSpec{
+			Name:     "web-1",
+			Location: &CloudInstanceAPILocation{Region: "GRA11"},
+			// Should never happen (write-only), but even then the merge must not
+			// let a response value displace the configured one.
+			UserData: testUserDataB,
+		},
+	}, m.priorSpec())
+
+	if m.UserData.IsNull() || m.UserData.IsUnknown() {
+		t.Fatalf("user_data must survive a merge, got %+v", m.UserData)
+	}
+	if got := m.UserData.ValueString(); got != testUserDataA {
+		t.Fatalf("user_data = %q, want the configured %q preserved", got, testUserDataA)
+	}
+}
+
+// tfsdkTags collects a model's tfsdk tag names, following embedded structs the way
+// terraform-plugin-framework's reflection does.
+func tfsdkTags(t *testing.T, typ reflect.Type) map[string]bool {
+	t.Helper()
+	out := map[string]bool{}
+	for i := 0; i < typ.NumField(); i++ {
+		f := typ.Field(i)
+		if f.Anonymous {
+			if _, ok := f.Tag.Lookup("tfsdk"); ok {
+				t.Fatalf("embedded field %s must not carry a tfsdk tag, the framework rejects it", f.Name)
+			}
+			for k := range tfsdkTags(t, f.Type) {
+				out[k] = true
+			}
+			continue
+		}
+		tag, ok := f.Tag.Lookup("tfsdk")
+		if !ok {
+			t.Fatalf("field %s has no tfsdk tag", f.Name)
+		}
+		if tag == "-" {
+			continue
+		}
+		out[tag] = true
+	}
+	return out
+}
+
+func sortedKeys(m map[string]bool) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// The framework demands exact parity between a model's tfsdk tags and the schema
+// it is read into and written from, in BOTH directions: an extra struct field or
+// an extra schema attribute fails at Get/Set time, at runtime, with no compile
+// error to warn you. The resource and the ovh_cloud_instance data source share
+// CloudInstanceModel, so an attribute added to the shared model silently breaks
+// the data source — which is exactly why write-only user_data lives on
+// CloudInstanceResourceModel instead.
+func TestUnitCloudInstanceModelsMatchSchemas(t *testing.T) {
+	ctx := context.Background()
+
+	schemaResp := &fwresource.SchemaResponse{}
+	(&cloudInstanceResource{}).Schema(ctx, fwresource.SchemaRequest{}, schemaResp)
+
+	resourceAttrs := map[string]bool{}
+	for name := range schemaResp.Schema.Attributes {
+		resourceAttrs[name] = true
+	}
+	resourceFields := tfsdkTags(t, reflect.TypeOf(CloudInstanceResourceModel{}))
+	if !reflect.DeepEqual(sortedKeys(resourceAttrs), sortedKeys(resourceFields)) {
+		t.Fatalf("resource schema and CloudInstanceResourceModel disagree:\n schema = %v\n  model = %v",
+			sortedKeys(resourceAttrs), sortedKeys(resourceFields))
+	}
+
+	dsAttrs := map[string]bool{}
+	for name := range instanceDataSourceAttributes(ctx) {
+		dsAttrs[name] = true
+	}
+	dsFields := tfsdkTags(t, reflect.TypeOf(CloudInstanceModel{}))
+	if !reflect.DeepEqual(sortedKeys(dsAttrs), sortedKeys(dsFields)) {
+		t.Fatalf("data source schema and CloudInstanceModel disagree:\n schema = %v\n  model = %v",
+			sortedKeys(dsAttrs), sortedKeys(dsFields))
+	}
+
+	if !resourceFields["user_data"] {
+		t.Fatal("the resource must expose user_data")
+	}
+	if dsFields["user_data"] || dsAttrs["user_data"] {
+		t.Fatal("the data source must NOT expose user_data: the API never returns it, so there is nothing to read back")
 	}
 }


### PR DESCRIPTION
# Description

Add missing field `user_data` to the `ovh_cloud_instance` resource.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- [ ] Test A: `make testacc TESTARGS="-run TestAccCloudInstance_userData"`

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or issues
- [x] I have added acceptance tests that prove my fix is effective or that my feature works
- [x] New and existing acceptance tests pass locally with my changes
- [x] I ran successfully `go mod vendor` if I added or modify `go.mod` file
